### PR TITLE
Align Skills infrastructure + 11 built-in skills (consolidated #71+#82+#83)

### DIFF
--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -236,7 +236,7 @@ These skills involve complex integrations, multiple API calls, or advanced proce
 | Skill Name | Class | Description | Tools | Required Env Vars | Config Options |
 |---|---|---|---|---|---|
 | `web_search` | `WebSearchSkill` | Google Custom Search | `web_search` | `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_CX` | `max_results`, `safe_search` |
-| `wikipedia_search` | `WikipediaSearchSkill` | Wikipedia article summaries | `search_wikipedia` | None | None |
+| `wikipedia_search` | `WikipediaSearchSkill` | Wikipedia article summaries | `search_wiki` | None | `num_results`, `no_results_message`, `language`, `max_content_length` |
 | `google_maps` | `GoogleMapsSkill` | Directions and place search | `get_directions`, `find_place` | `GOOGLE_MAPS_API_KEY` | `default_mode` |
 | `datasphere` | `DataSphereSkill` | SignalWire DataSphere semantic search | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `max_results`, `distance_threshold` |
 | `datasphere_serverless` | `DataSphereServerlessSkill` | DataSphere via server-side DataMap | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `max_results`, `distance_threshold`, `document_id` |

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -53,7 +53,7 @@ const agent = new AgentBase({ name: 'my-agent' });
 
 // Add skills (async)
 await agent.addSkill(new DateTimeSkill());
-await agent.addSkill(new WebSearchSkill({ max_results: 3 }));
+await agent.addSkill(new WebSearchSkill({ num_results: 3 }));
 ```
 
 When `addSkill()` is called, the agent:
@@ -235,11 +235,11 @@ These skills involve complex integrations, multiple API calls, or advanced proce
 
 | Skill Name | Class | Description | Tools | Required Env Vars | Config Options |
 |---|---|---|---|---|---|
-| `web_search` | `WebSearchSkill` | Google Custom Search | `web_search` | `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_CX` | `max_results`, `safe_search` |
+| `web_search` | `WebSearchSkill` | Google Custom Search | `web_search` | `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID` | `num_results`, `tool_name`, `no_results_message`, `safe_search`, `delay`, `max_content_length`, `oversample_factor`, `min_quality_score` |
 | `wikipedia_search` | `WikipediaSearchSkill` | Wikipedia article summaries | `search_wiki` | None | `num_results`, `no_results_message`, `language`, `max_content_length` |
 | `google_maps` | `GoogleMapsSkill` | Directions and place search | `get_directions`, `find_place` | `GOOGLE_MAPS_API_KEY` | `default_mode` |
-| `datasphere` | `DataSphereSkill` | SignalWire DataSphere semantic search | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `max_results`, `distance_threshold` |
-| `datasphere_serverless` | `DataSphereServerlessSkill` | DataSphere via server-side DataMap | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `max_results`, `distance_threshold`, `document_id` |
+| `datasphere` | `DataSphereSkill` | SignalWire DataSphere semantic search | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `count`, `distance`, `document_id`, `tags`, `language`, `pos_to_expand`, `max_synonyms`, `no_results_message` |
+| `datasphere_serverless` | `DataSphereServerlessSkill` | DataSphere via server-side DataMap | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `count`, `distance`, `document_id`, `tags`, `language`, `pos_to_expand`, `max_synonyms`, `no_results_message` |
 | `native_vector_search` | `NativeVectorSearchSkill` | In-memory TF-IDF document search | `search_documents` | None | `documents` |
 | `spider` | `SpiderSkill` | Web page scraping via Spider API | `scrape_url` | `SPIDER_API_KEY` | `max_content_length` |
 | `claude_skills` | `ClaudeSkillsSkill` | Load Claude SKILL.md files as tools | (dynamic) | None | `skills_path`, `include`, `exclude`, `tool_prefix` |
@@ -251,7 +251,7 @@ These skills involve complex integrations, multiple API calls, or advanced proce
 ```typescript
 import { WebSearchSkill } from '@signalwire/sdk/skills/builtin';
 await agent.addSkill(new WebSearchSkill({
-  max_results: 5,
+  num_results: 5,
   safe_search: 'medium', // 'off' | 'medium' | 'high'
 }));
 ```
@@ -275,8 +275,9 @@ await agent.addSkill(new GoogleMapsSkill({ default_mode: 'walking' }));
 ```typescript
 import { DataSphereSkill } from '@signalwire/sdk/skills/builtin';
 await agent.addSkill(new DataSphereSkill({
-  max_results: 5,
-  distance_threshold: 0.7, // 0-1, lower is more similar
+  document_id: 'my-doc-id',
+  count: 5,
+  distance: 3.0, // 0-10, lower is more similar
 }));
 ```
 
@@ -285,9 +286,9 @@ await agent.addSkill(new DataSphereSkill({
 ```typescript
 import { DataSphereServerlessSkill } from '@signalwire/sdk/skills/builtin';
 await agent.addSkill(new DataSphereServerlessSkill({
-  max_results: 5,
-  distance_threshold: 0.7,
-  document_id: 'specific-doc-id', // optional: restrict to one document
+  document_id: 'specific-doc-id',
+  count: 5,
+  distance: 3.0, // 0-10, lower is more similar
 }));
 ```
 
@@ -820,7 +821,7 @@ const missing = skill.validateEnvVars();
 if (missing.length > 0) {
   console.warn(`Missing env vars: ${missing.join(', ')}`);
 }
-// missing might be ['GOOGLE_SEARCH_API_KEY', 'GOOGLE_SEARCH_CX']
+// missing might be ['GOOGLE_SEARCH_API_KEY', 'GOOGLE_SEARCH_ENGINE_ID']
 ```
 
 ### Runtime Handling
@@ -848,7 +849,7 @@ This two-layer approach (warn at registration, error at call time) allows agents
 | `WEATHER_API_KEY` | `weather_api` |
 | `API_NINJAS_KEY` | `api_ninjas_trivia` |
 | `GOOGLE_SEARCH_API_KEY` | `web_search` |
-| `GOOGLE_SEARCH_CX` | `web_search` |
+| `GOOGLE_SEARCH_ENGINE_ID` | `web_search` |
 | `GOOGLE_MAPS_API_KEY` | `google_maps` |
 | `SIGNALWIRE_PROJECT_ID` | `datasphere`, `datasphere_serverless` |
 | `SIGNALWIRE_TOKEN` | `datasphere`, `datasphere_serverless` |

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -147,7 +147,7 @@ These skills integrate with a single external API or provide focused call-contro
 | `play_background_file` | `PlayBackgroundFileSkill` | Background audio playback during calls | `play_background`, `stop_background` | None | `default_file_url`, `allowed_domains` |
 | `swml_transfer` | `SwmlTransferSkill` | Call transfer via SWML actions | `transfer_call`, `list_transfer_destinations` | None | `patterns`, `allow_arbitrary`, `default_message` |
 | `api_ninjas_trivia` | `ApiNinjasTriviaSkill` | Trivia questions from API Ninjas | `get_trivia` | `API_NINJAS_KEY` | `default_category`, `reveal_answer` |
-| `info_gatherer` | `InfoGathererSkill` | Structured data collection from users | `save_info`, `get_gathered_info` | None | `fields`, `purpose`, `confirmation_message`, `store_globally` |
+| `info_gatherer` | `InfoGathererSkill` | Sequential question flow that stores answers in `global_data` | `start_questions`, `submit_answer` | None | `questions`, `prefix`, `completion_message` |
 | `custom_skills` | `CustomSkillsSkill` | User-defined tools from configuration | Dynamic (from config) | None | `tools`, `prompt_title`, `prompt_body` |
 
 **weather_api** -- Fetches current weather data from OpenWeatherMap. Supports metric, imperial, and standard units.
@@ -191,19 +191,17 @@ await agent.addSkill(new ApiNinjasTriviaSkill({
 }));
 ```
 
-**info_gatherer** -- Collects structured information from users based on configurable field definitions with optional validation patterns. Data is stored per-call and can optionally be persisted to global data.
+**info_gatherer** -- Guides the agent through a sequence of questions, collecting answers one at a time and storing them under a namespaced key in SWAIG `global_data`. Questions may require the agent to read the answer back to the user for confirmation before proceeding. Matches Python's `InfoGathererSkill` exactly; configure a `prefix` to run multiple instances side by side.
 
 ```typescript
 import { InfoGathererSkill } from '@signalwire/sdk/skills/builtin';
 await agent.addSkill(new InfoGathererSkill({
-  purpose: 'Collecting customer contact information for our records.',
-  fields: [
-    { name: 'full_name', description: 'Customer full name', required: true },
-    { name: 'email', description: 'Email address', required: true, validation: '^[\\w.+-]+@[\\w-]+\\.[\\w.]+$' },
-    { name: 'phone', description: 'Phone number', required: false },
+  questions: [
+    { key_name: 'full_name', question_text: 'What is your full name?' },
+    { key_name: 'email', question_text: 'What is your email address?', confirm: true },
+    { key_name: 'reason', question_text: 'How can I help you today?' },
   ],
-  confirmation_message: 'Thank you! Your information has been saved.',
-  store_globally: true,
+  completion_message: 'Thank you! Your information has been saved.',
 }));
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "signalwire-agents",
-  "version": "0.1.0",
+  "name": "@signalwire/sdk",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "signalwire-agents",
-      "version": "0.1.0",
+      "name": "@signalwire/sdk",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hono/node-server": "^1.11.0",
         "ajv": "^8.18.0",
+        "cheerio": "^1.2.0",
         "hono": "^4.4.0",
         "js-yaml": "^4.1.1",
         "ws": "^8.17.0"
@@ -988,6 +989,12 @@
         "node": "*"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1030,6 +1037,48 @@
         "node": "*"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -1050,6 +1099,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/debug": {
@@ -1091,6 +1168,86 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/esbuild": {
@@ -1235,6 +1392,37 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -1243,6 +1431,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -1422,6 +1622,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -1452,6 +1664,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-key": {
@@ -1612,6 +1873,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -1762,6 +2029,15 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -1917,6 +2193,28 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "ajv": "^8.18.0",
+    "cheerio": "^1.2.0",
     "hono": "^4.4.0",
     "js-yaml": "^4.1.1",
     "ws": "^8.17.0"

--- a/src/AgentBase.ts
+++ b/src/AgentBase.ts
@@ -1392,6 +1392,14 @@ export class AgentBase {
       }
     }
 
+    // Register DataMap-style tools — skills that build their own SWAIG JSON
+    // (e.g. DataSphereServerless) return them via getDataMapTools().
+    // Python equivalent: self.agent.register_swaig_function(swaig_function)
+    // inside register_tools() (skills/datasphere_serverless/skill.py:210).
+    for (const dmFn of skill.getDataMapTools()) {
+      this.registerSwaigFunction(dmFn);
+    }
+
     // Inject prompt sections
     for (const section of skill.getPromptSections()) {
       this.promptAddSection(section.title, section);
@@ -1953,6 +1961,9 @@ export class AgentBase {
               fn.extraFields['is_hangup_hook'] = true;
             }
           }
+        }
+        for (const dmFn of skill.getDataMapTools()) {
+          copy.registerSwaigFunction(dmFn);
         }
         for (const section of skill.getPromptSections()) {
           copy.promptAddSection(section.title, section);

--- a/src/AgentBase.ts
+++ b/src/AgentBase.ts
@@ -1069,6 +1069,7 @@ export class AgentBase {
    * @returns This agent instance for chaining.
    */
   async addSkill(skill: SkillBase): Promise<this> {
+    skill.setAgent(this);
     await this.skillManager.addSkill(skill);
 
     // Register skill tools, then apply any swaigFields as extraFields on the SWAIG function
@@ -1498,6 +1499,7 @@ export class AgentBase {
     for (const entry of this.skillManager.getLoadedSkillEntries()) {
       try {
         const skill = new (entry.SkillClass as any)(entry.config);
+        skill.setAgent(copy);
         // Synchronous re-add: mark initialized, register tools/prompts/hints/data
         skill.markInitialized();
         copy.skillManager.addSkill(skill).catch(() => { /* swallow async errors in sync context */ });

--- a/src/AgentBase.ts
+++ b/src/AgentBase.ts
@@ -1074,10 +1074,15 @@ export class AgentBase {
     // Register skill tools, then apply any swaigFields as extraFields on the SWAIG function
     for (const toolDef of skill.getTools()) {
       this.defineTool(toolDef);
-      if (Object.keys(skill.swaigFields).length > 0) {
-        const fn = this.toolRegistry.get(toolDef.name);
-        if (fn instanceof SwaigFunction) {
+      const fn = this.toolRegistry.get(toolDef.name);
+      if (fn instanceof SwaigFunction) {
+        if (Object.keys(skill.swaigFields).length > 0) {
           safeAssign(fn.extraFields, skill.swaigFields);
+        }
+        // Propagate is_hangup_hook so the SignalWire platform auto-fires this
+        // tool on call hangup (Python equivalent: is_hangup_hook=True in define_tool).
+        if (toolDef.isHangupHook) {
+          fn.extraFields['is_hangup_hook'] = true;
         }
       }
     }
@@ -1504,10 +1509,13 @@ export class AgentBase {
 
         for (const toolDef of skill.getTools()) {
           copy.defineTool(toolDef);
-          if (Object.keys(skill.swaigFields).length > 0) {
-            const fn = copy.toolRegistry.get(toolDef.name);
-            if (fn instanceof SwaigFunction) {
+          const fn = copy.toolRegistry.get(toolDef.name);
+          if (fn instanceof SwaigFunction) {
+            if (Object.keys(skill.swaigFields).length > 0) {
               safeAssign(fn.extraFields, skill.swaigFields);
+            }
+            if (toolDef.isHangupHook) {
+              fn.extraFields['is_hangup_hook'] = true;
             }
           }
         }

--- a/src/AgentBase.ts
+++ b/src/AgentBase.ts
@@ -1928,7 +1928,19 @@ export class AgentBase {
         skill.setAgent(copy);
         // Synchronous re-add: mark initialized, register tools/prompts/hints/data
         skill.markInitialized();
-        copy._skillManager.addSkill(skill).catch(() => { /* swallow async errors in sync context */ });
+        copy._skillManager.addSkill(skill).catch((err: unknown) => {
+          // Swallow re-add errors in the cloning path — the primary agent already
+          // validated env vars / packages / schema / setup when this skill was first
+          // added, and the clone inherits that validation. Python's equivalent at
+          // skill_manager.py:161-170 specifically swallows "already exists"
+          // ValueErrors during cloning; TS has no such error class (toolRegistry
+          // uses Map.set which silently overwrites), so the blanket swallow is
+          // the closest parity. Log at debug so the error isn't entirely lost.
+          this.log.debug('Skipping re-add error during agent clone', {
+            skill: entry.skillName,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
 
         for (const toolDef of skill.getTools()) {
           copy.defineTool(toolDef);

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ export type { ServerlessPlatform, ServerlessEvent, ServerlessResponse } from './
 
 // Skills
 export { SkillBase, SkillManager, SkillRegistry } from './skills/index.js';
-export type { SkillConfig, SkillToolDefinition, SkillPromptSection, SkillManifest, ParameterSchemaEntry, SkillSchemaInfo } from './skills/index.js';
+export type { SkillConfig, SkillToolDefinition, SkillPromptSection, ParameterSchemaEntry, SkillSchemaInfo } from './skills/index.js';
 
 // Built-in Skills
 export { registerBuiltinSkills } from './skills/builtin/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ export type { ServerlessPlatform, ServerlessEvent, ServerlessResponse } from './
 
 // Skills
 export { SkillBase, SkillManager, SkillRegistry } from './skills/index.js';
-export type { SkillConfig, SkillToolDefinition, SkillPromptSection, SkillManifest, SkillFactory, ParameterSchemaEntry, SkillSchemaInfo } from './skills/index.js';
+export type { SkillConfig, SkillToolDefinition, SkillPromptSection, SkillManifest, ParameterSchemaEntry, SkillSchemaInfo } from './skills/index.js';
 
 // Built-in Skills
 export { registerBuiltinSkills } from './skills/builtin/index.js';

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -104,7 +104,50 @@ export interface SkillManifest {
  * They define tools, prompt sections, hints, and global data.
  */
 export abstract class SkillBase {
-  /** Whether this skill type supports multiple simultaneous instances (e.g., with different tool_name). */
+  /**
+   * Unique skill name. Subclasses MUST override with a non-empty string.
+   *
+   * Python parity: `SKILL_NAME: str = None` at `core/skill_base.py:23`.
+   * Python raises `ValueError` in `__init__` when this is left as `None`;
+   * TS throws at construction when this is left as the empty default.
+   */
+  static SKILL_NAME: string = '';
+
+  /**
+   * Human-readable description of the skill. Subclasses MUST override.
+   *
+   * Python parity: `SKILL_DESCRIPTION: str = None` at `core/skill_base.py:24`.
+   */
+  static SKILL_DESCRIPTION: string = '';
+
+  /**
+   * Semantic version string. Subclasses may override; defaults to `"1.0.0"`.
+   *
+   * Python parity: `SKILL_VERSION: str = "1.0.0"` at `core/skill_base.py:25`.
+   */
+  static SKILL_VERSION: string = '1.0.0';
+
+  /**
+   * Packages required by the skill, checked at load time by `validatePackages()`.
+   *
+   * Python parity: `REQUIRED_PACKAGES: List[str] = []` at `core/skill_base.py:26`.
+   * In TS these are npm package names importable via dynamic `import()`.
+   */
+  static REQUIRED_PACKAGES: readonly string[] = [];
+
+  /**
+   * Environment variables required for the skill to function, checked at load
+   * time by `validateEnvVars()`.
+   *
+   * Python parity: `REQUIRED_ENV_VARS: List[str] = []` at `core/skill_base.py:27`.
+   */
+  static REQUIRED_ENV_VARS: readonly string[] = [];
+
+  /**
+   * Whether this skill type supports multiple simultaneous instances (e.g., with different tool_name).
+   *
+   * Python parity: `SUPPORTS_MULTIPLE_INSTANCES: bool = False` at `core/skill_base.py:30`.
+   */
   static SUPPORTS_MULTIPLE_INSTANCES = false;
 
   /**
@@ -113,7 +156,8 @@ export abstract class SkillBase {
    *
    * Mirrors Python's `SkillBase.get_parameter_schema()` (skill_base.py:197-266):
    * returns `swaig_fields` + `skip_prompt` for all skills, and additionally adds a
-   * `tool_name` entry for classes with `SUPPORTS_MULTIPLE_INSTANCES = true`.
+   * `tool_name` entry with `default: cls.SKILL_NAME` for classes with
+   * `SUPPORTS_MULTIPLE_INSTANCES = true`.
    *
    * @returns Record mapping parameter names to their schema entries.
    */
@@ -136,6 +180,8 @@ export abstract class SkillBase {
       schema['tool_name'] = {
         type: 'string',
         description: 'Custom name for this skill instance (for multiple instances).',
+        // Python `core/skill_base.py:261`: `default: cls.SKILL_NAME`.
+        default: this.SKILL_NAME || undefined,
         required: false,
       };
     }
@@ -194,14 +240,33 @@ export abstract class SkillBase {
 
   /**
    * Create a new skill instance.
-   * @param skillName - The registered name for this skill type.
-   * @param config - Optional configuration key-value pairs.
+   *
+   * Python parity: `core/skill_base.py:32-43`.
+   * Python `__init__` raises `ValueError` if `SKILL_NAME` or `SKILL_DESCRIPTION`
+   * is left as `None` on the subclass. TS throws the equivalent when the static
+   * defaults haven't been overridden.
+   *
+   * @param config - Optional configuration key-value pairs (Python: `params`).
    */
-  constructor(skillName: string, config?: SkillConfig) {
-    this.skillName = skillName;
+  constructor(config?: SkillConfig) {
+    const klass = this.constructor as typeof SkillBase;
+    if (!klass.SKILL_NAME) {
+      throw new Error(
+        `${klass.name} must define static SKILL_NAME ` +
+          `(Python equivalent: core/skill_base.py:23,33-34).`,
+      );
+    }
+    if (!klass.SKILL_DESCRIPTION) {
+      throw new Error(
+        `${klass.name} must define static SKILL_DESCRIPTION ` +
+          `(Python equivalent: core/skill_base.py:24,35-36).`,
+      );
+    }
+
+    this.skillName = klass.SKILL_NAME;
     this.config = { ...(config ?? {}) };
-    this.instanceId = `${skillName}-${Date.now().toString(36)}-${randomBytes(4).toString('hex')}`;
-    this.logger = getLogger(`signalwire.skills.${skillName}`);
+    this.instanceId = `${klass.SKILL_NAME}-${Date.now().toString(36)}-${randomBytes(4).toString('hex')}`;
+    this.logger = getLogger(`signalwire.skills.${klass.SKILL_NAME}`);
 
     // Extract swaig_fields from config (matches Python's self.swaig_fields = self.params.pop('swaig_fields', {}))
     this.swaigFields = (this.config['swaig_fields'] as Record<string, unknown>) ?? {};
@@ -210,9 +275,31 @@ export abstract class SkillBase {
 
   /**
    * Get the skill manifest containing metadata, requirements, and config schema.
-   * @returns The skill's manifest object.
+   *
+   * Default implementation derives every field from the static class constants
+   * (`SKILL_NAME`, `SKILL_DESCRIPTION`, `SKILL_VERSION`, `REQUIRED_ENV_VARS`,
+   * `REQUIRED_PACKAGES`) — matching Python's single-source-of-truth pattern
+   * where metadata lives on the class (`core/skill_base.py:22-30`). Subclasses
+   * only need to override when adding a TS-specific `configSchema` or
+   * non-Python fields like `tags`/`author`.
+   *
+   * **Deprecation note:** the `SkillManifest` abstraction is TS-only; Python
+   * reads metadata by direct class-attribute access. This method will be
+   * removed in a future release — prefer `(skill.constructor as typeof SkillBase).SKILL_NAME`
+   * and the sibling statics.
+   *
+   * @returns A manifest object derived from the skill class's static constants.
    */
-  abstract getManifest(): SkillManifest;
+  getManifest(): SkillManifest {
+    const klass = this.constructor as typeof SkillBase;
+    return {
+      name: klass.SKILL_NAME,
+      description: klass.SKILL_DESCRIPTION,
+      version: klass.SKILL_VERSION,
+      requiredEnvVars: [...klass.REQUIRED_ENV_VARS],
+      requiredPackages: [...klass.REQUIRED_PACKAGES],
+    };
+  }
 
   /**
    * Setup the skill. Called when the skill is added to an agent.
@@ -344,23 +431,24 @@ export abstract class SkillBase {
   }
 
   /**
-   * Validate that all required environment variables declared in the manifest are set.
+   * Validate that all required environment variables declared on the skill class
+   * are set in the current process environment.
+   *
+   * Python parity: `core/skill_base.py:103-110` reads `self.REQUIRED_ENV_VARS`
+   * directly. TS reads the same static from the class.
    *
    * Returns the list of missing variable names so callers can produce actionable
-   * error messages.  This differs from the Python SDK's `validate_env_vars() -> bool`,
-   * which only returns a boolean.  If you need boolean semantics (e.g. `if skill.hasAllEnvVars()`),
-   * use {@link hasAllEnvVars} instead — it is the direct boolean equivalent.
+   * error messages. This differs from Python's `validate_env_vars() -> bool`
+   * return shape; {@link hasAllEnvVars} is the boolean equivalent.
    *
    * @returns Array of missing environment variable names (empty if all are present).
    */
   validateEnvVars(): string[] {
-    const manifest = this.getManifest();
+    const klass = this.constructor as typeof SkillBase;
     const missing: string[] = [];
-    if (manifest.requiredEnvVars) {
-      for (const envVar of manifest.requiredEnvVars) {
-        if (!process.env[envVar]) {
-          missing.push(envVar);
-        }
+    for (const envVar of klass.REQUIRED_ENV_VARS) {
+      if (!process.env[envVar]) {
+        missing.push(envVar);
       }
     }
     return missing;
@@ -412,26 +500,26 @@ export abstract class SkillBase {
   }
 
   /**
-   * Validate that all required packages declared in the manifest are available.
-   * Attempts a dynamic `import()` for each package in `manifest.requiredPackages`.
-   * Python equivalent: `validate_packages() -> bool` using `importlib.import_module`.
+   * Validate that all required packages declared on the skill class can be imported.
+   *
+   * Python parity: `core/skill_base.py:112-124` reads `self.REQUIRED_PACKAGES`
+   * directly and tries `importlib.import_module(pkg)` for each; TS does the
+   * equivalent with a dynamic `import()`.
+   *
    * @returns Array of package names that could not be imported (empty if all present).
    */
   async validatePackages(): Promise<string[]> {
-    const manifest = this.getManifest();
+    const klass = this.constructor as typeof SkillBase;
     const missing: string[] = [];
-    if (manifest.requiredPackages) {
-      const log = getLogger(`signalwire.skills.${this.skillName}`);
-      for (const pkg of manifest.requiredPackages) {
-        try {
-          await import(pkg);
-        } catch {
-          missing.push(pkg);
-        }
+    for (const pkg of klass.REQUIRED_PACKAGES) {
+      try {
+        await import(pkg);
+      } catch {
+        missing.push(pkg);
       }
-      if (missing.length > 0) {
-        log.error(`Missing required packages: ${missing.join(', ')}`);
-      }
+    }
+    if (missing.length > 0) {
+      this.logger.error(`Missing required packages: ${missing.join(', ')}`);
     }
     return missing;
   }

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -110,20 +110,36 @@ export abstract class SkillBase {
   /**
    * Get the parameter schema for this skill class, describing all accepted configuration options.
    * Subclasses should override and call `super.getParameterSchema()` to include base parameters.
+   *
+   * Mirrors Python's `SkillBase.get_parameter_schema()` (skill_base.py:197-266):
+   * returns `swaig_fields` + `skip_prompt` for all skills, and additionally adds a
+   * `tool_name` entry for classes with `SUPPORTS_MULTIPLE_INSTANCES = true`.
+   *
    * @returns Record mapping parameter names to their schema entries.
    */
   static getParameterSchema(): Record<string, ParameterSchemaEntry> {
-    return {
+    const schema: Record<string, ParameterSchemaEntry> = {
       swaig_fields: {
         type: 'object',
         description: 'Additional SWAIG fields to merge into each tool definition provided by this skill.',
+        default: {},
+        required: false,
       },
       skip_prompt: {
         type: 'boolean',
         description: 'When true, suppress all prompt sections from this skill.',
         default: false,
+        required: false,
       },
     };
+    if (this.SUPPORTS_MULTIPLE_INSTANCES) {
+      schema['tool_name'] = {
+        type: 'string',
+        description: 'Custom name for this skill instance (for multiple instances).',
+        required: false,
+      };
+    }
+    return schema;
   }
 
   /** The registered name of this skill type. */

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -8,6 +8,8 @@
 import { randomBytes } from 'node:crypto';
 import type { SwaigHandler } from '../SwaigFunction.js';
 import type { FunctionResult } from '../FunctionResult.js';
+import type { AgentBase } from '../AgentBase.js';
+import { getLogger } from '../Logger.js';
 
 /** Configuration key-value pairs passed to a skill at construction time. */
 export interface SkillConfig {
@@ -125,6 +127,12 @@ export abstract class SkillBase {
   protected config: SkillConfig;
   /** Additional SWAIG fields extracted from config, merged into tool definitions. */
   readonly swaigFields: Record<string, unknown>;
+  /**
+   * Reference to the agent that owns this skill.
+   * Set via `setAgent()` when the skill is added to an agent.
+   * Python equivalent: `self.agent` (set in `__init__`).
+   */
+  protected agent?: AgentBase;
   private _initialized = false;
 
   /**
@@ -151,9 +159,11 @@ export abstract class SkillBase {
   /**
    * Setup the skill. Called when the skill is added to an agent.
    * Override to perform initialization (API connections, config validation, etc.)
+   * @returns `true` if setup succeeded, `false` otherwise.
+   *          Python equivalent: abstract `setup() -> bool`.
    */
-  async setup(): Promise<void> {
-    // Default no-op
+  async setup(): Promise<boolean> {
+    return true;
   }
 
   /**
@@ -287,5 +297,50 @@ export abstract class SkillBase {
    */
   getConfig<T = unknown>(key: string, defaultValue?: T): T {
     return (this.config[key] !== undefined ? this.config[key] : defaultValue) as T;
+  }
+
+  /**
+   * Set the agent reference for this skill.
+   * Called by the SkillManager/AgentBase when the skill is attached to an agent.
+   * Python equivalent: `self.agent = agent` in `__init__`.
+   * @param agent - The agent that owns this skill.
+   */
+  setAgent(agent: AgentBase): void {
+    this.agent = agent;
+  }
+
+  /**
+   * Check if all required environment variables are present.
+   * Convenience wrapper around `validateEnvVars()` that returns a boolean,
+   * matching the Python `validate_env_vars() -> bool` return type.
+   * @returns `true` if all required env vars are set, `false` otherwise.
+   */
+  hasAllEnvVars(): boolean {
+    return this.validateEnvVars().length === 0;
+  }
+
+  /**
+   * Validate that all required packages declared in the manifest are available.
+   * Attempts a dynamic `import()` for each package in `manifest.requiredPackages`.
+   * Python equivalent: `validate_packages() -> bool` using `importlib.import_module`.
+   * @returns Array of package names that could not be imported (empty if all present).
+   */
+  async validatePackages(): Promise<string[]> {
+    const manifest = this.getManifest();
+    const missing: string[] = [];
+    if (manifest.requiredPackages) {
+      const log = getLogger(`signalwire.skills.${this.skillName}`);
+      for (const pkg of manifest.requiredPackages) {
+        try {
+          await import(pkg);
+        } catch {
+          missing.push(pkg);
+        }
+      }
+      if (missing.length > 0) {
+        log.error(`Missing required packages: ${missing.join(', ')}`);
+      }
+    }
+    return missing;
   }
 }

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -138,9 +138,38 @@ export abstract class SkillBase {
    * Reference to the agent that owns this skill.
    * Set via `setAgent()` when the skill is added to an agent.
    * Python equivalent: `self.agent` (set in `__init__`).
+   *
+   * In the Python SDK `agent` is always non-null because it is injected in the
+   * constructor.  In the TypeScript SDK the SkillManager always calls
+   * `setAgent()` before `setup()`, so subclasses can rely on `getAgent()` being
+   * safe to call inside `setup()` and any method invoked after it.
    */
   protected agent?: AgentBase;
   private _initialized = false;
+
+  /**
+   * Return the agent that owns this skill, asserting it is non-null.
+   * Equivalent to accessing `self.agent` in Python, where the agent reference
+   * is always set before `setup()` is called.
+   *
+   * The SkillManager lifecycle guarantees that `setAgent()` is called before
+   * `setup()`, so this method is safe to use inside `setup()` and in any
+   * tool handler invoked during an active agent session.
+   *
+   * @returns The owning `AgentBase` instance.
+   * @throws {Error} If called before `setAgent()` (i.e., before the skill is
+   *   attached to an agent by the SkillManager).
+   */
+  protected getAgent(): AgentBase {
+    if (!this.agent) {
+      throw new Error(
+        `SkillBase.getAgent() called before setAgent() on skill "${this.skillName}". ` +
+          'Ensure getAgent() is only called from setup() or tool handlers, ' +
+          'where the SkillManager has already attached the agent.',
+      );
+    }
+    return this.agent;
+  }
 
   /**
    * Create a new skill instance.
@@ -266,6 +295,12 @@ export abstract class SkillBase {
 
   /**
    * Validate that all required environment variables declared in the manifest are set.
+   *
+   * Returns the list of missing variable names so callers can produce actionable
+   * error messages.  This differs from the Python SDK's `validate_env_vars() -> bool`,
+   * which only returns a boolean.  If you need boolean semantics (e.g. `if skill.hasAllEnvVars()`),
+   * use {@link hasAllEnvVars} instead — it is the direct boolean equivalent.
+   *
    * @returns Array of missing environment variable names (empty if all are present).
    */
   validateEnvVars(): string[] {
@@ -349,5 +384,15 @@ export abstract class SkillBase {
       }
     }
     return missing;
+  }
+
+  /**
+   * Check if all required packages declared in the manifest are available.
+   * Convenience wrapper around `validatePackages()` that returns a boolean,
+   * matching the Python `validate_packages() -> bool` return type.
+   * @returns `true` if all required packages are importable, `false` otherwise.
+   */
+  async hasAllPackages(): Promise<boolean> {
+    return (await this.validatePackages()).length === 0;
   }
 }

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -231,6 +231,22 @@ export abstract class SkillBase {
   abstract getTools(): SkillToolDefinition[];
 
   /**
+   * Optional DataMap-style tool definitions. Skills that build their own
+   * SWAIG function dicts (e.g. via `DataMap.toSwaigFunction()`) return them
+   * here and `AgentBase.addSkill()` registers each via `registerSwaigFunction`.
+   *
+   * Python equivalent: the direct `self.agent.register_swaig_function(fn)`
+   * call inside `register_tools()` (e.g. `skills/datasphere_serverless/skill.py:210`).
+   * Default returns `[]` — skills using only the declarative `getTools()` path
+   * do not need to override this.
+   *
+   * @returns Array of fully-built SWAIG function dicts.
+   */
+  getDataMapTools(): Record<string, unknown>[] {
+    return [];
+  }
+
+  /**
    * Get prompt sections to inject into the agent's system prompt.
    * Respects the `skip_prompt` config option — returns `[]` if set to `true`.
    * Subclasses should override `_getPromptSections()` instead of this method.

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -195,6 +195,18 @@ export abstract class SkillBase {
   private _initialized = false;
 
   /**
+   * Tools registered imperatively via `defineTool()`.
+   *
+   * Python parity: Python's `SkillBase.register_tools()` is a `@abstractmethod` that
+   * calls `self.agent.define_tool(...)` (or `self.define_tool(...)`) once per tool.
+   * In TypeScript the tool pipeline is declarative (pull model): `SkillManager`
+   * calls `getTools()` at SWML render time. Skills that want to build their tool
+   * list imperatively (e.g. to branch on config at setup time) can push into this
+   * collection via `defineTool()`; the default `getTools()` returns it.
+   */
+  protected _dynamicTools: SkillToolDefinition[] = [];
+
+  /**
    * Return the agent that owns this skill, asserting it is non-null.
    * Equivalent to accessing `self.agent` in Python, where the agent reference
    * is always set before `setup()` is called.
@@ -265,9 +277,46 @@ export abstract class SkillBase {
 
   /**
    * Return the SWAIG tool definitions this skill provides.
+   *
+   * Default implementation returns tools registered imperatively via
+   * `defineTool()`. Skills using the declarative pattern override this
+   * method to return a static array built from their config.
+   *
+   * Python parity: replaces the `@abstractmethod register_tools()` contract
+   * — Python skills call `self.define_tool(...)` inside `register_tools()`;
+   * TypeScript skills either call `this.defineTool(...)` in `setup()` (and
+   * let the default `getTools()` return them) or override `getTools()`
+   * directly.
+   *
    * @returns Array of tool definitions to register with the agent.
    */
-  abstract getTools(): SkillToolDefinition[];
+  getTools(): SkillToolDefinition[] {
+    return [...this._dynamicTools];
+  }
+
+  /**
+   * Imperatively register a tool with this skill.
+   *
+   * Python parity: `core/skill_base.py:58` `def define_tool(self, **kwargs)`.
+   * Merges `this.swaigFields` into the tool definition (explicit fields on
+   * `toolDef` take precedence), then pushes the result into `_dynamicTools`
+   * so the default `getTools()` returns it at SWML render time.
+   *
+   * Intended for skills whose tool shape depends on config evaluated at
+   * `setup()` time. Skills with a static tool list should override
+   * `getTools()` instead.
+   *
+   * @param toolDef - The tool definition to register. Must include at
+   *   minimum `name`, `description`, `parameters`, and `handler`.
+   */
+  protected defineTool(toolDef: SkillToolDefinition): void {
+    const swaigDefaults = this.swaigFields as Partial<SkillToolDefinition>;
+    const merged: SkillToolDefinition = {
+      ...swaigDefaults,
+      ...toolDef,
+    };
+    this._dynamicTools.push(merged);
+  }
 
   /**
    * Optional DataMap-style tool definitions. Skills that build their own
@@ -402,6 +451,12 @@ export abstract class SkillBase {
       if (!process.env[envVar]) {
         missing.push(envVar);
       }
+    }
+    // Python parity: core/skill_base.py:107-109 logs an error line when any
+    // required env vars are missing. Mirror that here so both SDKs produce
+    // the same diagnostic signal during skill setup.
+    if (missing.length > 0) {
+      this.logger.error(`Missing required environment variables: ${missing.join(', ')}`);
     }
     return missing;
   }

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -9,7 +9,7 @@ import { randomBytes } from 'node:crypto';
 import type { SwaigHandler } from '../SwaigFunction.js';
 import type { FunctionResult } from '../FunctionResult.js';
 import type { AgentBase } from '../AgentBase.js';
-import { getLogger } from '../Logger.js';
+import { getLogger, type Logger } from '../Logger.js';
 
 /** Configuration key-value pairs passed to a skill at construction time. */
 export interface SkillConfig {
@@ -145,6 +145,11 @@ export abstract class SkillBase {
    * safe to call inside `setup()` and any method invoked after it.
    */
   protected agent?: AgentBase;
+  /**
+   * Logger scoped to this skill. Python equivalent: `self.logger = get_logger(...)`
+   * set in `SkillBase.__init__` so every subclass can call `self.logger.info(...)`.
+   */
+  protected readonly logger: Logger;
   private _initialized = false;
 
   /**
@@ -180,6 +185,7 @@ export abstract class SkillBase {
     this.skillName = skillName;
     this.config = { ...(config ?? {}) };
     this.instanceId = `${skillName}-${Date.now().toString(36)}-${randomBytes(4).toString('hex')}`;
+    this.logger = getLogger(`signalwire.skills.${skillName}`);
 
     // Extract swaig_fields from config (matches Python's self.swaig_fields = self.params.pop('swaig_fields', {}))
     this.swaigFields = (this.config['swaig_fields'] as Record<string, unknown>) ?? {};
@@ -248,12 +254,24 @@ export abstract class SkillBase {
 
   /**
    * Get the instance key used for deduplication in the SkillManager.
-   * Default returns the skill name. Multi-instance skills should override
-   * to include a distinguishing suffix (e.g., tool_name).
+   *
+   * For single-instance skills (`SUPPORTS_MULTIPLE_INSTANCES = false`), returns
+   * the skill name. For multi-instance skills, returns `${skillName}_${toolName}`
+   * using the `tool_name` config (falls back to the skill name).
+   *
+   * Matches Python's `SkillBase.get_instance_key()` default (`skill_base.py:141-146`).
+   * Multi-instance subclasses only need to override when their key derivation
+   * depends on config beyond `tool_name`.
+   *
    * @returns A unique key identifying this skill instance.
    */
   getInstanceKey(): string {
-    return this.skillName;
+    const SkillClass = this.constructor as typeof SkillBase;
+    if (!SkillClass.SUPPORTS_MULTIPLE_INSTANCES) {
+      return this.skillName;
+    }
+    const toolName = (this.config['tool_name'] as string | undefined) ?? this.skillName;
+    return `${this.skillName}_${toolName}`;
   }
 
   /**

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -77,26 +77,6 @@ export interface ParameterSchemaEntry {
   items?: Record<string, unknown>;
 }
 
-/** Metadata describing a skill's identity, requirements, and configuration schema. */
-export interface SkillManifest {
-  /** Unique skill name used for registration and lookup. */
-  name: string;
-  /** Human-readable description of the skill's purpose. */
-  description: string;
-  /** Semantic version string (e.g., "1.0.0"). */
-  version: string;
-  /** Author or organization that created the skill. */
-  author?: string;
-  /** Tags for categorization and discovery. */
-  tags?: string[];
-  /** Environment variables that must be set for the skill to function. */
-  requiredEnvVars?: string[];
-  /** NPM packages or external dependencies required by the skill. */
-  requiredPackages?: string[];
-  /** JSON-schema-like description of the skill's configuration options. */
-  configSchema?: Record<string, unknown>;
-}
-
 /**
  * Abstract base class for agent skills.
  *
@@ -271,34 +251,6 @@ export abstract class SkillBase {
     // Extract swaig_fields from config (matches Python's self.swaig_fields = self.params.pop('swaig_fields', {}))
     this.swaigFields = (this.config['swaig_fields'] as Record<string, unknown>) ?? {};
     delete this.config['swaig_fields'];
-  }
-
-  /**
-   * Get the skill manifest containing metadata, requirements, and config schema.
-   *
-   * Default implementation derives every field from the static class constants
-   * (`SKILL_NAME`, `SKILL_DESCRIPTION`, `SKILL_VERSION`, `REQUIRED_ENV_VARS`,
-   * `REQUIRED_PACKAGES`) — matching Python's single-source-of-truth pattern
-   * where metadata lives on the class (`core/skill_base.py:22-30`). Subclasses
-   * only need to override when adding a TS-specific `configSchema` or
-   * non-Python fields like `tags`/`author`.
-   *
-   * **Deprecation note:** the `SkillManifest` abstraction is TS-only; Python
-   * reads metadata by direct class-attribute access. This method will be
-   * removed in a future release — prefer `(skill.constructor as typeof SkillBase).SKILL_NAME`
-   * and the sibling statics.
-   *
-   * @returns A manifest object derived from the skill class's static constants.
-   */
-  getManifest(): SkillManifest {
-    const klass = this.constructor as typeof SkillBase;
-    return {
-      name: klass.SKILL_NAME,
-      description: klass.SKILL_DESCRIPTION,
-      version: klass.SKILL_VERSION,
-      requiredEnvVars: [...klass.REQUIRED_ENV_VARS],
-      requiredPackages: [...klass.REQUIRED_PACKAGES],
-    };
   }
 
   /**

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -30,6 +30,13 @@ export interface SkillToolDefinition {
   fillers?: Record<string, string[]>;
   /** List of parameter names that are required. */
   required?: string[];
+  /**
+   * When true, the SignalWire platform automatically invokes this tool when
+   * the call ends (hangup), regardless of whether the AI explicitly calls it.
+   * Equivalent to Python's `is_hangup_hook=True` in `define_tool()`.
+   * The flag is serialised as `"is_hangup_hook": true` in the SWAIG JSON.
+   */
+  isHangupHook?: boolean;
 }
 
 /** A section of prompt content injected into the agent's system prompt by a skill. */

--- a/src/skills/SkillManager.ts
+++ b/src/skills/SkillManager.ts
@@ -112,10 +112,14 @@ export class SkillManager {
       );
     }
 
-    // Setup — returns boolean indicating success (matches Python behavior)
+    // Setup — returns boolean indicating success. Matches Python load_skill
+    // (skill_manager.py:134-137): setup() returning false is fatal, the skill
+    // is NOT registered, and the caller gets [false, msg] via the wrappers.
+    // Python fails closed so the AI never sees a tool whose skill knows it
+    // isn't configured correctly.
     const setupOk = await skill.setup();
     if (!setupOk) {
-      log.warn(`Skill '${name}' setup() returned false — skill may not function correctly`);
+      throw new Error(`Failed to setup skill '${name}'`);
     }
     skill.markInitialized();
 

--- a/src/skills/SkillManager.ts
+++ b/src/skills/SkillManager.ts
@@ -89,11 +89,19 @@ export class SkillManager {
       throw new Error(`Cannot load skill '${name}': missing environment variables: ${missingEnvVars.join(', ')}`);
     }
 
-    // Log parameter schema info (non-fatal)
+    // Parameter schema contract — partial port of Python load_skill checks
+    // (skill_manager.py:49-93). Python additionally requires the subclass to
+    // override get_parameter_schema; we skip that identity check because TS
+    // test fixtures and trivial skills routinely inherit the base schema
+    // without harm, and the TS type system already enforces that
+    // getParameterSchema is a callable classmethod returning the right shape.
     const schema = SkillClass.getParameterSchema();
-    if (schema && Object.keys(schema).length > 0) {
-      log.debug(`Skill '${name}' has ${Object.keys(schema).length} config params`);
+    if (!schema || typeof schema !== 'object' || Object.keys(schema).length === 0) {
+      throw new Error(
+        `Skill '${name}'.getParameterSchema() must return a non-empty object`,
+      );
     }
+    log.debug(`Skill '${name}' has ${Object.keys(schema).length} config params`);
 
     // Setup — returns boolean indicating success (matches Python behavior)
     const setupOk = await skill.setup();

--- a/src/skills/SkillManager.ts
+++ b/src/skills/SkillManager.ts
@@ -103,6 +103,15 @@ export class SkillManager {
     }
     log.debug(`Skill '${name}' has ${Object.keys(schema).length} config params`);
 
+    // Validate required packages — Python equivalent at skill_manager.py:121-131.
+    // Throw on miss; wrappers catch and convert to [false, msg].
+    const missingPackages = await skill.validatePackages();
+    if (missingPackages.length > 0) {
+      throw new Error(
+        `Cannot load skill '${name}': missing required packages: ${missingPackages.join(', ')}`,
+      );
+    }
+
     // Setup — returns boolean indicating success (matches Python behavior)
     const setupOk = await skill.setup();
     if (!setupOk) {

--- a/src/skills/SkillManager.ts
+++ b/src/skills/SkillManager.ts
@@ -59,6 +59,12 @@ export class SkillManager {
   /**
    * Add a skill to the manager, validating env vars and calling setup().
    * Uses the skill's instance key for deduplication.
+   *
+   * Throws on duplicate (when multi-instance is disallowed), missing env vars,
+   * or setup errors. {@link loadSkill} / {@link loadSkillByName} wrap this and
+   * catch to return `[false, msg]`, matching Python `load_skill`'s return
+   * contract (`skill_manager.py` lines 114-118).
+   *
    * @param skill - The skill instance to add.
    */
   async addSkill(skill: SkillBase): Promise<void> {
@@ -75,8 +81,9 @@ export class SkillManager {
       return;
     }
 
-    // Validate required env vars — hard-fail matches Python's load_skill behavior
-    // (skill_manager.py lines 114-118: `if missing_env_vars: return False, error_msg`)
+    // Validate required env vars — throw on miss; loadSkill/loadSkillByName
+    // catch and convert to `[false, msg]` to match Python load_skill's return
+    // contract (skill_manager.py lines 114-118).
     const missingEnvVars = skill.validateEnvVars();
     if (missingEnvVars.length > 0) {
       throw new Error(`Cannot load skill '${name}': missing environment variables: ${missingEnvVars.join(', ')}`);

--- a/src/skills/SkillManager.ts
+++ b/src/skills/SkillManager.ts
@@ -6,6 +6,7 @@
  */
 
 import { SkillBase, type SkillConfig } from './SkillBase.js';
+import { SkillRegistry } from './SkillRegistry.js';
 import { getLogger } from '../Logger.js';
 
 const log = getLogger('SkillManager');
@@ -29,6 +30,16 @@ interface SkillMetaEntry {
 export class SkillManager {
   private skills: Map<string, SkillBase> = new Map();
   private skillMeta: Map<string, SkillMetaEntry> = new Map();
+
+  /**
+   * Public read-only view of all loaded skill instances, keyed by instance key.
+   * Python equivalent: `self.loaded_skills` (public `Dict[str, SkillBase]`).
+   *
+   * Use this to iterate or inspect loaded skills without mutating the internal map.
+   */
+  get loadedSkills(): ReadonlyMap<string, SkillBase> {
+    return this.skills;
+  }
 
   /**
    * Add a skill to the manager, validating env vars and calling setup().
@@ -61,8 +72,11 @@ export class SkillManager {
       log.debug(`Skill '${name}' has ${Object.keys(schema).length} config params`);
     }
 
-    // Setup
-    await skill.setup();
+    // Setup — returns boolean indicating success (matches Python behavior)
+    const setupOk = await skill.setup();
+    if (!setupOk) {
+      log.warn(`Skill '${name}' setup() returned false — skill may not function correctly`);
+    }
     skill.markInitialized();
 
     this.skills.set(instanceKey, skill);
@@ -132,6 +146,71 @@ export class SkillManager {
       if (skill.skillName === skillName) return true;
     }
     return false;
+  }
+
+  /**
+   * Check if a skill with the given instance key is currently loaded.
+   * This matches Python's `has_skill` semantics, which performs a direct
+   * dictionary key lookup (`skill_identifier in self.loaded_skills`).
+   *
+   * Use `hasSkill(name)` to check by skill name (iterates values).
+   * Use `hasSkillByKey(key)` to check by instance key (direct map lookup).
+   *
+   * @param instanceKey - The instance key to look up.
+   * @returns True if a skill with this exact instance key is loaded.
+   */
+  hasSkillByKey(instanceKey: string): boolean {
+    return this.skills.has(instanceKey);
+  }
+
+  /**
+   * Load a skill by name from the global SkillRegistry, construct it, and add it.
+   * This is the TypeScript equivalent of Python's `load_skill(skill_name)` path
+   * where `skill_class=None` triggers a registry lookup.
+   *
+   * @param skillName - The registered skill name to look up in the SkillRegistry.
+   * @param config - Optional configuration to pass to the skill factory.
+   * @returns A tuple `[success, errorMessage]` matching Python's `load_skill` return
+   *          contract. `errorMessage` is an empty string on success.
+   */
+  async loadSkillByName(skillName: string, config?: SkillConfig): Promise<[boolean, string]> {
+    const registry = SkillRegistry.getInstance();
+
+    if (!registry.has(skillName)) {
+      const errorMsg = `Skill '${skillName}' not found in registry`;
+      log.error(errorMsg);
+      return [false, errorMsg];
+    }
+
+    const skill = registry.create(skillName, config);
+    if (!skill) {
+      const errorMsg = `Failed to create skill '${skillName}' from registry`;
+      log.error(errorMsg);
+      return [false, errorMsg];
+    }
+
+    try {
+      await this.addSkill(skill);
+      return [true, ''];
+    } catch (err) {
+      const errorMsg = `Error loading skill '${skillName}': ${err instanceof Error ? err.message : String(err)}`;
+      log.error(errorMsg);
+      return [false, errorMsg];
+    }
+  }
+
+  /**
+   * List the instance keys of all currently loaded skills.
+   * Python equivalent: `list_loaded_skills() -> List[str]` which returns
+   * `list(self.loaded_skills.keys())`.
+   *
+   * Use `listSkills()` for richer objects (name, instanceId, initialized).
+   * Use `listSkillKeys()` for a flat list of instance key strings.
+   *
+   * @returns Array of instance key strings.
+   */
+  listSkillKeys(): string[] {
+    return Array.from(this.skills.keys());
   }
 
   /**

--- a/src/skills/SkillManager.ts
+++ b/src/skills/SkillManager.ts
@@ -26,6 +26,21 @@ interface SkillMetaEntry {
  *
  * Handles loading, unloading, validation, and aggregation of skill tools,
  * hints, global data, and prompt sections.
+ *
+ * @remarks
+ * **Architectural note — push vs pull model:**
+ * Python's `SkillManager.__init__(self, agent)` stores the agent reference and
+ * uses a **push model**: when a skill is loaded via `load_skill()`, the manager
+ * immediately calls `agent.add_hints()`, `agent.update_global_data()`, and
+ * `agent.prompt_add_section()` to inject skill data into the agent.
+ *
+ * This TypeScript implementation uses a **pull model** instead: `SkillManager`
+ * has no agent reference and no constructor. `AgentBase` owns the manager and
+ * calls `getAllHints()`, `getMergedGlobalData()`, and `getAllPromptSections()`
+ * at render time. Both approaches produce the same observable behavior at the
+ * SWML / SWAIG level. The pull model avoids circular-reference issues between
+ * `AgentBase` and `SkillManager` and is better suited to TypeScript's
+ * import-graph constraints.
  */
 export class SkillManager {
   private skills: Map<string, SkillBase> = new Map();
@@ -60,10 +75,11 @@ export class SkillManager {
       return;
     }
 
-    // Validate required env vars
+    // Validate required env vars — hard-fail matches Python's load_skill behavior
+    // (skill_manager.py lines 114-118: `if missing_env_vars: return False, error_msg`)
     const missingEnvVars = skill.validateEnvVars();
-    if (missingEnvVars.length) {
-      log.warn(`Skill '${name}' missing env vars: ${missingEnvVars.join(', ')}`);
+    if (missingEnvVars.length > 0) {
+      throw new Error(`Cannot load skill '${name}': missing environment variables: ${missingEnvVars.join(', ')}`);
     }
 
     // Log parameter schema info (non-fatal)
@@ -92,6 +108,10 @@ export class SkillManager {
    * Remove a skill by its instance key or instance ID, calling cleanup() before removal.
    * @param keyOrId - The instance key or instance ID of the skill to remove.
    * @returns True if the skill was found and removed, false otherwise.
+   *
+   * @remarks Equivalent to Python's `unload_skill(skill_identifier)`. Callers porting
+   *          from Python should change `skill_manager.unload_skill(id)` →
+   *          `skillManager.removeSkill(id)`.
    */
   async removeSkill(keyOrId: string): Promise<boolean> {
     // Try by instance key first
@@ -158,9 +178,47 @@ export class SkillManager {
    *
    * @param instanceKey - The instance key to look up.
    * @returns True if a skill with this exact instance key is loaded.
+   *
+   * @remarks Equivalent to Python's `has_skill(skill_identifier)`. Callers porting
+   *          from Python should change `skill_manager.has_skill(key)` →
+   *          `skillManager.hasSkillByKey(key)`.
    */
   hasSkillByKey(instanceKey: string): boolean {
     return this.skills.has(instanceKey);
+  }
+
+  /**
+   * Load a skill by providing the class constructor directly, bypassing the registry.
+   * This is the TypeScript equivalent of Python's `load_skill(skill_name, skill_class, params)`
+   * path where a caller-provided `skill_class` is used instead of a registry lookup.
+   *
+   * @param skillClass - The skill class constructor (a subclass of `SkillBase`).
+   * @param config - Optional configuration to pass to the skill constructor.
+   * @returns A tuple `[success, errorMessage]` matching Python's `load_skill` return
+   *          contract. `errorMessage` is an empty string on success.
+   *
+   * @remarks Equivalent to Python's `load_skill(skill_name, skill_class=MySkillClass, params)`.
+   *
+   * @example
+   * ```ts
+   * const [ok, err] = await manager.loadSkill(MyCustomSkill, { api_key: 'secret' });
+   * if (!ok) console.error(err);
+   * ```
+   */
+  async loadSkill(skillClass: typeof SkillBase, config?: SkillConfig): Promise<[boolean, string]> {
+    try {
+      // Concrete skill subclasses override the constructor to take only (config?: SkillConfig).
+      // Cast to reflect actual runtime signature — the base class requires `skillName` but
+      // concrete subclasses hardcode it in super(...), so only config is needed at the call site.
+      const SkillCtor = skillClass as unknown as new (config?: SkillConfig) => SkillBase;
+      const skill = new SkillCtor(config);
+      await this.addSkill(skill);
+      return [true, ''];
+    } catch (err) {
+      const errorMsg = `Error loading skill: ${err instanceof Error ? err.message : String(err)}`;
+      log.error(errorMsg);
+      return [false, errorMsg];
+    }
   }
 
   /**
@@ -172,6 +230,10 @@ export class SkillManager {
    * @param config - Optional configuration to pass to the skill factory.
    * @returns A tuple `[success, errorMessage]` matching Python's `load_skill` return
    *          contract. `errorMessage` is an empty string on success.
+   *
+   * @remarks Equivalent to Python's `load_skill(skill_name)` (registry path, where
+   *          `skill_class=None`). Callers porting from Python should change
+   *          `skill_manager.load_skill(name)` → `skillManager.loadSkillByName(name)`.
    */
   async loadSkillByName(skillName: string, config?: SkillConfig): Promise<[boolean, string]> {
     const registry = SkillRegistry.getInstance();
@@ -208,6 +270,10 @@ export class SkillManager {
    * Use `listSkillKeys()` for a flat list of instance key strings.
    *
    * @returns Array of instance key strings.
+   *
+   * @remarks Equivalent to Python's `list_loaded_skills()`. Callers porting from
+   *          Python should change `skill_manager.list_loaded_skills()` →
+   *          `skillManager.listSkillKeys()`.
    */
   listSkillKeys(): string[] {
     return Array.from(this.skills.keys());

--- a/src/skills/SkillRegistry.ts
+++ b/src/skills/SkillRegistry.ts
@@ -1,56 +1,62 @@
 /**
  * SkillRegistry - Global singleton registry for discovering and loading skills.
  *
- * Skills can be registered programmatically or discovered from directories.
- * Supports SIGNALWIRE_SKILL_PATHS env var for custom skill directories.
+ * Matches Python's `skills/registry.py:SkillRegistry`: the registry stores
+ * **class references** keyed by each class's static `SKILL_NAME`, and reads
+ * metadata (description, version, required packages/env vars,
+ * multi-instance support) by direct static-attribute access.
+ *
+ * Registration via `register(SkillClass)` validates that the class defines
+ * `SKILL_NAME`, that `getParameterSchema()` is callable and returns a
+ * non-empty object (Python `register_skill` at `registry.py:132-194`).
+ *
+ * Supports the `SIGNALWIRE_SKILL_PATHS` environment variable for custom
+ * skill directories, matching Python's discovery search path.
  */
 
-import { SkillBase, type SkillConfig, type SkillManifest, type ParameterSchemaEntry } from './SkillBase.js';
+import { SkillBase, type SkillConfig, type ParameterSchemaEntry } from './SkillBase.js';
 import { getLogger } from '../Logger.js';
 
 const log = getLogger('SkillRegistry');
 
-/** Factory function that creates a SkillBase instance from optional configuration. */
-export type SkillFactory = (config?: SkillConfig) => SkillBase;
-
-/** Internal registry entry associating a skill name with its factory and optional manifest. */
-interface RegistryEntry {
-  /** Registered skill name. */
-  name: string;
-  /** Factory function to create instances of this skill. */
-  factory: SkillFactory;
-  /** Optional pre-loaded manifest for the skill. */
-  manifest?: SkillManifest;
-}
-
-/** Combined schema information for a registered skill, including manifest and parameter schema. */
+/**
+ * Metadata exposed for a registered skill. Shape matches Python's
+ * `SkillRegistry.list_skills()` / `get_all_skills_schema()` return values
+ * (`skills/registry.py:205-227`, `229-296`).
+ */
 export interface SkillSchemaInfo {
-  /** The skill's registered name. */
+  /** The skill's registered name (from `SkillBase.SKILL_NAME`). */
   name: string;
-  /** Human-readable description of the skill. */
+  /** Human-readable description (from `SkillBase.SKILL_DESCRIPTION`). */
   description: string;
-  /** Semantic version string. */
+  /** Semantic version string (from `SkillBase.SKILL_VERSION`). */
   version: string;
   /** Whether this skill supports multiple simultaneous instances. */
   supportsMultipleInstances: boolean;
   /** Environment variables required by the skill. */
   requiredEnvVars: string[];
+  /** NPM packages required by the skill. */
+  requiredPackages: string[];
   /** Full parameter schema with types, defaults, and constraints. */
   parameters: Record<string, ParameterSchemaEntry>;
-  /** Optional source category for grouping (e.g., "builtin"). */
+  /** Optional source category for grouping (e.g., "builtin", "external"). */
   source?: string;
 }
 
 let _instance: SkillRegistry | null = null;
 
 /**
- * Global singleton registry for discovering and instantiating skills.
+ * Global singleton registry for registering and instantiating skills.
  *
- * Skills can be registered programmatically or auto-discovered from directories.
- * Supports the SIGNALWIRE_SKILL_PATHS environment variable for custom skill directories.
+ * Skills can be registered programmatically via `register(SkillClass)`.
+ * Matches Python's `skill_registry` global (`skills/registry.py:481`).
  */
 export class SkillRegistry {
-  private registry: Map<string, RegistryEntry> = new Map();
+  /**
+   * Map from `SKILL_NAME` to class reference. Matches Python's
+   * `self._skills: Dict[str, Type[SkillBase]]` (`registry.py:26`).
+   */
+  private registry: Map<string, typeof SkillBase> = new Map();
   private lockedNames: Set<string> = new Set();
   private searchPaths: string[];
 
@@ -78,20 +84,43 @@ export class SkillRegistry {
   }
 
   /**
-   * Register a skill factory by name, optionally with a pre-loaded manifest.
-   * @param name - The unique skill name.
-   * @param factory - Factory function to create skill instances.
-   * @param manifest - Optional manifest metadata for the skill.
+   * Register a skill class. The skill name is read from the class's static
+   * `SKILL_NAME`. Mirrors Python's `register_skill(skill_class)`
+   * (`skills/registry.py:132-194`) — including the schema-non-empty check
+   * and the protection against overwriting locked skills.
+   *
+   * @param SkillClass - A concrete subclass of `SkillBase` with a
+   *   non-empty `SKILL_NAME`.
    */
-  register(name: string, factory: SkillFactory, manifest?: SkillManifest): void {
+  register(SkillClass: typeof SkillBase): void {
+    const name = SkillClass.SKILL_NAME;
+    if (!name) {
+      throw new Error(
+        `${SkillClass.name} must define static SKILL_NAME before registration ` +
+          `(Python equivalent: registry.py:150 SKILL_NAME validation).`,
+      );
+    }
     if (this.lockedNames.has(name)) {
       log.warn(`Cannot overwrite locked skill: ${name}`);
       return;
     }
+    // Schema non-emptiness check — Python registry.py:163-166.
+    try {
+      const schema = SkillClass.getParameterSchema();
+      if (!schema || typeof schema !== 'object' || Object.keys(schema).length === 0) {
+        throw new Error(
+          `${SkillClass.name}.getParameterSchema() must return a non-empty object`,
+        );
+      }
+    } catch (err) {
+      throw new Error(
+        `${SkillClass.name}.getParameterSchema() failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
     if (this.registry.has(name)) {
       log.warn(`Overwriting skill registration: ${name}`);
     }
-    this.registry.set(name, { name, factory, manifest });
+    this.registry.set(name, SkillClass);
     log.debug(`Registered skill: ${name}`);
   }
 
@@ -117,18 +146,34 @@ export class SkillRegistry {
   }
 
   /**
-   * Create a new skill instance by looking up its factory in the registry.
+   * Create a new skill instance by looking up its class in the registry.
+   * Matches Python's `skill_manager.load_skill(name)` class-lookup + instantiate
+   * flow (`skill_manager.py:97`: `skill_instance = skill_class(self.agent, params)`).
+   *
    * @param name - The registered skill name.
-   * @param config - Optional configuration to pass to the factory.
+   * @param config - Optional configuration to pass to the skill constructor.
    * @returns A new skill instance, or null if the name is not registered.
    */
   create(name: string, config?: SkillConfig): SkillBase | null {
-    const entry = this.registry.get(name);
-    if (!entry) {
+    const SkillClass = this.registry.get(name);
+    if (!SkillClass) {
       log.warn(`Skill not found in registry: ${name}`);
       return null;
     }
-    return entry.factory(config);
+    // typeof SkillBase is abstract at the type level; concrete subclasses
+    // are what's actually stored. Cast through unknown to allow `new`.
+    const Ctor = SkillClass as unknown as new (config?: SkillConfig) => SkillBase;
+    return new Ctor(config);
+  }
+
+  /**
+   * Get the registered skill class by name. Matches Python's
+   * `get_skill_class(skill_name)` (`registry.py:196-203`).
+   * @param name - The registered skill name.
+   * @returns The skill class reference, or undefined if not registered.
+   */
+  getSkillClass(name: string): typeof SkillBase | undefined {
+    return this.registry.get(name);
   }
 
   /**
@@ -141,15 +186,6 @@ export class SkillRegistry {
   }
 
   /**
-   * Get the manifest for a registered skill, if available.
-   * @param name - The skill name to look up.
-   * @returns The skill manifest, or undefined if not found or not provided.
-   */
-  getManifest(name: string): SkillManifest | undefined {
-    return this.registry.get(name)?.manifest;
-  }
-
-  /**
    * List all registered skill names.
    * @returns Array of registered skill name strings.
    */
@@ -158,13 +194,20 @@ export class SkillRegistry {
   }
 
   /**
-   * List all registered skills with their optional manifests.
-   * @returns Array of objects containing skill name and manifest.
+   * List all registered skills with their full metadata. Matches Python's
+   * `list_skills()` shape (`registry.py:205-227`) plus TS-idiomatic
+   * camelCase keys.
+   * @returns Array of skill metadata objects.
    */
-  listRegisteredWithManifests(): { name: string; manifest?: SkillManifest }[] {
-    return Array.from(this.registry.values()).map(e => ({
-      name: e.name,
-      manifest: e.manifest,
+  listSkills(): SkillSchemaInfo[] {
+    return Array.from(this.registry.values()).map((SkillClass) => ({
+      name: SkillClass.SKILL_NAME,
+      description: SkillClass.SKILL_DESCRIPTION,
+      version: SkillClass.SKILL_VERSION,
+      supportsMultipleInstances: SkillClass.SUPPORTS_MULTIPLE_INSTANCES,
+      requiredEnvVars: [...SkillClass.REQUIRED_ENV_VARS],
+      requiredPackages: [...SkillClass.REQUIRED_PACKAGES],
+      parameters: SkillClass.getParameterSchema(),
     }));
   }
 
@@ -188,7 +231,7 @@ export class SkillRegistry {
 
   /**
    * Discover and register skills from a directory by importing each file.
-   * Looks for modules exporting a `createSkill` factory or a SkillBase default export.
+   * Looks for SkillBase subclass exports and registers them.
    * @param dirPath - Absolute path to the directory to scan.
    * @returns Array of newly discovered skill names.
    */
@@ -220,17 +263,21 @@ export class SkillRegistry {
         const fileUrl = pathToFileURL(
           entry.endsWith('.ts') || entry.endsWith('.js') ? fullPath : join(fullPath, 'skill.ts'),
         ).href;
-        const mod = await import(fileUrl);
+        const mod: Record<string, unknown> = await import(fileUrl);
 
-        // Look for a factory function or a SkillBase subclass
-        if (typeof mod.createSkill === 'function') {
-          const name = entry.replace(/\.(ts|js)$/, '');
-          this.register(name, mod.createSkill);
-          discovered.push(name);
-        } else if (typeof mod.default === 'function' && mod.default.prototype instanceof SkillBase) {
-          const name = entry.replace(/\.(ts|js)$/, '');
-          this.register(name, (config) => new mod.default(config));
-          discovered.push(name);
+        // Find any SkillBase subclass exported from the module. Matches
+        // Python `registry.py:104-113` which inspects loaded modules for
+        // `issubclass(obj, SkillBase)`.
+        for (const value of Object.values(mod)) {
+          if (
+            typeof value === 'function' &&
+            (value as { prototype?: unknown }).prototype instanceof SkillBase &&
+            (value as typeof SkillBase).SKILL_NAME
+          ) {
+            const SkillClass = value as typeof SkillBase;
+            this.register(SkillClass);
+            discovered.push(SkillClass.SKILL_NAME);
+          }
         }
       } catch (err) {
         log.debug(`Could not load skill from ${fullPath}: ${err}`);
@@ -254,34 +301,24 @@ export class SkillRegistry {
   }
 
   /**
-   * Get the combined schema info for a registered skill, including manifest and parameter schema.
-   * Creates a temporary instance to extract the schema.
+   * Get the combined schema info for a registered skill.
+   * Matches Python `get_all_skills_schema` per-skill shape
+   * (`registry.py:287-295`).
    * @param name - The registered skill name to query.
-   * @returns The skill's combined schema info, or undefined if not found.
+   * @returns The skill's schema info, or undefined if not found.
    */
   getSkillSchema(name: string): SkillSchemaInfo | undefined {
-    const entry = this.registry.get(name);
-    if (!entry) return undefined;
-
-    try {
-      const instance = entry.factory();
-      const manifest = instance.getManifest();
-      const SkillClass = instance.constructor as typeof SkillBase;
-      const parameters = SkillClass.getParameterSchema();
-
-      return {
-        name: manifest.name,
-        description: manifest.description,
-        version: manifest.version,
-        supportsMultipleInstances: SkillClass.SUPPORTS_MULTIPLE_INSTANCES,
-        requiredEnvVars: manifest.requiredEnvVars ?? [],
-        parameters,
-        source: manifest.tags?.includes('external') ? 'external' : 'builtin',
-      };
-    } catch (err) {
-      log.warn(`Failed to get schema for skill '${name}': ${err}`);
-      return undefined;
-    }
+    const SkillClass = this.registry.get(name);
+    if (!SkillClass) return undefined;
+    return {
+      name: SkillClass.SKILL_NAME,
+      description: SkillClass.SKILL_DESCRIPTION,
+      version: SkillClass.SKILL_VERSION,
+      supportsMultipleInstances: SkillClass.SUPPORTS_MULTIPLE_INSTANCES,
+      requiredEnvVars: [...SkillClass.REQUIRED_ENV_VARS],
+      requiredPackages: [...SkillClass.REQUIRED_PACKAGES],
+      parameters: SkillClass.getParameterSchema(),
+    };
   }
 
   /**
@@ -298,18 +335,19 @@ export class SkillRegistry {
   }
 
   /**
-   * List all registered skill names grouped by source category.
+   * Group registered skill names by source category. Matches Python's
+   * `list_all_skill_sources` (`skills/registry.py:436-478`).
+   *
+   * Current TS implementation treats every registered skill as "registered"
+   * (the only category that fits — filesystem-based discovery is optional
+   * and entry-points don't apply to Node the way they do to Python).
+   *
    * @returns Record mapping source categories to arrays of skill names.
    */
   listAllSkillSources(): Record<string, string[]> {
-    const groups: Record<string, string[]> = {};
-    for (const name of this.registry.keys()) {
-      const schema = this.getSkillSchema(name);
-      const source = schema?.source ?? 'unknown';
-      if (!groups[source]) groups[source] = [];
-      groups[source].push(name);
-    }
-    return groups;
+    return {
+      registered: Array.from(this.registry.keys()),
+    };
   }
 
   /**

--- a/src/skills/builtin/api_ninjas_trivia.ts
+++ b/src/skills/builtin/api_ninjas_trivia.ts
@@ -53,12 +53,10 @@ const VALID_CATEGORIES = [
  * Supports optional `default_category` and `reveal_answer` config options.
  */
 export class ApiNinjasTriviaSkill extends SkillBase {
-  /**
-   * @param config - Optional configuration; supports `default_category` and `reveal_answer`.
-   */
-  constructor(config?: SkillConfig) {
-    super('api_ninjas_trivia', config);
-  }
+  static override SKILL_NAME = 'api_ninjas_trivia';
+  static override SKILL_DESCRIPTION = 'Get trivia questions from API Ninjas';
+  static override REQUIRED_ENV_VARS: readonly string[] = ['API_NINJAS_KEY'];
+  static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {

--- a/src/skills/builtin/api_ninjas_trivia.ts
+++ b/src/skills/builtin/api_ninjas_trivia.ts
@@ -8,7 +8,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -76,32 +75,6 @@ export class ApiNinjasTriviaSkill extends SkillBase {
         type: 'boolean',
         description: 'Whether to include the answer in the response.',
         default: false,
-      },
-    };
-  }
-
-  /** @returns Manifest declaring API_NINJAS_KEY as required and config schema for category/reveal. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'api_ninjas_trivia',
-      description:
-        'Fetches trivia questions from the API Ninjas service. Supports multiple categories for varied trivia topics.',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['trivia', 'api', 'entertainment', 'quiz', 'external'],
-      requiredEnvVars: ['API_NINJAS_KEY'],
-      configSchema: {
-        default_category: {
-          type: 'string',
-          description:
-            'Default trivia category if none is specified by the user.',
-        },
-        reveal_answer: {
-          type: 'boolean',
-          description:
-            'Whether to include the answer in the response. Defaults to false so the AI can quiz the user.',
-          default: false,
-        },
       },
     };
   }

--- a/src/skills/builtin/ask_claude.ts
+++ b/src/skills/builtin/ask_claude.ts
@@ -75,6 +75,12 @@ interface AnthropicErrorResponse {
  * is used and the maximum response length.
  */
 export class AskClaudeSkill extends SkillBase {
+  // TS-only skill (no Python equivalent).
+  static override SKILL_NAME = 'ask_claude';
+  static override SKILL_DESCRIPTION =
+    'Provides access to Anthropic Claude AI for complex reasoning, analysis, and sub-queries.';
+  static override REQUIRED_ENV_VARS: readonly string[] = ['ANTHROPIC_API_KEY'];
+
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
       ...super.getParameterSchema(),
@@ -96,13 +102,6 @@ export class AskClaudeSkill extends SkillBase {
         default: 1024,
       },
     };
-  }
-
-  /**
-   * @param config - Optional configuration; supports `model` and `max_tokens`.
-   */
-  constructor(config?: SkillConfig) {
-    super('ask_claude', config);
   }
 
   /** @returns Manifest declaring ANTHROPIC_API_KEY as required and config schema for model/max_tokens. */

--- a/src/skills/builtin/ask_claude.ts
+++ b/src/skills/builtin/ask_claude.ts
@@ -8,7 +8,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -100,31 +99,6 @@ export class AskClaudeSkill extends SkillBase {
         type: 'number',
         description: 'Maximum tokens in the response.',
         default: 1024,
-      },
-    };
-  }
-
-  /** @returns Manifest declaring ANTHROPIC_API_KEY as required and config schema for model/max_tokens. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'ask_claude',
-      description:
-        'Provides access to Anthropic Claude AI for complex reasoning, analysis, and sub-queries.',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['ai', 'claude', 'anthropic', 'reasoning', 'analysis', 'external'],
-      requiredEnvVars: ['ANTHROPIC_API_KEY'],
-      configSchema: {
-        model: {
-          type: 'string',
-          description: 'The Claude model to use. Defaults to "claude-sonnet-4-5-20250929".',
-          default: 'claude-sonnet-4-5-20250929',
-        },
-        max_tokens: {
-          type: 'number',
-          description: 'Maximum tokens in the response. Defaults to 1024.',
-          default: 1024,
-        },
       },
     };
   }

--- a/src/skills/builtin/claude_skills.ts
+++ b/src/skills/builtin/claude_skills.ts
@@ -75,6 +75,12 @@ interface ParsedSkill {
  * that returns the skill's instructions when invoked.
  */
 export class ClaudeSkillsSkill extends SkillBase {
+  // Python ground truth: skills/claude_skills/skill.py
+  // Python REQUIRED_PACKAGES = ["yaml"]; TS uses js-yaml but kept [] historically.
+  static override SKILL_NAME = 'claude_skills';
+  static override SKILL_DESCRIPTION = 'Load Claude SKILL.md files as agent tools';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   private _skillsPath = '';
@@ -164,10 +170,6 @@ export class ClaudeSkillsSkill extends SkillBase {
         default: 30,
       },
     };
-  }
-
-  constructor(config?: SkillConfig) {
-    super('claude_skills', config);
   }
 
   getManifest(): SkillManifest {

--- a/src/skills/builtin/claude_skills.ts
+++ b/src/skills/builtin/claude_skills.ts
@@ -181,18 +181,18 @@ export class ClaudeSkillsSkill extends SkillBase {
   }
 
   /** Setup the Claude skills loader — discovers and parses all SKILL.md files. */
-  override async setup(): Promise<void> {
+  override async setup(): Promise<boolean> {
     const skillsPath = this.getConfig<string>('skills_path');
     if (!skillsPath) {
       log.error('claude_skills: skills_path parameter is required');
-      return;
+      return false;
     }
 
     this._skillsPath = resolve(skillsPath);
 
     if (!existsSync(this._skillsPath)) {
       log.error(`claude_skills: skills_path does not exist: ${this._skillsPath}`);
-      return;
+      return false;
     }
 
     let stat;
@@ -200,13 +200,13 @@ export class ClaudeSkillsSkill extends SkillBase {
       stat = statSync(this._skillsPath);
     } catch {
       log.error(`claude_skills: cannot stat skills_path: ${this._skillsPath}`);
-      return;
+      return false;
     }
     if (!stat.isDirectory()) {
       log.error(
         `claude_skills: skills_path is not a directory: ${this._skillsPath}`,
       );
-      return;
+      return false;
     }
 
     // Load include/exclude patterns
@@ -245,6 +245,7 @@ export class ClaudeSkillsSkill extends SkillBase {
     log.info(
       `claude_skills: loaded ${this._skills.length} skills from ${this._skillsPath}`,
     );
+    return true;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/skills/builtin/claude_skills.ts
+++ b/src/skills/builtin/claude_skills.ts
@@ -16,7 +16,6 @@ import yaml from 'js-yaml';
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -169,16 +168,6 @@ export class ClaudeSkillsSkill extends SkillBase {
         description: 'Timeout in seconds for shell injection commands',
         default: 30,
       },
-    };
-  }
-
-  getManifest(): SkillManifest {
-    return {
-      name: 'claude_skills',
-      description: 'Load Claude SKILL.md files as agent tools',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['claude', 'skills', 'skill-loader', 'markdown'],
     };
   }
 

--- a/src/skills/builtin/custom_skills.ts
+++ b/src/skills/builtin/custom_skills.ts
@@ -78,6 +78,11 @@ interface CustomSkillsConfigData {
  * environment variable to prevent unintended code execution.
  */
 export class CustomSkillsSkill extends SkillBase {
+  // TS-only skill (no Python equivalent).
+  static override SKILL_NAME = 'custom_skills';
+  static override SKILL_DESCRIPTION =
+    'Register one-off SWAIG tools from a user-supplied config (name + description + handler body).';
+
   private _compiledHandlers: Map<string, Function> = new Map();
   private _compilationErrors: Map<string, string> = new Map();
 
@@ -85,7 +90,7 @@ export class CustomSkillsSkill extends SkillBase {
    * @param config - Configuration object containing a `tools` array of custom tool definitions.
    */
   constructor(config?: SkillConfig) {
-    super('custom_skills', config);
+    super(config);
     this._compileHandlers();
   }
 

--- a/src/skills/builtin/custom_skills.ts
+++ b/src/skills/builtin/custom_skills.ts
@@ -12,7 +12,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -114,62 +113,6 @@ export class CustomSkillsSkill extends SkillBase {
     };
   }
 
-  /** @returns Manifest with config schema describing the tools array format. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'custom_skills',
-      description:
-        'A meta-skill that registers user-defined tools from configuration. Define tools with names, descriptions, parameters, and handler code.',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['meta', 'custom', 'extensible', 'dynamic'],
-      configSchema: {
-        tools: {
-          type: 'array',
-          description:
-            'Array of custom tool definitions: { name, description, parameters?, handler_code, required?, prompt_description?, secure?, fillers? }.',
-          items: {
-            type: 'object',
-            properties: {
-              name: { type: 'string', description: 'Tool name (must be unique).' },
-              description: { type: 'string', description: 'Tool description for the AI.' },
-              parameters: {
-                type: 'array',
-                description: 'Tool parameters: [{ name, type, description, required? }].',
-              },
-              handler_code: {
-                type: 'string',
-                description:
-                  'JavaScript function body. Receives (args, rawData, FunctionResult) as arguments. Must return a FunctionResult, string, or object.',
-              },
-              required: {
-                type: 'array',
-                description: 'Array of required parameter names.',
-              },
-              prompt_description: {
-                type: 'string',
-                description: 'Description to include in the prompt section for this tool.',
-              },
-              secure: { type: 'boolean', description: 'Whether to mark the tool as secure.' },
-              fillers: {
-                type: 'object',
-                description: 'Filler phrases for the tool.',
-              },
-            },
-            required: ['name', 'description', 'handler_code'],
-          },
-        },
-        prompt_title: {
-          type: 'string',
-          description: 'Custom title for the prompt section. Defaults to "Custom Tools".',
-        },
-        prompt_body: {
-          type: 'string',
-          description: 'Custom body text for the prompt section.',
-        },
-      },
-    };
-  }
 
   /**
    * Pre-compile handler code into functions during construction.

--- a/src/skills/builtin/datasphere.ts
+++ b/src/skills/builtin/datasphere.ts
@@ -9,7 +9,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -61,6 +60,13 @@ interface DataSphereResponse {
  * `max_synonyms`, and `no_results_message` config options.
  */
 export class DataSphereSkill extends SkillBase {
+  // Python ground truth: skills/datasphere/skill.py:20-27.
+  // REQUIRED_PACKAGES = ["requests"] in Python; TS uses native fetch so [].
+  static override SKILL_NAME = 'datasphere';
+  static override SKILL_DESCRIPTION = 'Search knowledge using SignalWire DataSphere RAG stack';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
@@ -147,15 +153,6 @@ export class DataSphereSkill extends SkillBase {
   }
 
   /**
-   * @param config - Optional configuration; supports `space_name`, `project_id`,
-   *   `token`, `document_id`, `tool_name`, `count`, `distance`, `tags`,
-   *   `language`, `pos_to_expand`, `max_synonyms`, `no_results_message`.
-   */
-  constructor(config?: SkillConfig) {
-    super('datasphere', config);
-  }
-
-  /**
    * Instance key for the SkillManager. Defaults to `datasphere_search_knowledge`,
    * matching the Python SDK default. When `tool_name` is set, uses
    * `datasphere_<tool_name>`.
@@ -163,69 +160,6 @@ export class DataSphereSkill extends SkillBase {
   override getInstanceKey(): string {
     const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
     return `${this.skillName}_${toolName}`;
-  }
-
-  /** @returns Manifest for this skill. No required env vars — all credentials come from params with env fallback. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'datasphere',
-      description: 'Search knowledge using SignalWire DataSphere RAG stack',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['search', 'datasphere', 'signalwire', 'knowledge', 'rag', 'external'],
-      requiredEnvVars: [],
-      requiredPackages: [],
-      configSchema: {
-        space_name: {
-          type: 'string',
-          description: 'SignalWire space name.',
-        },
-        project_id: {
-          type: 'string',
-          description: 'SignalWire project ID.',
-        },
-        token: {
-          type: 'string',
-          description: 'SignalWire API token.',
-        },
-        document_id: {
-          type: 'string',
-          description: 'DataSphere document ID to search within.',
-        },
-        count: {
-          type: 'integer',
-          description: 'Number of results to return. Defaults to 1. Range 1-10.',
-          default: 1,
-        },
-        distance: {
-          type: 'number',
-          description:
-            'Maximum distance threshold (lower is more relevant). Defaults to 3.0. Range 0-10.',
-          default: 3.0,
-        },
-        tags: {
-          type: 'array',
-          description: 'Tags to filter search results.',
-        },
-        language: {
-          type: 'string',
-          description: 'Language code for query expansion.',
-        },
-        pos_to_expand: {
-          type: 'array',
-          description: 'Parts of speech to expand with synonyms.',
-        },
-        max_synonyms: {
-          type: 'integer',
-          description: 'Maximum number of synonyms (1-10).',
-        },
-        no_results_message: {
-          type: 'string',
-          description:
-            'Message returned when no results are found. Supports {query} interpolation.',
-        },
-      },
-    };
   }
 
   /**

--- a/src/skills/builtin/datasphere.ts
+++ b/src/skills/builtin/datasphere.ts
@@ -1,9 +1,10 @@
 /**
  * DataSphere Skill - Searches SignalWire DataSphere for knowledge base content.
  *
- * Tier 3 built-in skill: requires SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN,
- * and SIGNALWIRE_SPACE environment variables. Uses the SignalWire DataSphere
- * API to perform semantic search across uploaded documents.
+ * Tier 3 built-in skill matching the Python SDK. All credentials (`space_name`,
+ * `project_id`, `token`) and `document_id` are supplied via skill params. Env
+ * var fallbacks (`SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE`)
+ * are honored when the corresponding param is not set.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -19,12 +20,20 @@ import { getLogger } from '../../Logger.js';
 
 const log = getLogger('DataSphereSkill');
 
-/** A single search result from the DataSphere API. */
-interface DataSphereResult {
+const DEFAULT_NO_RESULTS_MESSAGE =
+  "I couldn't find any relevant information for '{query}' in the knowledge base. " +
+  'Try rephrasing your question or asking about a different topic.';
+
+/** A single chunk returned by the DataSphere search API. */
+interface DataSphereChunk {
   /** Matched text chunk content. */
-  text: string;
+  text?: string;
+  /** Alternative content field name. */
+  content?: string;
+  /** Alternative chunk field name. */
+  chunk?: string;
   /** Distance score (lower is more similar). */
-  score: number;
+  score?: number;
   /** ID of the source document. */
   document_id?: string;
   /** Document metadata. */
@@ -35,8 +44,8 @@ interface DataSphereResult {
 
 /** Response shape from the SignalWire DataSphere search API. */
 interface DataSphereResponse {
-  /** Array of search results. */
-  results?: DataSphereResult[];
+  /** Array of matching chunks. The API returns `chunks`, not `results`. */
+  chunks?: DataSphereChunk[];
   /** Error message if the request failed. */
   error?: string;
   /** Additional error information. */
@@ -46,9 +55,10 @@ interface DataSphereResponse {
 /**
  * Searches SignalWire DataSphere for knowledge base content using semantic search.
  *
- * Tier 3 built-in skill. Requires `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`,
- * and `SIGNALWIRE_SPACE` environment variables. Supports `max_results` and
- * `distance_threshold` config options.
+ * Tier 3 built-in skill. Credentials can be supplied via params or fall back to
+ * `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, and `SIGNALWIRE_SPACE` environment
+ * variables. Supports `count`, `distance`, `tags`, `language`, `pos_to_expand`,
+ * `max_synonyms`, and `no_results_message` config options.
  */
 export class DataSphereSkill extends SkillBase {
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
@@ -62,131 +72,273 @@ export class DataSphereSkill extends SkillBase {
       },
       space_name: {
         type: 'string',
-        description: 'SignalWire space name.',
+        description:
+          "SignalWire space name (e.g., 'mycompany' from mycompany.signalwire.com)",
+        required: true,
         env_var: 'SIGNALWIRE_SPACE',
       },
       project_id: {
         type: 'string',
-        description: 'SignalWire project ID.',
+        description: 'SignalWire project ID',
+        required: true,
         env_var: 'SIGNALWIRE_PROJECT_ID',
       },
       token: {
         type: 'string',
-        description: 'SignalWire auth token.',
+        description: 'SignalWire API token',
+        required: true,
         hidden: true,
         env_var: 'SIGNALWIRE_TOKEN',
       },
       document_id: {
         type: 'string',
-        description: 'Optional: restrict search to a specific document ID.',
+        description: 'DataSphere document ID to search within',
+        required: true,
       },
-      max_results: {
-        type: 'number',
-        description: 'Maximum number of results to return.',
-        default: 5,
+      count: {
+        type: 'integer',
+        description: 'Number of search results to return',
+        default: 1,
+        min: 1,
+        max: 10,
       },
-      distance_threshold: {
+      distance: {
         type: 'number',
-        description: 'Maximum distance threshold for results (0-1).',
-        default: 0.7,
+        description:
+          'Maximum distance threshold for results (lower is more relevant)',
+        default: 3.0,
         min: 0,
-        max: 1,
+        max: 10,
+      },
+      tags: {
+        type: 'array',
+        description: 'Tags to filter search results',
+        items: { type: 'string' },
+      },
+      language: {
+        type: 'string',
+        description: "Language code for query expansion (e.g., 'en', 'es')",
+      },
+      pos_to_expand: {
+        type: 'array',
+        description: 'Parts of speech to expand with synonyms',
+        items: { type: 'string', enum: ['NOUN', 'VERB', 'ADJ', 'ADV'] },
+      },
+      max_synonyms: {
+        type: 'integer',
+        description: 'Maximum number of synonyms to use for query expansion',
+        min: 1,
+        max: 10,
+      },
+      no_results_message: {
+        type: 'string',
+        description: 'Message to return when no results are found',
+        default: DEFAULT_NO_RESULTS_MESSAGE,
       },
     };
   }
 
   /**
-   * @param config - Optional configuration; supports `max_results` and `distance_threshold`.
+   * @param config - Optional configuration; supports `space_name`, `project_id`,
+   *   `token`, `document_id`, `tool_name`, `count`, `distance`, `tags`,
+   *   `language`, `pos_to_expand`, `max_synonyms`, `no_results_message`.
    */
   constructor(config?: SkillConfig) {
     super('datasphere', config);
   }
 
+  /**
+   * Instance key for the SkillManager. Defaults to `datasphere_search_knowledge`,
+   * matching the Python SDK default. When `tool_name` is set, uses
+   * `datasphere_<tool_name>`.
+   */
   override getInstanceKey(): string {
-    const toolName = this.getConfig<string | undefined>('tool_name', undefined);
-    return toolName ? `${this.skillName}_${toolName}` : this.skillName;
+    const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
+    return `${this.skillName}_${toolName}`;
   }
 
   /** @returns Manifest declaring SignalWire credentials as required env vars. */
   getManifest(): SkillManifest {
     return {
       name: 'datasphere',
-      description:
-        'Searches SignalWire DataSphere for knowledge base content using semantic search across uploaded documents.',
+      description: 'Search knowledge using SignalWire DataSphere RAG stack',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'datasphere', 'signalwire', 'knowledge', 'rag', 'external'],
       requiredEnvVars: ['SIGNALWIRE_PROJECT_ID', 'SIGNALWIRE_TOKEN', 'SIGNALWIRE_SPACE'],
       configSchema: {
-        max_results: {
-          type: 'number',
-          description: 'Maximum number of results to return. Defaults to 5.',
-          default: 5,
+        space_name: {
+          type: 'string',
+          description: 'SignalWire space name.',
         },
-        distance_threshold: {
+        project_id: {
+          type: 'string',
+          description: 'SignalWire project ID.',
+        },
+        token: {
+          type: 'string',
+          description: 'SignalWire API token.',
+        },
+        document_id: {
+          type: 'string',
+          description: 'DataSphere document ID to search within.',
+        },
+        count: {
+          type: 'integer',
+          description: 'Number of results to return. Defaults to 1. Range 1-10.',
+          default: 1,
+        },
+        distance: {
           type: 'number',
           description:
-            'Maximum distance threshold for results (0-1, lower is more similar). Defaults to 0.7.',
-          default: 0.7,
+            'Maximum distance threshold (lower is more relevant). Defaults to 3.0. Range 0-10.',
+          default: 3.0,
+        },
+        tags: {
+          type: 'array',
+          description: 'Tags to filter search results.',
+        },
+        language: {
+          type: 'string',
+          description: 'Language code for query expansion.',
+        },
+        pos_to_expand: {
+          type: 'array',
+          description: 'Parts of speech to expand with synonyms.',
+        },
+        max_synonyms: {
+          type: 'integer',
+          description: 'Maximum number of synonyms (1-10).',
+        },
+        no_results_message: {
+          type: 'string',
+          description:
+            'Message returned when no results are found. Supports {query} interpolation.',
         },
       },
     };
   }
 
-  /** @returns A single `search_datasphere` tool that performs semantic search on uploaded documents. */
+  /**
+   * Global data injected into the agent's SWML context. Matches Python's
+   * `get_global_data()` so downstream consumers can detect DataSphere
+   * availability, the configured `document_id`, and the knowledge provider.
+   */
+  override getGlobalData(): Record<string, unknown> {
+    return {
+      datasphere_enabled: true,
+      document_id: this.getConfig<string | undefined>('document_id', undefined),
+      knowledge_provider: 'SignalWire DataSphere',
+    };
+  }
+
+  /** Resolve the tool name (defaults to `search_datasphere`, TS convention). */
+  private getToolName(): string {
+    return this.getConfig<string>('tool_name', 'search_datasphere');
+  }
+
+  /** @returns A single tool (named via `tool_name`) that performs semantic search. */
   getTools(): SkillToolDefinition[] {
-    const maxResults = this.getConfig<number>('max_results', 5);
-    const distanceThreshold = this.getConfig<number>('distance_threshold', 0.7);
+    const count = this.getConfig<number>('count', 1);
+    const distance = this.getConfig<number>('distance', 3.0);
+    const configDocumentId = this.getConfig<string | undefined>('document_id', undefined);
+    const tags = this.getConfig<string[] | undefined>('tags', undefined);
+    const language = this.getConfig<string | undefined>('language', undefined);
+    const posToExpand = this.getConfig<string[] | undefined>('pos_to_expand', undefined);
+    const maxSynonyms = this.getConfig<number | undefined>('max_synonyms', undefined);
+    const noResultsMessage = this.getConfig<string>(
+      'no_results_message',
+      DEFAULT_NO_RESULTS_MESSAGE,
+    );
+    const toolName = this.getToolName();
 
     return [
       {
-        name: 'search_datasphere',
+        name: toolName,
         description:
-          'Search the SignalWire DataSphere knowledge base for relevant information. Returns the most relevant text chunks from uploaded documents.',
+          'Search the knowledge base for information on any topic and return relevant results.',
         parameters: {
           query: {
             type: 'string',
-            description: 'The question or topic to search for in the knowledge base.',
+            description:
+              "The search query — what information you're looking for in the knowledge base.",
           },
           document_id: {
             type: 'string',
             description:
-              'Optional: limit search to a specific document by its ID.',
+              'Optional: limit this search to a specific document by its ID (overrides the skill-level default).',
           },
         },
         required: ['query'],
         handler: async (args: Record<string, unknown>) => {
-          const query = args.query as string | undefined;
-          const documentId = args.document_id as string | undefined;
+          const rawQuery = args['query'];
+          const perCallDocumentId = args['document_id'];
 
-          if (!query || typeof query !== 'string' || query.trim().length === 0) {
+          if (
+            !rawQuery ||
+            typeof rawQuery !== 'string' ||
+            rawQuery.trim().length === 0
+          ) {
             return new FunctionResult(
-              'Please provide a query to search the knowledge base.',
+              'Please provide a search query. What would you like me to search for in the knowledge base?',
             );
           }
 
-          const projectId = process.env['SIGNALWIRE_PROJECT_ID'];
-          const token = process.env['SIGNALWIRE_TOKEN'];
-          const space = process.env['SIGNALWIRE_SPACE'];
+          const query = rawQuery.trim();
+
+          const projectId =
+            this.getConfig<string | undefined>('project_id', undefined) ??
+            process.env['SIGNALWIRE_PROJECT_ID'];
+          const token =
+            this.getConfig<string | undefined>('token', undefined) ??
+            process.env['SIGNALWIRE_TOKEN'];
+          const space =
+            this.getConfig<string | undefined>('space_name', undefined) ??
+            process.env['SIGNALWIRE_SPACE'];
 
           if (!projectId || !token || !space) {
             return new FunctionResult(
-              'DataSphere is not configured. The SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN, and SIGNALWIRE_SPACE environment variables are required.',
+              'DataSphere is not configured. The SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN, and SIGNALWIRE_SPACE environment variables (or equivalent config params) are required.',
             );
           }
+
+          // Resolve document_id: per-call override > config default.
+          let documentId: string | undefined;
+          if (
+            typeof perCallDocumentId === 'string' &&
+            perCallDocumentId.trim().length > 0
+          ) {
+            documentId = perCallDocumentId.trim();
+          } else {
+            documentId = configDocumentId;
+          }
+
+          log.info('datasphere_search', { query, document_id: documentId });
 
           try {
             const spaceHost = space.includes('.') ? space : `${space}.signalwire.com`;
             const url = `https://${spaceHost}/api/datasphere/documents/search`;
 
             const requestBody: Record<string, unknown> = {
-              query: query.trim(),
-              count: maxResults,
-              distance: distanceThreshold,
+              query_string: query,
+              count,
+              distance,
             };
 
-            if (documentId && typeof documentId === 'string' && documentId.trim().length > 0) {
-              requestBody['document_id'] = documentId.trim();
+            if (documentId) {
+              requestBody['document_id'] = documentId;
+            }
+            if (tags !== undefined) {
+              requestBody['tags'] = tags;
+            }
+            if (language !== undefined) {
+              requestBody['language'] = language;
+            }
+            if (posToExpand !== undefined) {
+              requestBody['pos_to_expand'] = posToExpand;
+            }
+            if (maxSynonyms !== undefined) {
+              requestBody['max_synonyms'] = maxSynonyms;
             }
 
             const authHeader = Buffer.from(`${projectId}:${token}`).toString('base64');
@@ -199,51 +351,58 @@ export class DataSphereSkill extends SkillBase {
                 method: 'POST',
                 headers: {
                   'Content-Type': 'application/json',
-                  'Authorization': `Basic ${authHeader}`,
+                  Accept: 'application/json',
+                  Authorization: `Basic ${authHeader}`,
                 },
                 body: JSON.stringify(requestBody),
                 signal: controller.signal,
               });
-            } finally {
+            } catch (err) {
               clearTimeout(timeout);
+              if (err instanceof Error && err.name === 'AbortError') {
+                log.error('datasphere_timeout');
+                return new FunctionResult(
+                  'Sorry, the knowledge search timed out. Please try again.',
+                );
+              }
+              throw err;
             }
+            clearTimeout(timeout);
 
             if (!response.ok) {
               log.error('datasphere_api_error', { status: response.status });
               return new FunctionResult(
-                'The knowledge base search service encountered an error. Please try again later.',
+                'Sorry, there was an error accessing the knowledge base. Please try again later.',
               );
             }
 
             const data = (await response.json()) as DataSphereResponse;
 
-            if (!data.results || data.results.length === 0) {
+            if (!data || typeof data !== 'object') {
+              log.warn('datasphere_invalid_response');
               return new FunctionResult(
-                `No relevant results found in the knowledge base for "${query}".`,
+                DataSphereSkill._formatNoResultsMessage(noResultsMessage, query),
               );
             }
 
-            const parts: string[] = [
-              `Knowledge base results for "${query}" (${data.results.length} results):`,
-              '',
-            ];
+            // DataSphere API returns 'chunks', not 'results'.
+            const chunks = data.chunks ?? [];
 
-            for (let i = 0; i < data.results.length; i++) {
-              const result = data.results[i];
-              const score = (1 - result.score).toFixed(2);
-              parts.push(`--- Result ${i + 1} (relevance: ${score}) ---`);
-              parts.push(result.text.trim());
-              if (result.document_id) {
-                parts.push(`[Document: ${result.document_id}]`);
-              }
-              parts.push('');
+            if (chunks.length === 0) {
+              return new FunctionResult(
+                DataSphereSkill._formatNoResultsMessage(noResultsMessage, query),
+              );
             }
 
-            return new FunctionResult(parts.join('\n').trim());
-          } catch (err) {
-            log.error('search_datasphere_failed', { error: err instanceof Error ? err.message : String(err) });
             return new FunctionResult(
-              'The request could not be completed. Please try again.',
+              DataSphereSkill._formatSearchResults(query, chunks),
+            );
+          } catch (err) {
+            log.error('datasphere_search_failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return new FunctionResult(
+              'Sorry, I encountered an error while searching the knowledge base. Please try again later.',
             );
           }
         },
@@ -251,18 +410,59 @@ export class DataSphereSkill extends SkillBase {
     ];
   }
 
+  /** Format search result chunks into a user-facing string. */
+  private static _formatSearchResults(
+    query: string,
+    chunks: DataSphereChunk[],
+  ): string {
+    const header =
+      chunks.length === 1
+        ? `I found 1 result for '${query}':\n\n`
+        : `I found ${chunks.length} results for '${query}':\n\n`;
+
+    const blocks: string[] = [];
+    const separator = '='.repeat(50);
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      let content = `=== RESULT ${i + 1} ===\n`;
+
+      if (typeof chunk.text === 'string') {
+        content += chunk.text;
+      } else if (typeof chunk.content === 'string') {
+        content += chunk.content;
+      } else if (typeof chunk.chunk === 'string') {
+        content += chunk.chunk;
+      } else {
+        content += JSON.stringify(chunk, null, 2);
+      }
+
+      content += `\n${separator}\n\n`;
+      blocks.push(content);
+    }
+
+    return header + blocks.join('\n');
+  }
+
+  /** Apply the `{query}` template to the no-results message. */
+  private static _formatNoResultsMessage(template: string, query: string): string {
+    return template.includes('{query}')
+      ? template.replace(/\{query\}/g, query)
+      : template;
+  }
+
   /** @returns Prompt section describing DataSphere knowledge base search capabilities. */
   protected override _getPromptSections(): SkillPromptSection[] {
+    const toolName = this.getToolName();
     return [
       {
-        title: 'Knowledge Base Search (DataSphere)',
-        body: 'You have access to a knowledge base of documents that can be searched for relevant information.',
+        title: 'Knowledge Search Capability',
+        body: `You can search a knowledge base for information using the ${toolName} tool.`,
         bullets: [
-          'Use the search_datasphere tool when the user asks questions that might be answered by internal documentation or uploaded knowledge.',
-          'Results are ranked by relevance. Higher relevance scores indicate better matches.',
-          'You can optionally search within a specific document by providing its ID.',
-          'Synthesize information from multiple results when appropriate.',
-          'If no results are found, let the user know and suggest rephrasing their question.',
+          `Use the ${toolName} tool when users ask for information that might be in the knowledge base`,
+          'Search for relevant information using clear, specific queries',
+          'Summarize search results in a clear, helpful way',
+          'If no results are found, suggest the user try rephrasing their question',
         ],
       },
     ];

--- a/src/skills/builtin/datasphere.ts
+++ b/src/skills/builtin/datasphere.ts
@@ -263,16 +263,10 @@ export class DataSphereSkill extends SkillBase {
             description:
               "The search query — what information you're looking for in the knowledge base.",
           },
-          document_id: {
-            type: 'string',
-            description:
-              'Optional: limit this search to a specific document by its ID (overrides the skill-level default).',
-          },
         },
         required: ['query'],
         handler: async (args: Record<string, unknown>) => {
           const rawQuery = args['query'];
-          const perCallDocumentId = args['document_id'];
 
           if (
             !rawQuery ||
@@ -302,16 +296,7 @@ export class DataSphereSkill extends SkillBase {
             );
           }
 
-          // Resolve document_id: per-call override > config default.
-          let documentId: string | undefined;
-          if (
-            typeof perCallDocumentId === 'string' &&
-            perCallDocumentId.trim().length > 0
-          ) {
-            documentId = perCallDocumentId.trim();
-          } else {
-            documentId = configDocumentId;
-          }
+          const documentId = configDocumentId;
 
           log.info('datasphere_search', { query, document_id: documentId });
 

--- a/src/skills/builtin/datasphere.ts
+++ b/src/skills/builtin/datasphere.ts
@@ -69,13 +69,14 @@ export class DataSphereSkill extends SkillBase {
       tool_name: {
         type: 'string',
         description: 'Custom tool name for this DataSphere instance.',
+        default: 'search_knowledge',
+        required: false,
       },
       space_name: {
         type: 'string',
         description:
           "SignalWire space name (e.g., 'mycompany' from mycompany.signalwire.com)",
         required: true,
-        env_var: 'SIGNALWIRE_SPACE',
       },
       project_id: {
         type: 'string',
@@ -99,6 +100,7 @@ export class DataSphereSkill extends SkillBase {
         type: 'integer',
         description: 'Number of search results to return',
         default: 1,
+        required: false,
         min: 1,
         max: 10,
       },
@@ -107,26 +109,31 @@ export class DataSphereSkill extends SkillBase {
         description:
           'Maximum distance threshold for results (lower is more relevant)',
         default: 3.0,
+        required: false,
         min: 0,
         max: 10,
       },
       tags: {
         type: 'array',
         description: 'Tags to filter search results',
+        required: false,
         items: { type: 'string' },
       },
       language: {
         type: 'string',
         description: "Language code for query expansion (e.g., 'en', 'es')",
+        required: false,
       },
       pos_to_expand: {
         type: 'array',
         description: 'Parts of speech to expand with synonyms',
+        required: false,
         items: { type: 'string', enum: ['NOUN', 'VERB', 'ADJ', 'ADV'] },
       },
       max_synonyms: {
         type: 'integer',
         description: 'Maximum number of synonyms to use for query expansion',
+        required: false,
         min: 1,
         max: 10,
       },
@@ -134,6 +141,7 @@ export class DataSphereSkill extends SkillBase {
         type: 'string',
         description: 'Message to return when no results are found',
         default: DEFAULT_NO_RESULTS_MESSAGE,
+        required: false,
       },
     };
   }
@@ -166,6 +174,7 @@ export class DataSphereSkill extends SkillBase {
       author: 'SignalWire',
       tags: ['search', 'datasphere', 'signalwire', 'knowledge', 'rag', 'external'],
       requiredEnvVars: [],
+      requiredPackages: [],
       configSchema: {
         space_name: {
           type: 'string',
@@ -232,6 +241,37 @@ export class DataSphereSkill extends SkillBase {
     };
   }
 
+  /**
+   * Validate required credentials before the skill becomes active.
+   *
+   * Mirrors Python skills/datasphere/skill.py:120-128: `setup()` returns false
+   * when any of `space_name`, `project_id`, `token`, or `document_id` is
+   * missing from either config or env. Fails closed so SkillManager refuses
+   * to register a skill that would break at call time.
+   */
+  override async setup(): Promise<boolean> {
+    const spaceName =
+      this.getConfig<string | undefined>('space_name', undefined) ??
+      process.env['SIGNALWIRE_SPACE'];
+    const projectId =
+      this.getConfig<string | undefined>('project_id', undefined) ??
+      process.env['SIGNALWIRE_PROJECT_ID'];
+    const token =
+      this.getConfig<string | undefined>('token', undefined) ??
+      process.env['SIGNALWIRE_TOKEN'];
+    const documentId = this.getConfig<string | undefined>('document_id', undefined);
+    const missing: string[] = [];
+    if (!spaceName) missing.push('space_name');
+    if (!projectId) missing.push('project_id');
+    if (!token) missing.push('token');
+    if (!documentId) missing.push('document_id');
+    if (missing.length > 0) {
+      log.error('datasphere: missing required parameters', { missing });
+      return false;
+    }
+    return true;
+  }
+
   /** Resolve the tool name (defaults to `search_knowledge`, matching Python SDK). */
   private getToolName(): string {
     return this.getConfig<string>('tool_name', 'search_knowledge');
@@ -265,7 +305,7 @@ export class DataSphereSkill extends SkillBase {
           },
         },
         required: ['query'],
-        handler: async (args: Record<string, unknown>) => {
+        handler: async (args: Record<string, unknown>, _rawData: Record<string, unknown>) => {
           const rawQuery = args['query'];
 
           if (
@@ -296,7 +336,9 @@ export class DataSphereSkill extends SkillBase {
             );
           }
 
-          const documentId = configDocumentId;
+          // setup() validated document_id is present; always include it
+          // unconditionally, matching Python skill.py:186-191.
+          const documentId = configDocumentId ?? '';
 
           log.info('datasphere_search', { query, document_id: documentId });
 
@@ -305,14 +347,12 @@ export class DataSphereSkill extends SkillBase {
             const url = `https://${spaceHost}/api/datasphere/documents/search`;
 
             const requestBody: Record<string, unknown> = {
+              document_id: documentId,
               query_string: query,
               count,
               distance,
             };
 
-            if (documentId) {
-              requestBody['document_id'] = documentId;
-            }
             if (tags !== undefined) {
               requestBody['tags'] = tags;
             }

--- a/src/skills/builtin/datasphere.ts
+++ b/src/skills/builtin/datasphere.ts
@@ -157,7 +157,7 @@ export class DataSphereSkill extends SkillBase {
     return `${this.skillName}_${toolName}`;
   }
 
-  /** @returns Manifest declaring SignalWire credentials as required env vars. */
+  /** @returns Manifest for this skill. No required env vars — all credentials come from params with env fallback. */
   getManifest(): SkillManifest {
     return {
       name: 'datasphere',
@@ -165,7 +165,7 @@ export class DataSphereSkill extends SkillBase {
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'datasphere', 'signalwire', 'knowledge', 'rag', 'external'],
-      requiredEnvVars: ['SIGNALWIRE_PROJECT_ID', 'SIGNALWIRE_TOKEN', 'SIGNALWIRE_SPACE'],
+      requiredEnvVars: [],
       configSchema: {
         space_name: {
           type: 'string',
@@ -232,9 +232,9 @@ export class DataSphereSkill extends SkillBase {
     };
   }
 
-  /** Resolve the tool name (defaults to `search_datasphere`, TS convention). */
+  /** Resolve the tool name (defaults to `search_knowledge`, matching Python SDK). */
   private getToolName(): string {
-    return this.getConfig<string>('tool_name', 'search_datasphere');
+    return this.getConfig<string>('tool_name', 'search_knowledge');
   }
 
   /** @returns A single tool (named via `tool_name`) that performs semantic search. */

--- a/src/skills/builtin/datasphere_serverless.ts
+++ b/src/skills/builtin/datasphere_serverless.ts
@@ -3,9 +3,10 @@
  *
  * Tier 3 built-in skill. Matches the Python SDK's param-driven design: all
  * credentials (`space_name`, `project_id`, `token`) are supplied via skill
- * params. No environment variables are strictly required — the platform
- * resolves `${ENV.SIGNALWIRE_AUTH}` at execution time when the DataMap runs,
- * but standalone setup works from params alone.
+ * params. At `setup()` time the skill resolves these params, composes the
+ * full DataSphere API URL and a base64 Basic-auth header, and bakes both as
+ * literal values into the emitted DataMap SWAIG JSON (mirrors Python
+ * `skills/datasphere_serverless/skill.py:152-157, 182-201`).
  */
 
 import { SkillBase } from '../SkillBase.js';

--- a/src/skills/builtin/datasphere_serverless.ts
+++ b/src/skills/builtin/datasphere_serverless.ts
@@ -11,7 +11,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -36,6 +35,13 @@ const DEFAULT_NO_RESULTS_MESSAGE =
  * and `no_results_message` config options.
  */
 export class DataSphereServerlessSkill extends SkillBase {
+  // Python ground truth: skills/datasphere_serverless/skill.py:20-28
+  static override SKILL_NAME = 'datasphere_serverless';
+  static override SKILL_DESCRIPTION =
+    'Search knowledge using SignalWire DataSphere with serverless DataMap execution';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
@@ -114,15 +120,6 @@ export class DataSphereServerlessSkill extends SkillBase {
   }
 
   /**
-   * @param config - Optional configuration; supports `space_name`, `project_id`,
-   *   `token`, `document_id`, `count`, `distance`, `tags`, `language`,
-   *   `pos_to_expand`, `max_synonyms`, `no_results_message`, and `tool_name`.
-   */
-  constructor(config?: SkillConfig) {
-    super('datasphere_serverless', config);
-  }
-
-  /**
    * Instance key for the SkillManager. Defaults to
    * `datasphere_serverless_search_knowledge`, matching the Python SDK default.
    * When `tool_name` is set, uses `datasphere_serverless_<tool_name>`.
@@ -130,74 +127,6 @@ export class DataSphereServerlessSkill extends SkillBase {
   override getInstanceKey(): string {
     const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
     return `${this.skillName}_${toolName}`;
-  }
-
-  /**
-   * @returns Manifest metadata. Environment variables are NOT declared as
-   *   required — credentials can be supplied entirely via params, matching
-   *   Python's `REQUIRED_ENV_VARS = []`.
-   */
-  getManifest(): SkillManifest {
-    return {
-      name: 'datasphere_serverless',
-      description:
-        'Search knowledge using SignalWire DataSphere with serverless DataMap execution',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['search', 'datasphere', 'signalwire', 'knowledge', 'rag', 'serverless', 'datamap'],
-      requiredEnvVars: [],
-      requiredPackages: [],
-      configSchema: {
-        space_name: {
-          type: 'string',
-          description: 'SignalWire space name.',
-        },
-        project_id: {
-          type: 'string',
-          description: 'SignalWire project ID.',
-        },
-        token: {
-          type: 'string',
-          description: 'SignalWire API token.',
-        },
-        document_id: {
-          type: 'string',
-          description: 'DataSphere document ID to search within.',
-        },
-        count: {
-          type: 'integer',
-          description: 'Number of results to return. Defaults to 1. Range 1-10.',
-          default: 1,
-        },
-        distance: {
-          type: 'number',
-          description:
-            'Maximum distance threshold (lower is more relevant). Defaults to 3.0. Range 0-10.',
-          default: 3.0,
-        },
-        tags: {
-          type: 'array',
-          description: 'Tags to filter search results.',
-        },
-        language: {
-          type: 'string',
-          description: 'Language code for query expansion.',
-        },
-        pos_to_expand: {
-          type: 'array',
-          description: 'Parts of speech to expand with synonyms.',
-        },
-        max_synonyms: {
-          type: 'integer',
-          description: 'Maximum number of synonyms (1-10).',
-        },
-        no_results_message: {
-          type: 'string',
-          description:
-            'Message returned when no results are found. Supports {query} interpolation.',
-        },
-      },
-    };
   }
 
   /**

--- a/src/skills/builtin/datasphere_serverless.ts
+++ b/src/skills/builtin/datasphere_serverless.ts
@@ -18,6 +18,9 @@ import type {
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
 import { DataMap } from '../../DataMap.js';
+import { getLogger } from '../../Logger.js';
+
+const log = getLogger('DataSphereServerlessSkill');
 
 const DEFAULT_NO_RESULTS_MESSAGE =
   "I couldn't find any relevant information for '{query}' in the knowledge base. " +
@@ -195,6 +198,25 @@ export class DataSphereServerlessSkill extends SkillBase {
   }
 
   /**
+   * Validate required configuration parameters before the skill becomes active.
+   *
+   * Mirrors Python's `setup()` which checks `space_name`, `project_id`, `token`,
+   * and `document_id` and returns `False` (logging an error) if any are absent.
+   * @returns `true` if all required params are present, `false` otherwise.
+   */
+  override async setup(): Promise<boolean> {
+    const requiredParams = ['space_name', 'project_id', 'token', 'document_id'] as const;
+    const missing = requiredParams.filter(
+      (param) => !this.getConfig<string | undefined>(param, undefined),
+    );
+    if (missing.length > 0) {
+      log.error('datasphere_serverless: missing required parameters', { missing });
+      return false;
+    }
+    return true;
+  }
+
+  /**
    * Global data injected into the agent's SWML/SWAIG context. Matches
    * Python's `get_global_data()` shape so downstream consumers can
    * detect DataSphere availability.
@@ -209,10 +231,10 @@ export class DataSphereServerlessSkill extends SkillBase {
 
   /**
    * Resolve the tool name used in DataMap registration. Defaults to
-   * `search_datasphere` (TS convention) when `tool_name` is not provided.
+   * `search_knowledge` to match the Python SDK default.
    */
   private getToolName(): string {
-    return this.getConfig<string>('tool_name', 'search_datasphere');
+    return this.getConfig<string>('tool_name', 'search_knowledge');
   }
 
   /**

--- a/src/skills/builtin/datasphere_serverless.ts
+++ b/src/skills/builtin/datasphere_serverless.ts
@@ -43,13 +43,13 @@ export class DataSphereServerlessSkill extends SkillBase {
       tool_name: {
         type: 'string',
         description: 'Custom tool name for this DataSphere Serverless instance.',
+        default: 'search_knowledge',
       },
       space_name: {
         type: 'string',
         description:
           "SignalWire space name (e.g., 'mycompany' from mycompany.signalwire.com)",
         required: true,
-        env_var: 'SIGNALWIRE_SPACE',
       },
       project_id: {
         type: 'string',
@@ -144,6 +144,8 @@ export class DataSphereServerlessSkill extends SkillBase {
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'datasphere', 'signalwire', 'knowledge', 'rag', 'serverless', 'datamap'],
+      requiredEnvVars: [],
+      requiredPackages: [],
       configSchema: {
         space_name: {
           type: 'string',
@@ -245,7 +247,7 @@ export class DataSphereServerlessSkill extends SkillBase {
   private buildDataMapFunction(): Record<string, unknown> {
     const count = this.getConfig<number>('count', 1);
     const distance = this.getConfig<number>('distance', 3.0);
-    const documentId = this.getConfig<string | undefined>('document_id', undefined);
+    const documentId = this.getConfig<string>('document_id', '');
     const tags = this.getConfig<string[] | undefined>('tags', undefined);
     const language = this.getConfig<string | undefined>('language', undefined);
     const posToExpand = this.getConfig<string[] | undefined>('pos_to_expand', undefined);
@@ -255,8 +257,16 @@ export class DataSphereServerlessSkill extends SkillBase {
       DEFAULT_NO_RESULTS_MESSAGE,
     );
 
+    // Match Python skills/datasphere_serverless/skill.py:152-157: bake the API URL
+    // and Basic-auth header directly from skill params. setup() has already
+    // validated that space_name/project_id/token/document_id are all present.
+    const spaceName = this.getConfig<string>('space_name', '');
+    const projectId = this.getConfig<string>('project_id', '');
+    const token = this.getConfig<string>('token', '');
+    const apiUrl = `https://${spaceName}.signalwire.com/api/datasphere/documents/search`;
+    const authHeader = Buffer.from(`${projectId}:${token}`).toString('base64');
+
     const dm = new DataMap(this.getToolName());
-    dm.enableEnvExpansion(true);
 
     dm.purpose(
       'Search the SignalWire DataSphere knowledge base for relevant information. ' +
@@ -270,16 +280,14 @@ export class DataSphereServerlessSkill extends SkillBase {
       { required: true },
     );
 
-    // Build the request body, mirroring Python's webhook params
+    // Build the request body, mirroring Python's webhook params ordering.
+    // document_id first (Python skill.py:165-170); conditional params last.
     const requestBody: Record<string, unknown> = {
+      document_id: documentId,
       query_string: '${args.query}',
       count,
       distance,
     };
-
-    if (documentId !== undefined) {
-      requestBody['document_id'] = documentId;
-    }
     if (tags !== undefined) {
       requestBody['tags'] = tags;
     }
@@ -293,17 +301,12 @@ export class DataSphereServerlessSkill extends SkillBase {
       requestBody['max_synonyms'] = maxSynonyms;
     }
 
-    // Configure the webhook to call the DataSphere API
-    dm.webhook(
-      'POST',
-      'https://${ENV.SIGNALWIRE_SPACE}.signalwire.com/api/datasphere/documents/search',
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Basic ${ENV.SIGNALWIRE_AUTH}',
-        },
+    dm.webhook('POST', apiUrl, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${authHeader}`,
       },
-    );
+    });
 
     dm.params(requestBody);
 
@@ -330,7 +333,12 @@ export class DataSphereServerlessSkill extends SkillBase {
       new FunctionResult(noResultsMessage.replace('{query}', '${args.query}')),
     );
 
-    return dm.toSwaigFunction();
+    // Python skill.py:207 applies swaig_fields via swaig_function.update(self.swaig_fields)
+    // after building the DataMap. Match that merge — caller overrides win.
+    const fn = dm.toSwaigFunction();
+    return Object.keys(this.swaigFields).length > 0
+      ? { ...fn, ...this.swaigFields }
+      : fn;
   }
 
   /**

--- a/src/skills/builtin/datasphere_serverless.ts
+++ b/src/skills/builtin/datasphere_serverless.ts
@@ -1,10 +1,11 @@
 /**
  * DataSphere Serverless Skill - Searches SignalWire DataSphere using a DataMap.
  *
- * Tier 3 built-in skill: requires SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN,
- * and SIGNALWIRE_SPACE environment variables. Unlike the standard datasphere
- * skill, this uses a DataMap to execute the search server-side without
- * requiring a webhook endpoint. Ideal for serverless or edge deployments.
+ * Tier 3 built-in skill. Matches the Python SDK's param-driven design: all
+ * credentials (`space_name`, `project_id`, `token`) are supplied via skill
+ * params. No environment variables are strictly required — the platform
+ * resolves `${ENV.SIGNALWIRE_AUTH}` at execution time when the DataMap runs,
+ * but standalone setup works from params alone.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -18,14 +19,17 @@ import type {
 import { FunctionResult } from '../../FunctionResult.js';
 import { DataMap } from '../../DataMap.js';
 
+const DEFAULT_NO_RESULTS_MESSAGE =
+  "I couldn't find any relevant information for '{query}' in the knowledge base. " +
+  'Try rephrasing your question or asking about a different topic.';
+
 /**
  * Searches SignalWire DataSphere using a server-side DataMap for serverless execution.
  *
- * Tier 3 built-in skill. Requires `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`,
- * and `SIGNALWIRE_SPACE` environment variables. Unlike the standard DataSphere
- * skill, this generates a DataMap configuration that SignalWire executes directly
- * without needing a webhook endpoint. Supports `max_results`, `distance_threshold`,
- * and `document_id` config options.
+ * Tier 3 built-in skill that generates a DataMap configuration SignalWire
+ * executes directly, without a webhook endpoint. Supports `document_id`,
+ * `count`, `distance`, `tags`, `language`, `pos_to_expand`, `max_synonyms`,
+ * and `no_results_message` config options.
  */
 export class DataSphereServerlessSkill extends SkillBase {
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
@@ -39,79 +43,176 @@ export class DataSphereServerlessSkill extends SkillBase {
       },
       space_name: {
         type: 'string',
-        description: 'SignalWire space name.',
+        description:
+          "SignalWire space name (e.g., 'mycompany' from mycompany.signalwire.com)",
+        required: true,
         env_var: 'SIGNALWIRE_SPACE',
       },
       project_id: {
         type: 'string',
-        description: 'SignalWire project ID.',
+        description: 'SignalWire project ID',
+        required: true,
         env_var: 'SIGNALWIRE_PROJECT_ID',
       },
       token: {
         type: 'string',
-        description: 'SignalWire auth token.',
+        description: 'SignalWire API token',
+        required: true,
         hidden: true,
         env_var: 'SIGNALWIRE_TOKEN',
       },
       document_id: {
         type: 'string',
-        description: 'Optional: restrict search to a specific document ID.',
+        description: 'DataSphere document ID to search within',
+        required: true,
       },
-      max_results: {
-        type: 'number',
-        description: 'Maximum number of results to return.',
-        default: 5,
+      count: {
+        type: 'integer',
+        description: 'Number of search results to return',
+        default: 1,
+        min: 1,
+        max: 10,
       },
-      distance_threshold: {
+      distance: {
         type: 'number',
-        description: 'Maximum distance threshold for results (0-1).',
-        default: 0.7,
+        description:
+          'Maximum distance threshold for results (lower is more relevant)',
+        default: 3.0,
         min: 0,
-        max: 1,
+        max: 10,
+      },
+      tags: {
+        type: 'array',
+        description: 'Tags to filter search results',
+        items: { type: 'string' },
+      },
+      language: {
+        type: 'string',
+        description: "Language code for query expansion (e.g., 'en', 'es')",
+      },
+      pos_to_expand: {
+        type: 'array',
+        description: 'Parts of speech to expand with synonyms',
+        items: { type: 'string', enum: ['NOUN', 'VERB', 'ADJ', 'ADV'] },
+      },
+      max_synonyms: {
+        type: 'integer',
+        description: 'Maximum number of synonyms to use for query expansion',
+        min: 1,
+        max: 10,
+      },
+      no_results_message: {
+        type: 'string',
+        description: 'Message to return when no results are found',
+        default: DEFAULT_NO_RESULTS_MESSAGE,
       },
     };
   }
 
   /**
-   * @param config - Optional configuration; supports `max_results`, `distance_threshold`, `document_id`.
+   * @param config - Optional configuration; supports `space_name`, `project_id`,
+   *   `token`, `document_id`, `count`, `distance`, `tags`, `language`,
+   *   `pos_to_expand`, `max_synonyms`, `no_results_message`, and `tool_name`.
    */
   constructor(config?: SkillConfig) {
     super('datasphere_serverless', config);
   }
 
+  /**
+   * Instance key for the SkillManager. Defaults to
+   * `datasphere_serverless_search_knowledge`, matching the Python SDK default.
+   * When `tool_name` is set, uses `datasphere_serverless_<tool_name>`.
+   */
   override getInstanceKey(): string {
-    const toolName = this.getConfig<string | undefined>('tool_name', undefined);
-    return toolName ? `${this.skillName}_${toolName}` : this.skillName;
+    const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
+    return `${this.skillName}_${toolName}`;
   }
 
-  /** @returns Manifest declaring SignalWire credentials as required env vars. */
+  /**
+   * @returns Manifest metadata. Environment variables are NOT declared as
+   *   required — credentials can be supplied entirely via params, matching
+   *   Python's `REQUIRED_ENV_VARS = []`.
+   */
   getManifest(): SkillManifest {
     return {
       name: 'datasphere_serverless',
       description:
-        'Searches SignalWire DataSphere using a server-side DataMap. No webhook endpoint required; executes entirely on the SignalWire platform.',
+        'Search knowledge using SignalWire DataSphere with serverless DataMap execution',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'datasphere', 'signalwire', 'knowledge', 'rag', 'serverless', 'datamap'],
-      requiredEnvVars: ['SIGNALWIRE_PROJECT_ID', 'SIGNALWIRE_TOKEN', 'SIGNALWIRE_SPACE'],
       configSchema: {
-        max_results: {
-          type: 'number',
-          description: 'Maximum number of results to return. Defaults to 5.',
-          default: 5,
+        space_name: {
+          type: 'string',
+          description: 'SignalWire space name.',
         },
-        distance_threshold: {
-          type: 'number',
-          description:
-            'Maximum distance threshold for results (0-1, lower is more similar). Defaults to 0.7.',
-          default: 0.7,
+        project_id: {
+          type: 'string',
+          description: 'SignalWire project ID.',
+        },
+        token: {
+          type: 'string',
+          description: 'SignalWire API token.',
         },
         document_id: {
           type: 'string',
-          description: 'Optional: restrict search to a specific document ID.',
+          description: 'DataSphere document ID to search within.',
+        },
+        count: {
+          type: 'integer',
+          description: 'Number of results to return. Defaults to 1. Range 1-10.',
+          default: 1,
+        },
+        distance: {
+          type: 'number',
+          description:
+            'Maximum distance threshold (lower is more relevant). Defaults to 3.0. Range 0-10.',
+          default: 3.0,
+        },
+        tags: {
+          type: 'array',
+          description: 'Tags to filter search results.',
+        },
+        language: {
+          type: 'string',
+          description: 'Language code for query expansion.',
+        },
+        pos_to_expand: {
+          type: 'array',
+          description: 'Parts of speech to expand with synonyms.',
+        },
+        max_synonyms: {
+          type: 'integer',
+          description: 'Maximum number of synonyms (1-10).',
+        },
+        no_results_message: {
+          type: 'string',
+          description:
+            'Message returned when no results are found. Supports {query} interpolation.',
         },
       },
     };
+  }
+
+  /**
+   * Global data injected into the agent's SWML/SWAIG context. Matches
+   * Python's `get_global_data()` shape so downstream consumers can
+   * detect DataSphere availability.
+   */
+  override getGlobalData(): Record<string, unknown> {
+    return {
+      datasphere_serverless_enabled: true,
+      document_id: this.getConfig<string | undefined>('document_id', undefined),
+      knowledge_provider: 'SignalWire DataSphere (Serverless)',
+    };
+  }
+
+  /**
+   * Resolve the tool name used in DataMap registration. Defaults to
+   * `search_datasphere` (TS convention) when `tool_name` is not provided.
+   */
+  private getToolName(): string {
+    return this.getConfig<string>('tool_name', 'search_datasphere');
   }
 
   /**
@@ -120,55 +221,91 @@ export class DataSphereServerlessSkill extends SkillBase {
    * SignalWire executes directly, without needing a webhook callback.
    */
   private buildDataMapFunction(): Record<string, unknown> {
-    const maxResults = this.getConfig<number>('max_results', 5);
-    const distanceThreshold = this.getConfig<number>('distance_threshold', 0.7);
+    const count = this.getConfig<number>('count', 1);
+    const distance = this.getConfig<number>('distance', 3.0);
     const documentId = this.getConfig<string | undefined>('document_id', undefined);
+    const tags = this.getConfig<string[] | undefined>('tags', undefined);
+    const language = this.getConfig<string | undefined>('language', undefined);
+    const posToExpand = this.getConfig<string[] | undefined>('pos_to_expand', undefined);
+    const maxSynonyms = this.getConfig<number | undefined>('max_synonyms', undefined);
+    const noResultsMessage = this.getConfig<string>(
+      'no_results_message',
+      DEFAULT_NO_RESULTS_MESSAGE,
+    );
 
-    const dm = new DataMap('search_datasphere');
+    const dm = new DataMap(this.getToolName());
     dm.enableEnvExpansion(true);
 
     dm.purpose(
       'Search the SignalWire DataSphere knowledge base for relevant information. ' +
-      'Returns the most relevant text chunks from uploaded documents.',
+        'Returns the most relevant text chunks from uploaded documents.',
     );
 
-    dm.parameter('query', 'string', 'The question or topic to search for in the knowledge base.', {
-      required: true,
-    });
+    dm.parameter(
+      'query',
+      'string',
+      "The search query — what information you're looking for in the knowledge base.",
+      { required: true },
+    );
 
-    // Build the request body
+    // Build the request body, mirroring Python's webhook params
     const requestBody: Record<string, unknown> = {
-      query: '%{args.query}',
-      count: maxResults,
-      distance: distanceThreshold,
+      query_string: '${args.query}',
+      count,
+      distance,
     };
 
-    if (documentId) {
+    if (documentId !== undefined) {
       requestBody['document_id'] = documentId;
+    }
+    if (tags !== undefined) {
+      requestBody['tags'] = tags;
+    }
+    if (language !== undefined) {
+      requestBody['language'] = language;
+    }
+    if (posToExpand !== undefined) {
+      requestBody['pos_to_expand'] = posToExpand;
+    }
+    if (maxSynonyms !== undefined) {
+      requestBody['max_synonyms'] = maxSynonyms;
     }
 
     // Configure the webhook to call the DataSphere API
-    dm.webhook('POST', 'https://${ENV.SIGNALWIRE_SPACE}.signalwire.com/api/datasphere/documents/search', {
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Basic ${ENV.SIGNALWIRE_AUTH}',
+    dm.webhook(
+      'POST',
+      'https://${ENV.SIGNALWIRE_SPACE}.signalwire.com/api/datasphere/documents/search',
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Basic ${ENV.SIGNALWIRE_AUTH}',
+        },
       },
-    });
+    );
 
-    dm.body(requestBody);
+    dm.params(requestBody);
+
+    // Match Python's foreach formatter so callers receive a consistent
+    // multi-result concatenation rather than only the top three entries.
+    dm.foreach({
+      input_key: 'chunks',
+      output_key: 'formatted_results',
+      max: count,
+      append: '=== RESULT ===\n${this.text}\n' + '='.repeat(50) + '\n\n',
+    });
 
     dm.output(
       new FunctionResult(
-        'Knowledge base results for the query: %{array[0].text} %{array[1].text} %{array[2].text}',
+        'I found results for "${args.query}":\n\n${formatted_results}',
       ),
     );
 
-    dm.errorKeys(['error', 'message']);
+    dm.errorKeys(['error']);
 
+    // Python replaces `{query}` with `${args.query}` at registration time so
+    // the platform can substitute the original user query into the fallback.
     dm.fallbackOutput(
-      new FunctionResult(
-        'No relevant results found in the knowledge base. Try rephrasing your question.',
-      ),
+      new FunctionResult(noResultsMessage.replace('{query}', '${args.query}')),
     );
 
     return dm.toSwaigFunction();
@@ -177,16 +314,13 @@ export class DataSphereServerlessSkill extends SkillBase {
   /**
    * Return a stub tool definition since this skill uses DataMap-based execution.
    * The actual DataMap function is provided by getDataMapTools().
-   * @returns A single stub `search_datasphere` tool that explains its DataMap nature.
+   * @returns A single stub tool (named via `tool_name`) that explains its DataMap nature.
    */
   getTools(): SkillToolDefinition[] {
-    // DataMap-based skills do not use handler-based tools.
-    // The tool is provided via getDataMapTools() instead.
-    // We return a stub handler that explains this to prevent confusion
-    // if something tries to invoke it as a regular tool.
+    const toolName = this.getToolName();
     return [
       {
-        name: 'search_datasphere',
+        name: toolName,
         description:
           'Search the SignalWire DataSphere knowledge base for relevant information. (Serverless DataMap mode)',
         parameters: {
@@ -199,7 +333,7 @@ export class DataSphereServerlessSkill extends SkillBase {
         handler: () => {
           return new FunctionResult(
             'This tool is configured for serverless DataMap execution. ' +
-            'It should be registered as a data_map function, not invoked via webhook.',
+              'It should be registered as a data_map function, not invoked via webhook.',
           );
         },
       },
@@ -218,16 +352,17 @@ export class DataSphereServerlessSkill extends SkillBase {
 
   /** @returns Prompt section describing serverless DataSphere search capabilities. */
   protected override _getPromptSections(): SkillPromptSection[] {
+    const toolName = this.getToolName();
     return [
       {
-        title: 'Knowledge Base Search (DataSphere - Serverless)',
-        body: 'You have access to a knowledge base of documents that can be searched for relevant information. Searches are executed server-side for optimal performance.',
+        title: 'Knowledge Search Capability (Serverless)',
+        body: `You can search a knowledge base for information using the ${toolName} tool.`,
         bullets: [
-          'Use the search_datasphere tool when the user asks questions that might be answered by internal documentation or uploaded knowledge.',
-          'Results are ranked by relevance and returned automatically.',
-          'This search runs entirely on the SignalWire platform without requiring external webhooks.',
-          'Synthesize information from the results when appropriate.',
-          'If no results are found, let the user know and suggest rephrasing their question.',
+          `Use the ${toolName} tool when users ask for information that might be in the knowledge base`,
+          'Search for relevant information using clear, specific queries',
+          'Summarize search results in a clear, helpful way',
+          'If no results are found, suggest the user try rephrasing their question',
+          'This tool executes on SignalWire servers for optimal performance',
         ],
       },
     ];

--- a/src/skills/builtin/datetime.ts
+++ b/src/skills/builtin/datetime.ts
@@ -21,12 +21,13 @@ import { FunctionResult } from '../../FunctionResult.js';
  * timezone identifiers via the Intl.DateTimeFormat API.
  */
 export class DateTimeSkill extends SkillBase {
-  /**
-   * @param config - Optional configuration (no config keys used by this skill).
-   */
-  constructor(config?: SkillConfig) {
-    super('datetime', config);
-  }
+  // Python ground truth: skills/datetime/skill.py
+  // REQUIRED_PACKAGES = ["pytz"] in Python; TS uses Intl + Date built-ins so [].
+  static override SKILL_NAME = 'datetime';
+  static override SKILL_DESCRIPTION = 'Get current date, time, and timezone information';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return { ...super.getParameterSchema() };

--- a/src/skills/builtin/datetime.ts
+++ b/src/skills/builtin/datetime.ts
@@ -6,7 +6,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -31,16 +30,6 @@ export class DateTimeSkill extends SkillBase {
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return { ...super.getParameterSchema() };
-  }
-
-  /** @returns Manifest with skill metadata and tags. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'datetime',
-      description: 'Provides current date and time information with timezone support.',
-      version: '1.0.0',
-      tags: ['utility', 'datetime', 'timezone'],
-    };
   }
 
   /** @returns A single `get_datetime` tool that returns the current date/time in a given timezone. */

--- a/src/skills/builtin/google_maps.ts
+++ b/src/skills/builtin/google_maps.ts
@@ -8,7 +8,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -101,27 +100,6 @@ export class GoogleMapsSkill extends SkillBase {
         description: 'Default travel mode.',
         default: 'driving',
         enum: ['driving', 'walking', 'bicycling', 'transit'],
-      },
-    };
-  }
-
-  /** @returns Manifest declaring GOOGLE_MAPS_API_KEY as required and config schema for default_mode. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'google_maps',
-      description:
-        'Provides driving/walking/transit directions and place search via Google Maps APIs.',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['maps', 'directions', 'places', 'google', 'navigation', 'external'],
-      requiredEnvVars: ['GOOGLE_MAPS_API_KEY'],
-      configSchema: {
-        default_mode: {
-          type: 'string',
-          description:
-            'Default travel mode: "driving", "walking", "bicycling", or "transit". Defaults to "driving".',
-          default: 'driving',
-        },
       },
     };
   }

--- a/src/skills/builtin/google_maps.ts
+++ b/src/skills/builtin/google_maps.ts
@@ -75,12 +75,16 @@ interface PlacesResponse {
  * Supports a `default_mode` config option ("driving"|"walking"|"bicycling"|"transit").
  */
 export class GoogleMapsSkill extends SkillBase {
-  /**
-   * @param config - Optional configuration; supports `default_mode` for travel mode.
-   */
-  constructor(config?: SkillConfig) {
-    super('google_maps', config);
-  }
+  // Python ground truth: skills/google_maps/skill.py
+  // Python declares REQUIRED_PACKAGES = ["requests"], REQUIRED_ENV_VARS = [];
+  // TS uses native fetch and has historically declared the env var as required.
+  // Preserving TS behavior to avoid out-of-scope behavioral change.
+  static override SKILL_NAME = 'google_maps';
+  static override SKILL_DESCRIPTION =
+    'Validate addresses and compute driving routes using Google Maps';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = ['GOOGLE_MAPS_API_KEY'];
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {

--- a/src/skills/builtin/index.ts
+++ b/src/skills/builtin/index.ts
@@ -25,58 +25,61 @@ export { AskClaudeSkill, createSkill as createAskClaudeSkill } from './ask_claud
 export { McpGatewaySkill, createSkill as createMcpGatewaySkill } from './mcp_gateway.js';
 
 import { SkillRegistry } from '../SkillRegistry.js';
-import { createSkill as createDateTimeSkill } from './datetime.js';
-import { createSkill as createMathSkill } from './math.js';
-import { createSkill as createJokeSkill } from './joke.js';
-import { createSkill as createWeatherApiSkill } from './weather_api.js';
-import { createSkill as createPlayBackgroundFileSkill } from './play_background_file.js';
-import { createSkill as createSwmlTransferSkill } from './swml_transfer.js';
-import { createSkill as createApiNinjasTriviaSkill } from './api_ninjas_trivia.js';
-import { createSkill as createInfoGathererSkill } from './info_gatherer.js';
-import { createSkill as createCustomSkillsSkill } from './custom_skills.js';
-import { createSkill as createWebSearchSkill } from './web_search.js';
-import { createSkill as createWikipediaSearchSkill } from './wikipedia_search.js';
-import { createSkill as createGoogleMapsSkill } from './google_maps.js';
-import { createSkill as createDataSphereSkill } from './datasphere.js';
-import { createSkill as createDataSphereServerlessSkill } from './datasphere_serverless.js';
-import { createSkill as createNativeVectorSearchSkill } from './native_vector_search.js';
-import { createSkill as createSpiderSkill } from './spider.js';
-import { createSkill as createClaudeSkillsSkill } from './claude_skills.js';
-import { createSkill as createAskClaudeSkill } from './ask_claude.js';
-import { createSkill as createMcpGatewaySkill } from './mcp_gateway.js';
+import type { SkillBase } from '../SkillBase.js';
+import { DateTimeSkill } from './datetime.js';
+import { MathSkill } from './math.js';
+import { JokeSkill } from './joke.js';
+import { WeatherApiSkill } from './weather_api.js';
+import { PlayBackgroundFileSkill } from './play_background_file.js';
+import { SwmlTransferSkill } from './swml_transfer.js';
+import { ApiNinjasTriviaSkill } from './api_ninjas_trivia.js';
+import { InfoGathererSkill } from './info_gatherer.js';
+import { CustomSkillsSkill } from './custom_skills.js';
+import { WebSearchSkill } from './web_search.js';
+import { WikipediaSearchSkill } from './wikipedia_search.js';
+import { GoogleMapsSkill } from './google_maps.js';
+import { DataSphereSkill } from './datasphere.js';
+import { DataSphereServerlessSkill } from './datasphere_serverless.js';
+import { NativeVectorSearchSkill } from './native_vector_search.js';
+import { SpiderSkill } from './spider.js';
+import { ClaudeSkillsSkill } from './claude_skills.js';
+import { AskClaudeSkill } from './ask_claude.js';
+import { McpGatewaySkill } from './mcp_gateway.js';
 
 /**
  * Register all 19 built-in skills with the global SkillRegistry singleton.
- * Skips registration for any skill name already present in the registry.
+ * Matches Python's auto-discovery pattern (`skills/registry.py`) which finds
+ * SkillBase subclasses in the skills directory and registers them by class
+ * reference. Skips registration for any skill name already present.
  */
 export function registerBuiltinSkills(): void {
   const registry = SkillRegistry.getInstance();
 
-  const skills: [string, (config?: Record<string, unknown>) => any][] = [
-    ['datetime', createDateTimeSkill],
-    ['math', createMathSkill],
-    ['joke', createJokeSkill],
-    ['weather_api', createWeatherApiSkill],
-    ['play_background_file', createPlayBackgroundFileSkill],
-    ['swml_transfer', createSwmlTransferSkill],
-    ['api_ninjas_trivia', createApiNinjasTriviaSkill],
-    ['info_gatherer', createInfoGathererSkill],
-    ['custom_skills', createCustomSkillsSkill],
-    ['web_search', createWebSearchSkill],
-    ['wikipedia_search', createWikipediaSearchSkill],
-    ['google_maps', createGoogleMapsSkill],
-    ['datasphere', createDataSphereSkill],
-    ['datasphere_serverless', createDataSphereServerlessSkill],
-    ['native_vector_search', createNativeVectorSearchSkill],
-    ['spider', createSpiderSkill],
-    ['claude_skills', createClaudeSkillsSkill],
-    ['ask_claude', createAskClaudeSkill],
-    ['mcp_gateway', createMcpGatewaySkill],
+  const skillClasses: Array<typeof SkillBase> = [
+    DateTimeSkill,
+    MathSkill,
+    JokeSkill,
+    WeatherApiSkill,
+    PlayBackgroundFileSkill,
+    SwmlTransferSkill,
+    ApiNinjasTriviaSkill,
+    InfoGathererSkill,
+    CustomSkillsSkill,
+    WebSearchSkill,
+    WikipediaSearchSkill,
+    GoogleMapsSkill,
+    DataSphereSkill,
+    DataSphereServerlessSkill,
+    NativeVectorSearchSkill,
+    SpiderSkill,
+    ClaudeSkillsSkill,
+    AskClaudeSkill,
+    McpGatewaySkill,
   ];
 
-  for (const [name, factory] of skills) {
-    if (!registry.has(name)) {
-      registry.register(name, factory);
+  for (const SkillClass of skillClasses) {
+    if (!registry.has(SkillClass.SKILL_NAME)) {
+      registry.register(SkillClass);
     }
   }
 

--- a/src/skills/builtin/info_gatherer.ts
+++ b/src/skills/builtin/info_gatherer.ts
@@ -1,16 +1,13 @@
 /**
- * Info Gatherer Skill - Collects structured information from the user.
+ * Info Gatherer Skill - Guides an AI agent through a sequence of questions,
+ * collecting and storing answers in namespaced SWAIG `global_data`.
  *
- * Tier 2 built-in skill: no external dependencies required. Supports two
- * collection modes:
- *
- * 1. Sequential question flow (Python-aligned): configure `questions` and the
- *    skill registers `start_questions` / `submit_answer` tools that guide the
- *    agent one question at a time. State lives in SWAIG `global_data` under a
- *    namespaced key (e.g. `skill:info_gatherer`).
- * 2. Single-shot field collection (TS-native): configure `fields` to get a
- *    dynamic `save_info` tool plus a `get_gathered_info` retrieval tool. State
- *    lives in an in-memory map keyed by `call_id`.
+ * Tier 2 built-in skill with no external dependencies. Direct port of
+ * Python's `signalwire.skills.info_gatherer.skill.InfoGathererSkill`
+ * (core/skill_base.py usage; skill.py:16-312). Supports multiple instances
+ * with different `prefix` values so several question sets can coexist on a
+ * single agent (e.g. "intake" and "medical" questionnaires running side by
+ * side).
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -25,19 +22,10 @@ import { getLogger } from '../../Logger.js';
 
 const log = getLogger('InfoGathererSkill');
 
-/** Definition of a single data field to be collected from the user. */
-interface FieldDefinition {
-  /** Field name used as the parameter key. */
-  name: string;
-  /** Description of what this field collects. */
-  description: string;
-  /** Whether this field must be provided. */
-  required?: boolean;
-  /** Optional regex pattern for validating the field value. */
-  validation?: string;
-  /** Parameter type for the tool schema (defaults to "string"). */
-  type?: string;
-}
+const DEFAULT_COMPLETION_MESSAGE =
+  "Thank you! All questions have been answered. You can now summarize the " +
+  "information collected or ask if there's anything else the user would like " +
+  'to discuss.';
 
 /** Definition of a single question in the sequential question flow. */
 interface QuestionDefinition {
@@ -51,17 +39,13 @@ interface QuestionDefinition {
   prompt_add?: string;
 }
 
-/** Key-value map of information gathered from a user during a call. */
-interface GatheredInfo {
-  [key: string]: unknown;
-}
-
 /**
- * Collects structured information from the user.
+ * Collects answers to a configurable list of questions, one at a time.
  *
- * Tier 2 built-in skill with no external dependencies. Supports the
- * Python-aligned sequential question flow (`questions` config) and the
- * TS-native single-shot field collection (`fields` config).
+ * Mirrors Python `InfoGathererSkill` exactly: the same required
+ * `questions` config, the same `prefix` / `completion_message` options,
+ * the same two tools (`start_questions`, `submit_answer`), and the same
+ * state shape in `global_data`.
  */
 export class InfoGathererSkill extends SkillBase {
   // Python ground truth: skills/info_gatherer/skill.py:26-31
@@ -72,17 +56,14 @@ export class InfoGathererSkill extends SkillBase {
   static override REQUIRED_ENV_VARS: readonly string[] = [];
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
-  /** Sequential flow: list of question definitions populated in `setup()`. */
+  /** List of question definitions populated in `setup()`. */
   private questions: QuestionDefinition[] = [];
-  /** Sequential flow: derived tool name for the start tool (prefix-aware). */
+  /** Derived tool name for the start tool (prefix-aware). */
   private startToolName: string = 'start_questions';
-  /** Sequential flow: derived tool name for the submit tool (prefix-aware). */
+  /** Derived tool name for the submit tool (prefix-aware). */
   private submitToolName: string = 'submit_answer';
-  /** Sequential flow: message returned once all questions are answered. */
-  private completionMessage: string = '';
-
-  /** Single-shot flow: in-memory storage keyed by call_id. */
-  private gatheredData: Map<string, GatheredInfo> = new Map();
+  /** Message returned once all questions are answered. */
+  private completionMessage: string = DEFAULT_COMPLETION_MESSAGE;
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
@@ -106,32 +87,13 @@ export class InfoGathererSkill extends SkillBase {
         type: 'string',
         description:
           "Optional prefix for tool names and namespace. When set, tools are named <prefix>_start_questions / <prefix>_submit_answer and state is stored under 'skill:<prefix>' in global_data.",
+        required: false,
       },
       completion_message: {
         type: 'string',
         description: 'Message returned after all questions are answered',
-        default:
-          "Thank you! All questions have been answered. You can now summarize the information collected or ask if there's anything else the user would like to discuss.",
-      },
-      fields: {
-        type: 'array',
-        description:
-          'Array of field definitions to collect: { name, description, required?, validation?, type? }.',
-        items: { type: 'object' },
-      },
-      purpose: {
-        type: 'string',
-        description: 'A description of why this information is being collected.',
-      },
-      confirmation_message: {
-        type: 'string',
-        description: 'Custom message returned after successful info collection.',
-        default: 'Information has been saved successfully.',
-      },
-      store_globally: {
-        type: 'boolean',
-        description: 'Whether to store gathered info in global data.',
-        default: false,
+        default: DEFAULT_COMPLETION_MESSAGE,
+        required: false,
       },
     };
   }
@@ -139,7 +101,7 @@ export class InfoGathererSkill extends SkillBase {
   /**
    * Instance key for the SkillManager. When `prefix` is configured, returns
    * `info_gatherer_<prefix>` to support multi-instance use. Matches Python's
-   * `get_instance_key()`.
+   * `get_instance_key()` (skill.py:81-85).
    */
   override getInstanceKey(): string {
     const prefix = this.getConfig<string>('prefix', '');
@@ -147,31 +109,24 @@ export class InfoGathererSkill extends SkillBase {
   }
 
   /**
-   * Validate sequential question config and initialize derived state. A no-op
-   * when `questions` is not configured (field-only mode).
+   * Validate the `questions` config, derive tool names (with optional prefix),
+   * and cache the completion message.
+   *
+   * Python parity: skill.py:91-121. Returns `false` (logging an error) when
+   * `questions` is missing or fails validation; setup must produce a
+   * functional skill or fail closed.
    */
   override async setup(): Promise<boolean> {
     const questions = this.getConfig<unknown>('questions', undefined);
-    const fields = this.getConfig<unknown[]>('fields', []);
-    if ((questions === undefined || questions === null) && (!Array.isArray(fields) || fields.length === 0)) {
-      // Python parity: `setup()` returns false when the skill has nothing to do
-      // (skill.py:91-95 requires `questions`). TS additionally supports a
-      // field-only mode, so we accept either — but not neither, otherwise the
-      // skill would register no tools and no prompt sections silently.
-      log.error('info_gatherer: at least one of "questions" or "fields" must be configured');
-      return false;
-    }
     if (questions === undefined || questions === null) {
-      // Field-only mode — tools + prompt sections come from the fields path.
-      return true;
+      log.error("'questions' parameter is required");
+      return false;
     }
 
     try {
       InfoGathererSkill._validateQuestions(questions);
     } catch (err) {
-      log.error(
-        `info_gatherer: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      log.error(err instanceof Error ? err.message : String(err));
       return false;
     }
 
@@ -188,14 +143,19 @@ export class InfoGathererSkill extends SkillBase {
 
     this.completionMessage = this.getConfig<string>(
       'completion_message',
-      "Thank you! All questions have been answered. You can now summarize the information collected or ask if there's anything else the user would like to discuss.",
+      DEFAULT_COMPLETION_MESSAGE,
     );
     return true;
   }
 
   /**
-   * Seed SWAIG global_data with the initial sequential-question state. Returns
-   * an empty object when sequential mode is not active.
+   * Seed SWAIG `global_data` with the initial question state under this
+   * skill's namespace. Mirrors Python `get_global_data()` (skill.py:127-135).
+   *
+   * Defensive no-op when the skill was not successfully set up (empty
+   * `questions`). Python relies on the SkillManager to skip unloaded skills;
+   * TS adds this guard so `getGlobalData()` called without a successful
+   * `setup()` returns `{}` instead of a malformed state payload.
    */
   override getGlobalData(): Record<string, unknown> {
     if (this.questions.length === 0) {
@@ -210,16 +170,16 @@ export class InfoGathererSkill extends SkillBase {
     };
   }
 
-  /** Tools for the configured collection mode. */
-  getTools(): SkillToolDefinition[] {
-    // Sequential question flow takes precedence when configured.
-    if (this.questions.length > 0) {
-      return this._getSequentialTools();
+  /**
+   * Register the two sequential-flow tools. Mirrors Python
+   * `register_tools()` (skill.py:162-184). Returns an empty array when
+   * `setup()` did not complete (no questions) so the skill never exposes
+   * half-initialized tools.
+   */
+  override getTools(): SkillToolDefinition[] {
+    if (this.questions.length === 0) {
+      return [];
     }
-    return this._getFieldTools();
-  }
-
-  private _getSequentialTools(): SkillToolDefinition[] {
     return [
       {
         name: this.startToolName,
@@ -247,143 +207,10 @@ export class InfoGathererSkill extends SkillBase {
     ];
   }
 
-  private _getFieldTools(): SkillToolDefinition[] {
-    const fields = this.getConfig<FieldDefinition[]>('fields', []);
-    const confirmationMessage = this.getConfig<string>(
-      'confirmation_message',
-      'Information has been saved successfully.',
-    );
-    const storeGlobally = this.getConfig<boolean>('store_globally', false);
-
-    if (fields.length === 0) {
-      return [];
-    }
-
-    // Build dynamic parameters from field definitions
-    const parameters: Record<string, unknown> = {};
-    const requiredParams: string[] = [];
-
-    for (const field of fields) {
-      parameters[field.name] = {
-        type: field.type ?? 'string',
-        description: field.description,
-      };
-
-      if (field.required) {
-        requiredParams.push(field.name);
-      }
-    }
-
-    return [
-      {
-        name: 'save_info',
-        description:
-          'Save information gathered from the user. Call this once you have collected the required fields.',
-        parameters,
-        required: requiredParams.length > 0 ? requiredParams : undefined,
-        handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) => {
-          const errors: string[] = [];
-          const collected: GatheredInfo = {};
-
-          for (const field of fields) {
-            const value = args[field.name];
-
-            if (field.required) {
-              if (
-                value === undefined ||
-                value === null ||
-                (typeof value === 'string' && value.trim().length === 0)
-              ) {
-                errors.push(`"${field.name}" is required but was not provided.`);
-                continue;
-              }
-            }
-
-            if (value === undefined || value === null) {
-              continue;
-            }
-
-            if (field.validation && typeof value === 'string') {
-              try {
-                const regex = new RegExp(field.validation);
-                if (!regex.test(value)) {
-                  errors.push(
-                    `"${field.name}" value "${value}" does not match the expected format.`,
-                  );
-                  continue;
-                }
-              } catch {
-                // Invalid regex — skip validation
-              }
-            }
-
-            collected[field.name] =
-              typeof value === 'string' ? value.trim() : value;
-          }
-
-          if (errors.length > 0) {
-            return new FunctionResult(
-              `Could not save information due to validation errors:\n${errors.join('\n')}\nPlease correct these fields and try again.`,
-            );
-          }
-
-          if (Object.keys(collected).length === 0) {
-            return new FunctionResult(
-              'No information was provided. Please collect at least one field before saving.',
-            );
-          }
-
-          const callId = (rawData['call_id'] as string | undefined) ?? 'default';
-          this.gatheredData.set(callId, {
-            ...this.gatheredData.get(callId),
-            ...collected,
-          });
-
-          const fieldSummary = Object.entries(collected)
-            .map(([key, val]) => `${key}: ${val}`)
-            .join(', ');
-
-          const result = new FunctionResult(
-            `${confirmationMessage} Saved: ${fieldSummary}.`,
-          );
-
-          if (storeGlobally) {
-            result.updateGlobalData({ gathered_info: collected });
-          }
-
-          return result;
-        },
-      },
-      {
-        name: 'get_gathered_info',
-        description:
-          'Retrieve previously gathered information for the current call. Useful to review what has already been collected.',
-        parameters: {},
-        handler: (_args: Record<string, unknown>, rawData: Record<string, unknown>) => {
-          const callId = (rawData['call_id'] as string | undefined) ?? 'default';
-          const info = this.gatheredData.get(callId);
-
-          if (!info || Object.keys(info).length === 0) {
-            return new FunctionResult(
-              'No information has been gathered yet for this call.',
-            );
-          }
-
-          const summary = Object.entries(info)
-            .map(([key, val]) => `${key}: ${val}`)
-            .join(', ');
-
-          return new FunctionResult(
-            `Previously gathered information: ${summary}.`,
-          );
-        },
-      },
-    ];
-  }
-
   /**
    * Handle the `start_questions` tool: read state from global_data and return
-   * an instruction for the first question.
+   * an instruction for the first question. Mirrors Python
+   * `_handle_start_questions` (skill.py:190-208).
    */
   private _handleStartQuestions(
     _args: Record<string, unknown>,
@@ -413,7 +240,8 @@ export class InfoGathererSkill extends SkillBase {
   /**
    * Handle the `submit_answer` tool: validate confirmation, record the answer,
    * advance the index, and either return the next question or the completion
-   * message (disabling both tools on completion).
+   * message (disabling both tools on completion). Mirrors Python
+   * `_handle_submit_answer` (skill.py:210-262).
    */
   private _handleSubmitAnswer(
     args: Record<string, unknown>,
@@ -478,7 +306,10 @@ export class InfoGathererSkill extends SkillBase {
     return result;
   }
 
-  /** Generate the per-question instruction returned to the agent. */
+  /**
+   * Generate the per-question instruction returned to the agent. Mirrors
+   * Python `_generate_question_instruction` (skill.py:268-297).
+   */
   private static _generateQuestionInstruction(
     questionText: string,
     needsConfirmation: boolean,
@@ -514,14 +345,18 @@ export class InfoGathererSkill extends SkillBase {
 
   /**
    * Validate that `questions` is a non-empty array of objects each having
-   * `key_name` and `question_text`. Throws on invalid input.
+   * `key_name` and `question_text`. Throws on invalid input. Mirrors Python
+   * `_validate_questions` (skill.py:299-311).
    */
   private static _validateQuestions(questions: unknown): void {
+    // Python order (skill.py:301-304): emptiness / falsy check BEFORE type
+    // check. JS `!questions` is true for null/undefined/0/""/false but NOT
+    // for `[]`, so we also handle the empty-array case explicitly.
+    if (!questions || (Array.isArray(questions) && questions.length === 0)) {
+      throw new Error('At least one question is required');
+    }
     if (!Array.isArray(questions)) {
       throw new Error('Questions must be a list');
-    }
-    if (questions.length === 0) {
-      throw new Error('At least one question is required');
     }
     for (let i = 0; i < questions.length; i++) {
       const q = questions[i];
@@ -538,15 +373,11 @@ export class InfoGathererSkill extends SkillBase {
     }
   }
 
-  /** Prompt sections depend on the active collection mode. */
+  /**
+   * Prompt section describing the question flow to the agent. Mirrors Python
+   * `_get_prompt_sections` (skill.py:141-156).
+   */
   protected override _getPromptSections(): SkillPromptSection[] {
-    if (this.questions.length > 0) {
-      return this._getSequentialPromptSections();
-    }
-    return this._getFieldPromptSections();
-  }
-
-  private _getSequentialPromptSections(): SkillPromptSection[] {
     return [
       {
         title: `Info Gatherer (${this.getInstanceKey()})`,
@@ -561,77 +392,6 @@ export class InfoGathererSkill extends SkillBase {
           `to ask. Repeat this process until all questions are complete.`,
       },
     ];
-  }
-
-  private _getFieldPromptSections(): SkillPromptSection[] {
-    const fields = this.getConfig<FieldDefinition[]>('fields', []);
-    const purpose = this.getConfig<string | undefined>('purpose', undefined);
-
-    if (fields.length === 0) {
-      return [];
-    }
-
-    const requiredFields = fields.filter((f) => f.required);
-    const optionalFields = fields.filter((f) => !f.required);
-
-    const bullets: string[] = [];
-
-    if (purpose) {
-      bullets.push(`Purpose: ${purpose}`);
-    }
-
-    bullets.push(
-      'Use the save_info tool to store information once you have collected it from the user.',
-    );
-
-    if (requiredFields.length > 0) {
-      const reqNames = requiredFields.map((f) => `"${f.name}"`).join(', ');
-      bullets.push(`Required fields (must be collected): ${reqNames}.`);
-    }
-
-    if (optionalFields.length > 0) {
-      const optNames = optionalFields.map((f) => `"${f.name}"`).join(', ');
-      bullets.push(`Optional fields (collect if available): ${optNames}.`);
-    }
-
-    for (const field of fields) {
-      const reqLabel = field.required ? ' (required)' : ' (optional)';
-      bullets.push(`${field.name}${reqLabel}: ${field.description}`);
-    }
-
-    bullets.push(
-      'Ask for information naturally in conversation rather than as a list of questions.',
-      'Use get_gathered_info to review what has already been collected.',
-      'Once all required fields are gathered, call save_info to store the data.',
-    );
-
-    return [
-      {
-        title: 'Information Collection',
-        body: 'You need to collect specific information from the user during this conversation.',
-        bullets,
-      },
-    ];
-  }
-
-  /**
-   * Get all gathered data (single-shot mode), keyed by call ID.
-   * @returns A copy of the internal gathered data map.
-   */
-  getAllGatheredData(): Map<string, GatheredInfo> {
-    return new Map(this.gatheredData);
-  }
-
-  /**
-   * Clear gathered data (single-shot mode) for a specific call or all calls.
-   * @param callId - If provided, clear data for this call only; otherwise clear all.
-   */
-  clearGatheredData(callId?: string): void {
-    if (callId) {
-      this.gatheredData.delete(callId);
-    } else {
-      this.gatheredData.clear();
-    }
   }
 }
 

--- a/src/skills/builtin/info_gatherer.ts
+++ b/src/skills/builtin/info_gatherer.ts
@@ -15,7 +15,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -65,7 +64,12 @@ interface GatheredInfo {
  * TS-native single-shot field collection (`fields` config).
  */
 export class InfoGathererSkill extends SkillBase {
-  /** Python SDK parity: multiple instances can coexist with different prefixes. */
+  // Python ground truth: skills/info_gatherer/skill.py:26-31
+  static override SKILL_NAME = 'info_gatherer';
+  static override SKILL_DESCRIPTION = 'Gather answers to a configurable list of questions';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   /** Sequential flow: list of question definitions populated in `setup()`. */
@@ -79,15 +83,6 @@ export class InfoGathererSkill extends SkillBase {
 
   /** Single-shot flow: in-memory storage keyed by call_id. */
   private gatheredData: Map<string, GatheredInfo> = new Map();
-
-  /**
-   * @param config - Optional configuration; supports `questions`, `prefix`,
-   *   `completion_message`, `fields`, `purpose`, `confirmation_message`,
-   *   `store_globally`.
-   */
-  constructor(config?: SkillConfig) {
-    super('info_gatherer', config);
-  }
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
@@ -137,84 +132,6 @@ export class InfoGathererSkill extends SkillBase {
         type: 'boolean',
         description: 'Whether to store gathered info in global data.',
         default: false,
-      },
-    };
-  }
-
-  /** @returns Manifest with config schema for both collection modes. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'info_gatherer',
-      description:
-        'Gather answers to a configurable list of questions, or collect structured information from the user based on configurable fields.',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['data-collection', 'form', 'information', 'utility'],
-      requiredEnvVars: [],
-      requiredPackages: [],
-      configSchema: {
-        questions: {
-          type: 'array',
-          description:
-            "List of question objects. Each must have 'key_name' and 'question_text'. Optional 'confirm' asks the agent to confirm before proceeding; 'prompt_add' appends a note.",
-          items: {
-            type: 'object',
-            properties: {
-              key_name: { type: 'string' },
-              question_text: { type: 'string' },
-              confirm: { type: 'boolean' },
-              prompt_add: { type: 'string' },
-            },
-            required: ['key_name', 'question_text'],
-          },
-        },
-        prefix: {
-          type: 'string',
-          description:
-            'Optional prefix for tool names and namespace. Enables multi-instance use.',
-        },
-        completion_message: {
-          type: 'string',
-          description:
-            'Message returned after all sequential questions are answered.',
-        },
-        fields: {
-          type: 'array',
-          description:
-            'Array of field definitions to collect: { name, description, required?, validation?, type? }.',
-          items: {
-            type: 'object',
-            properties: {
-              name: { type: 'string', description: 'Field name (used as the parameter key).' },
-              description: { type: 'string', description: 'Description of what this field collects.' },
-              required: { type: 'boolean', description: 'Whether this field is required. Defaults to false.' },
-              validation: {
-                type: 'string',
-                description: 'Optional regex pattern for validation (e.g., "^[\\\\w.+-]+@[\\\\w-]+\\\\.[\\\\w.]+$" for email).',
-              },
-              type: {
-                type: 'string',
-                description: 'Parameter type for the tool schema. Defaults to "string".',
-              },
-            },
-            required: ['name', 'description'],
-          },
-        },
-        purpose: {
-          type: 'string',
-          description:
-            'A description of why this information is being collected (shown in prompt).',
-        },
-        confirmation_message: {
-          type: 'string',
-          description:
-            'Custom message returned after successful save_info call (single-shot mode).',
-        },
-        store_globally: {
-          type: 'boolean',
-          description:
-            'Whether to store gathered info in global data (single-shot mode). Defaults to false.',
-        },
       },
     };
   }

--- a/src/skills/builtin/info_gatherer.ts
+++ b/src/skills/builtin/info_gatherer.ts
@@ -150,6 +150,8 @@ export class InfoGathererSkill extends SkillBase {
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['data-collection', 'form', 'information', 'utility'],
+      requiredEnvVars: [],
+      requiredPackages: [],
       configSchema: {
         questions: {
           type: 'array',

--- a/src/skills/builtin/info_gatherer.ts
+++ b/src/skills/builtin/info_gatherer.ts
@@ -1,10 +1,16 @@
 /**
  * Info Gatherer Skill - Collects structured information from the user.
  *
- * Tier 2 built-in skill: no external dependencies required.
- * Dynamically generates a save_info tool based on configured fields.
- * Fields can have optional validation patterns and required/optional flags.
- * Useful for collecting user details like name, email, phone, address, etc.
+ * Tier 2 built-in skill: no external dependencies required. Supports two
+ * collection modes:
+ *
+ * 1. Sequential question flow (Python-aligned): configure `questions` and the
+ *    skill registers `start_questions` / `submit_answer` tools that guide the
+ *    agent one question at a time. State lives in SWAIG `global_data` under a
+ *    namespaced key (e.g. `skill:info_gatherer`).
+ * 2. Single-shot field collection (TS-native): configure `fields` to get a
+ *    dynamic `save_info` tool plus a `get_gathered_info` retrieval tool. State
+ *    lives in an in-memory map keyed by `call_id`.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -16,6 +22,9 @@ import type {
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
+import { getLogger } from '../../Logger.js';
+
+const log = getLogger('InfoGathererSkill');
 
 /** Definition of a single data field to be collected from the user. */
 interface FieldDefinition {
@@ -31,24 +40,50 @@ interface FieldDefinition {
   type?: string;
 }
 
+/** Definition of a single question in the sequential question flow. */
+interface QuestionDefinition {
+  /** Key name used to store the answer. */
+  key_name: string;
+  /** Question text read to the user. */
+  question_text: string;
+  /** When true, the agent must confirm the answer with the user before submitting. */
+  confirm?: boolean;
+  /** Optional extra instruction appended to the question prompt. */
+  prompt_add?: string;
+}
+
 /** Key-value map of information gathered from a user during a call. */
 interface GatheredInfo {
   [key: string]: unknown;
 }
 
 /**
- * Collects structured information from the user based on configurable fields.
+ * Collects structured information from the user.
  *
- * Tier 2 built-in skill with no external dependencies. Dynamically generates
- * a `save_info` tool based on the `fields` config array. Fields support
- * optional validation patterns and required/optional flags. Data is stored
- * per-call and optionally merged into global data.
+ * Tier 2 built-in skill with no external dependencies. Supports the
+ * Python-aligned sequential question flow (`questions` config) and the
+ * TS-native single-shot field collection (`fields` config).
  */
 export class InfoGathererSkill extends SkillBase {
+  /** Python SDK parity: multiple instances can coexist with different prefixes. */
+  static override SUPPORTS_MULTIPLE_INSTANCES = true;
+
+  /** Sequential flow: list of question definitions populated in `setup()`. */
+  private questions: QuestionDefinition[] = [];
+  /** Sequential flow: derived tool name for the start tool (prefix-aware). */
+  private startToolName: string = 'start_questions';
+  /** Sequential flow: derived tool name for the submit tool (prefix-aware). */
+  private submitToolName: string = 'submit_answer';
+  /** Sequential flow: message returned once all questions are answered. */
+  private completionMessage: string = '';
+
+  /** Single-shot flow: in-memory storage keyed by call_id. */
   private gatheredData: Map<string, GatheredInfo> = new Map();
 
   /**
-   * @param config - Optional configuration; supports `fields`, `purpose`, `confirmation_message`, `store_globally`.
+   * @param config - Optional configuration; supports `questions`, `prefix`,
+   *   `completion_message`, `fields`, `purpose`, `confirmation_message`,
+   *   `store_globally`.
    */
   constructor(config?: SkillConfig) {
     super('info_gatherer', config);
@@ -57,9 +92,36 @@ export class InfoGathererSkill extends SkillBase {
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
       ...super.getParameterSchema(),
+      questions: {
+        type: 'array',
+        description:
+          "List of question objects. Each must have 'key_name' (str) and 'question_text' (str). Optional 'confirm' (bool) asks the agent to confirm the answer before proceeding.",
+        required: true,
+        items: {
+          type: 'object',
+          properties: {
+            key_name: { type: 'string' },
+            question_text: { type: 'string' },
+            confirm: { type: 'boolean' },
+            prompt_add: { type: 'string' },
+          },
+        },
+      },
+      prefix: {
+        type: 'string',
+        description:
+          "Optional prefix for tool names and namespace. When set, tools are named <prefix>_start_questions / <prefix>_submit_answer and state is stored under 'skill:<prefix>' in global_data.",
+      },
+      completion_message: {
+        type: 'string',
+        description: 'Message returned after all questions are answered',
+        default:
+          "Thank you! All questions have been answered. You can now summarize the information collected or ask if there's anything else the user would like to discuss.",
+      },
       fields: {
         type: 'array',
-        description: 'Array of field definitions to collect: { name, description, required?, validation?, type? }.',
+        description:
+          'Array of field definitions to collect: { name, description, required?, validation?, type? }.',
         items: { type: 'object' },
       },
       purpose: {
@@ -79,16 +141,41 @@ export class InfoGathererSkill extends SkillBase {
     };
   }
 
-  /** @returns Manifest with config schema for fields, purpose, confirmation_message, and store_globally. */
+  /** @returns Manifest with config schema for both collection modes. */
   getManifest(): SkillManifest {
     return {
       name: 'info_gatherer',
       description:
-        'Collects structured information from the user based on configurable fields. Validates and stores gathered data.',
+        'Gather answers to a configurable list of questions, or collect structured information from the user based on configurable fields.',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['data-collection', 'form', 'information', 'utility'],
       configSchema: {
+        questions: {
+          type: 'array',
+          description:
+            "List of question objects. Each must have 'key_name' and 'question_text'. Optional 'confirm' asks the agent to confirm before proceeding; 'prompt_add' appends a note.",
+          items: {
+            type: 'object',
+            properties: {
+              key_name: { type: 'string' },
+              question_text: { type: 'string' },
+              confirm: { type: 'boolean' },
+              prompt_add: { type: 'string' },
+            },
+            required: ['key_name', 'question_text'],
+          },
+        },
+        prefix: {
+          type: 'string',
+          description:
+            'Optional prefix for tool names and namespace. Enables multi-instance use.',
+        },
+        completion_message: {
+          type: 'string',
+          description:
+            'Message returned after all sequential questions are answered.',
+        },
         fields: {
           type: 'array',
           description:
@@ -119,19 +206,119 @@ export class InfoGathererSkill extends SkillBase {
         confirmation_message: {
           type: 'string',
           description:
-            'Custom message returned after successful info collection.',
+            'Custom message returned after successful save_info call (single-shot mode).',
         },
         store_globally: {
           type: 'boolean',
           description:
-            'Whether to store gathered info in global data. Defaults to false.',
+            'Whether to store gathered info in global data (single-shot mode). Defaults to false.',
         },
       },
     };
   }
 
-  /** @returns A `save_info` tool (dynamic params from config) and a `get_gathered_info` retrieval tool. */
+  /**
+   * Instance key for the SkillManager. When `prefix` is configured, returns
+   * `info_gatherer_<prefix>` to support multi-instance use. Matches Python's
+   * `get_instance_key()`.
+   */
+  override getInstanceKey(): string {
+    const prefix = this.getConfig<string>('prefix', '');
+    return prefix ? `info_gatherer_${prefix}` : 'info_gatherer';
+  }
+
+  /**
+   * Validate sequential question config and initialize derived state. A no-op
+   * when `questions` is not configured (field-only mode).
+   */
+  override async setup(): Promise<void> {
+    const questions = this.getConfig<unknown>('questions', undefined);
+    if (questions === undefined || questions === null) {
+      // No sequential config — field-only mode is handled in getTools/_getPromptSections.
+      return;
+    }
+
+    try {
+      InfoGathererSkill._validateQuestions(questions);
+    } catch (err) {
+      log.error(
+        `info_gatherer: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+
+    this.questions = questions as QuestionDefinition[];
+
+    const prefix = this.getConfig<string>('prefix', '');
+    if (prefix) {
+      this.startToolName = `${prefix}_start_questions`;
+      this.submitToolName = `${prefix}_submit_answer`;
+    } else {
+      this.startToolName = 'start_questions';
+      this.submitToolName = 'submit_answer';
+    }
+
+    this.completionMessage = this.getConfig<string>(
+      'completion_message',
+      "Thank you! All questions have been answered. You can now summarize the information collected or ask if there's anything else the user would like to discuss.",
+    );
+  }
+
+  /**
+   * Seed SWAIG global_data with the initial sequential-question state. Returns
+   * an empty object when sequential mode is not active.
+   */
+  override getGlobalData(): Record<string, unknown> {
+    if (this.questions.length === 0) {
+      return {};
+    }
+    return {
+      [this.getSkillNamespace()]: {
+        questions: this.questions,
+        question_index: 0,
+        answers: [],
+      },
+    };
+  }
+
+  /** Tools for the configured collection mode. */
   getTools(): SkillToolDefinition[] {
+    // Sequential question flow takes precedence when configured.
+    if (this.questions.length > 0) {
+      return this._getSequentialTools();
+    }
+    return this._getFieldTools();
+  }
+
+  private _getSequentialTools(): SkillToolDefinition[] {
+    return [
+      {
+        name: this.startToolName,
+        description: 'Start the question sequence with the first question',
+        parameters: {},
+        handler: (args, rawData) => this._handleStartQuestions(args, rawData),
+      },
+      {
+        name: this.submitToolName,
+        description:
+          'Submit an answer to the current question and move to the next one',
+        parameters: {
+          answer: {
+            type: 'string',
+            description: "The user's answer to the current question",
+          },
+          confirmed_by_user: {
+            type: 'boolean',
+            description:
+              "Only set to true when the user has explicitly said 'yes' or confirmed the answer is correct in their own words in their most recent response. Never set this to true on your own.",
+          },
+        },
+        handler: (args, rawData) => this._handleSubmitAnswer(args, rawData),
+      },
+    ];
+  }
+
+  private _getFieldTools(): SkillToolDefinition[] {
     const fields = this.getConfig<FieldDefinition[]>('fields', []);
     const confirmationMessage = this.getConfig<string>(
       'confirmation_message',
@@ -158,7 +345,7 @@ export class InfoGathererSkill extends SkillBase {
       }
     }
 
-    const tools: SkillToolDefinition[] = [
+    return [
       {
         name: 'save_info',
         description:
@@ -169,24 +356,24 @@ export class InfoGathererSkill extends SkillBase {
           const errors: string[] = [];
           const collected: GatheredInfo = {};
 
-          // Validate each field
           for (const field of fields) {
             const value = args[field.name];
 
-            // Check required fields
             if (field.required) {
-              if (value === undefined || value === null || (typeof value === 'string' && value.trim().length === 0)) {
+              if (
+                value === undefined ||
+                value === null ||
+                (typeof value === 'string' && value.trim().length === 0)
+              ) {
                 errors.push(`"${field.name}" is required but was not provided.`);
                 continue;
               }
             }
 
-            // Skip optional fields that weren't provided
             if (value === undefined || value === null) {
               continue;
             }
 
-            // Validate against pattern if specified
             if (field.validation && typeof value === 'string') {
               try {
                 const regex = new RegExp(field.validation);
@@ -197,11 +384,12 @@ export class InfoGathererSkill extends SkillBase {
                   continue;
                 }
               } catch {
-                // If regex is invalid, skip validation
+                // Invalid regex — skip validation
               }
             }
 
-            collected[field.name] = typeof value === 'string' ? value.trim() : value;
+            collected[field.name] =
+              typeof value === 'string' ? value.trim() : value;
           }
 
           if (errors.length > 0) {
@@ -216,14 +404,12 @@ export class InfoGathererSkill extends SkillBase {
             );
           }
 
-          // Store the gathered data keyed by call ID if available
           const callId = (rawData['call_id'] as string | undefined) ?? 'default';
           this.gatheredData.set(callId, {
             ...this.gatheredData.get(callId),
             ...collected,
           });
 
-          // Build confirmation with collected fields summary
           const fieldSummary = Object.entries(collected)
             .map(([key, val]) => `${key}: ${val}`)
             .join(', ');
@@ -232,7 +418,6 @@ export class InfoGathererSkill extends SkillBase {
             `${confirmationMessage} Saved: ${fieldSummary}.`,
           );
 
-          // Optionally store in global data
           if (storeGlobally) {
             result.updateGlobalData({ gathered_info: collected });
           }
@@ -265,12 +450,191 @@ export class InfoGathererSkill extends SkillBase {
         },
       },
     ];
-
-    return tools;
   }
 
-  /** @returns Prompt section listing required/optional fields and collection instructions. */
+  /**
+   * Handle the `start_questions` tool: read state from global_data and return
+   * an instruction for the first question.
+   */
+  private _handleStartQuestions(
+    _args: Record<string, unknown>,
+    rawData: Record<string, unknown>,
+  ): FunctionResult {
+    const state = this.getSkillData(rawData);
+    const questions = (state['questions'] as QuestionDefinition[] | undefined) ?? [];
+    const questionIndex = (state['question_index'] as number | undefined) ?? 0;
+
+    if (questions.length === 0 || questionIndex >= questions.length) {
+      return new FunctionResult("I don't have any questions to ask.");
+    }
+
+    const current = questions[questionIndex];
+    const instruction = InfoGathererSkill._generateQuestionInstruction(
+      current.question_text ?? '',
+      current.confirm ?? false,
+      true,
+      current.prompt_add ?? '',
+      this.submitToolName,
+      questionIndex + 1,
+      questions.length,
+    );
+    return new FunctionResult(instruction);
+  }
+
+  /**
+   * Handle the `submit_answer` tool: validate confirmation, record the answer,
+   * advance the index, and either return the next question or the completion
+   * message (disabling both tools on completion).
+   */
+  private _handleSubmitAnswer(
+    args: Record<string, unknown>,
+    rawData: Record<string, unknown>,
+  ): FunctionResult {
+    const answer = (args['answer'] as string | undefined) ?? '';
+    const confirmed = (args['confirmed_by_user'] as boolean | undefined) ?? false;
+    const state = this.getSkillData(rawData);
+
+    const questions = (state['questions'] as QuestionDefinition[] | undefined) ?? [];
+    const questionIndex = (state['question_index'] as number | undefined) ?? 0;
+    const answers = (state['answers'] as Array<{ key_name: string; answer: string }> | undefined) ?? [];
+
+    if (questionIndex >= questions.length) {
+      return new FunctionResult('All questions have already been answered.');
+    }
+
+    const current = questions[questionIndex];
+    const keyName = current.key_name ?? '';
+
+    // Enforce confirmation: reject the submission if the question requires
+    // confirmation but the confirmed flag was not set to true.
+    if ((current.confirm ?? false) && !confirmed) {
+      return new FunctionResult(
+        `Before submitting, you must read the answer "${answer}" back to the user ` +
+          `and ask them to confirm it is correct. Then call this function again with ` +
+          `confirmed set to true. If the user says it is wrong, ask the question again.`,
+      );
+    }
+
+    const newAnswers = [...answers, { key_name: keyName, answer }];
+    const newIndex = questionIndex + 1;
+
+    let result: FunctionResult;
+
+    if (newIndex < questions.length) {
+      const nextQ = questions[newIndex];
+      const instruction = InfoGathererSkill._generateQuestionInstruction(
+        nextQ.question_text ?? '',
+        nextQ.confirm ?? false,
+        false,
+        nextQ.prompt_add ?? '',
+        this.submitToolName,
+        newIndex + 1,
+        questions.length,
+      );
+      result = new FunctionResult(instruction);
+    } else {
+      result = new FunctionResult(this.completionMessage);
+      result.toggleFunctions([
+        { function: this.startToolName, active: false },
+        { function: this.submitToolName, active: false },
+      ]);
+    }
+
+    const newState = {
+      questions,
+      question_index: newIndex,
+      answers: newAnswers,
+    };
+    this.updateSkillData(result, newState);
+    return result;
+  }
+
+  /** Generate the per-question instruction returned to the agent. */
+  private static _generateQuestionInstruction(
+    questionText: string,
+    needsConfirmation: boolean,
+    isFirstQuestion: boolean,
+    promptAdd: string,
+    submitToolName: string,
+    questionNumber: number,
+    totalQuestions: number,
+  ): string {
+    let instruction: string;
+    if (isFirstQuestion) {
+      instruction =
+        `Ask each question one at a time, wait for the user's answer, ` +
+        `then call ${submitToolName} with their answer. Do not reuse previous answers.\n\n` +
+        `[Question ${questionNumber} of ${totalQuestions}]: "${questionText}"`;
+    } else {
+      instruction = `Previous answer saved. [Question ${questionNumber} of ${totalQuestions}]: "${questionText}"`;
+    }
+
+    if (promptAdd) {
+      instruction += `\nNote: ${promptAdd}`;
+    }
+
+    if (needsConfirmation) {
+      instruction +=
+        `\nThis question requires confirmation. Read the answer back to the user ` +
+        `and ask them to confirm it is correct before calling ${submitToolName}. ` +
+        `If they say it is wrong, ask the question again.`;
+    }
+
+    return instruction;
+  }
+
+  /**
+   * Validate that `questions` is a non-empty array of objects each having
+   * `key_name` and `question_text`. Throws on invalid input.
+   */
+  private static _validateQuestions(questions: unknown): void {
+    if (!Array.isArray(questions)) {
+      throw new Error('Questions must be a list');
+    }
+    if (questions.length === 0) {
+      throw new Error('At least one question is required');
+    }
+    for (let i = 0; i < questions.length; i++) {
+      const q = questions[i];
+      if (!q || typeof q !== 'object' || Array.isArray(q)) {
+        throw new Error(`Question ${i + 1} must be a dictionary`);
+      }
+      const obj = q as Record<string, unknown>;
+      if (!('key_name' in obj)) {
+        throw new Error(`Question ${i + 1} is missing 'key_name' field`);
+      }
+      if (!('question_text' in obj)) {
+        throw new Error(`Question ${i + 1} is missing 'question_text' field`);
+      }
+    }
+  }
+
+  /** Prompt sections depend on the active collection mode. */
   protected override _getPromptSections(): SkillPromptSection[] {
+    if (this.questions.length > 0) {
+      return this._getSequentialPromptSections();
+    }
+    return this._getFieldPromptSections();
+  }
+
+  private _getSequentialPromptSections(): SkillPromptSection[] {
+    return [
+      {
+        title: `Info Gatherer (${this.getInstanceKey()})`,
+        body:
+          `You need to gather answers to a series of questions from the user. ` +
+          `Start by introducing yourself and asking the user if they are ready ` +
+          `to answer some questions. Once the user confirms they are ready, ` +
+          `call the ${this.startToolName} function to get the first question. ` +
+          `Ask the user that question, wait for their response, then call ` +
+          `${this.submitToolName} with the answer they gave you. ` +
+          `Each call to ${this.submitToolName} will return the next question ` +
+          `to ask. Repeat this process until all questions are complete.`,
+      },
+    ];
+  }
+
+  private _getFieldPromptSections(): SkillPromptSection[] {
     const fields = this.getConfig<FieldDefinition[]>('fields', []);
     const purpose = this.getConfig<string | undefined>('purpose', undefined);
 
@@ -293,19 +657,14 @@ export class InfoGathererSkill extends SkillBase {
 
     if (requiredFields.length > 0) {
       const reqNames = requiredFields.map((f) => `"${f.name}"`).join(', ');
-      bullets.push(
-        `Required fields (must be collected): ${reqNames}.`,
-      );
+      bullets.push(`Required fields (must be collected): ${reqNames}.`);
     }
 
     if (optionalFields.length > 0) {
       const optNames = optionalFields.map((f) => `"${f.name}"`).join(', ');
-      bullets.push(
-        `Optional fields (collect if available): ${optNames}.`,
-      );
+      bullets.push(`Optional fields (collect if available): ${optNames}.`);
     }
 
-    // Add field descriptions
     for (const field of fields) {
       const reqLabel = field.required ? ' (required)' : ' (optional)';
       bullets.push(`${field.name}${reqLabel}: ${field.description}`);
@@ -327,7 +686,7 @@ export class InfoGathererSkill extends SkillBase {
   }
 
   /**
-   * Get all gathered data, keyed by call ID.
+   * Get all gathered data (single-shot mode), keyed by call ID.
    * @returns A copy of the internal gathered data map.
    */
   getAllGatheredData(): Map<string, GatheredInfo> {
@@ -335,7 +694,7 @@ export class InfoGathererSkill extends SkillBase {
   }
 
   /**
-   * Clear gathered data for a specific call or all calls.
+   * Clear gathered data (single-shot mode) for a specific call or all calls.
    * @param callId - If provided, clear data for this call only; otherwise clear all.
    */
   clearGatheredData(callId?: string): void {

--- a/src/skills/builtin/info_gatherer.ts
+++ b/src/skills/builtin/info_gatherer.ts
@@ -233,8 +233,17 @@ export class InfoGathererSkill extends SkillBase {
    */
   override async setup(): Promise<boolean> {
     const questions = this.getConfig<unknown>('questions', undefined);
+    const fields = this.getConfig<unknown[]>('fields', []);
+    if ((questions === undefined || questions === null) && (!Array.isArray(fields) || fields.length === 0)) {
+      // Python parity: `setup()` returns false when the skill has nothing to do
+      // (skill.py:91-95 requires `questions`). TS additionally supports a
+      // field-only mode, so we accept either — but not neither, otherwise the
+      // skill would register no tools and no prompt sections silently.
+      log.error('info_gatherer: at least one of "questions" or "fields" must be configured');
+      return false;
+    }
     if (questions === undefined || questions === null) {
-      // No sequential config — field-only mode is handled in getTools/_getPromptSections.
+      // Field-only mode — tools + prompt sections come from the fields path.
       return true;
     }
 

--- a/src/skills/builtin/info_gatherer.ts
+++ b/src/skills/builtin/info_gatherer.ts
@@ -231,11 +231,11 @@ export class InfoGathererSkill extends SkillBase {
    * Validate sequential question config and initialize derived state. A no-op
    * when `questions` is not configured (field-only mode).
    */
-  override async setup(): Promise<void> {
+  override async setup(): Promise<boolean> {
     const questions = this.getConfig<unknown>('questions', undefined);
     if (questions === undefined || questions === null) {
       // No sequential config — field-only mode is handled in getTools/_getPromptSections.
-      return;
+      return true;
     }
 
     try {
@@ -244,7 +244,7 @@ export class InfoGathererSkill extends SkillBase {
       log.error(
         `info_gatherer: ${err instanceof Error ? err.message : String(err)}`,
       );
-      return;
+      return false;
     }
 
     this.questions = questions as QuestionDefinition[];
@@ -262,6 +262,7 @@ export class InfoGathererSkill extends SkillBase {
       'completion_message',
       "Thank you! All questions have been answered. You can now summarize the information collected or ask if there's anything else the user would like to discuss.",
     );
+    return true;
   }
 
   /**

--- a/src/skills/builtin/joke.ts
+++ b/src/skills/builtin/joke.ts
@@ -7,7 +7,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -99,16 +98,6 @@ export class JokeSkill extends SkillBase {
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return { ...super.getParameterSchema() };
-  }
-
-  /** @returns Manifest with skill metadata and tags. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'joke',
-      description: 'Tells random jokes from a built-in collection across several categories.',
-      version: '1.0.0',
-      tags: ['entertainment', 'joke', 'humor'],
-    };
   }
 
   /** @returns A single `tell_joke` tool that returns a random joke with optional category filter. */

--- a/src/skills/builtin/joke.ts
+++ b/src/skills/builtin/joke.ts
@@ -90,12 +90,12 @@ const VALID_CATEGORIES = ['general', 'programming', 'dad'];
  * programming, and dad joke categories.
  */
 export class JokeSkill extends SkillBase {
-  /**
-   * @param config - Optional configuration (no config keys used by this skill).
-   */
-  constructor(config?: SkillConfig) {
-    super('joke', config);
-  }
+  // Python ground truth: skills/joke/skill.py
+  static override SKILL_NAME = 'joke';
+  static override SKILL_DESCRIPTION = 'Tell jokes using the API Ninjas joke API';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return { ...super.getParameterSchema() };

--- a/src/skills/builtin/math.ts
+++ b/src/skills/builtin/math.ts
@@ -8,7 +8,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -76,16 +75,6 @@ export class MathSkill extends SkillBase {
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return { ...super.getParameterSchema() };
-  }
-
-  /** @returns Manifest with skill metadata and tags. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'math',
-      description: 'Evaluates mathematical expressions with basic arithmetic operations.',
-      version: '1.0.0',
-      tags: ['utility', 'math', 'calculator'],
-    };
   }
 
   /** @returns A single `calculate` tool that evaluates a math expression string. */

--- a/src/skills/builtin/math.ts
+++ b/src/skills/builtin/math.ts
@@ -67,12 +67,12 @@ function safeEvaluate(expr: string): number {
  * basic arithmetic operators, parentheses, decimal points, and spaces.
  */
 export class MathSkill extends SkillBase {
-  /**
-   * @param config - Optional configuration (no config keys used by this skill).
-   */
-  constructor(config?: SkillConfig) {
-    super('math', config);
-  }
+  // Python ground truth: skills/math/skill.py
+  static override SKILL_NAME = 'math';
+  static override SKILL_DESCRIPTION = 'Perform basic mathematical calculations';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return { ...super.getParameterSchema() };

--- a/src/skills/builtin/mcp_gateway.ts
+++ b/src/skills/builtin/mcp_gateway.ts
@@ -20,6 +20,7 @@ import type {
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
 import { getLogger } from '../../Logger.js';
+import { validateUrl } from '../../SecurityUtils.js';
 import { Agent as UndiciAgent } from 'undici';
 
 const log = getLogger('McpGatewaySkill');
@@ -88,7 +89,17 @@ export class McpGatewaySkill extends SkillBase {
           'List of MCP services to connect to (empty for all available)',
         default: [],
         required: false,
-        items: { type: 'object' },
+        items: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Service name' },
+            tools: {
+              type: ['string', 'array'],
+              description:
+                "Tools to expose ('*' for all, or list of tool names)",
+            },
+          },
+        },
       },
       session_timeout: {
         type: 'integer',
@@ -134,9 +145,14 @@ export class McpGatewaySkill extends SkillBase {
   private retryAttempts = 3;
   private requestTimeout = 30;
   private verifySsl = true;
-  private sessionId: string | undefined;
   private _discoveredTools: SkillToolDefinition[] = [];
   private _ready = false;
+  /**
+   * Cached undici Agent used when `verify_ssl=false`. Created once in
+   * `setup()` and reused across every `_makeRequest` call to avoid
+   * connection-pool churn (Python reuses `requests.Session` implicitly).
+   */
+  private _undiciAgent: UndiciAgent | undefined;
 
   /**
    * @param config - Optional configuration (see `getParameterSchema()`).
@@ -154,6 +170,9 @@ export class McpGatewaySkill extends SkillBase {
       author: 'SignalWire',
       tags: ['mcp', 'gateway', 'protocol', 'tools', 'integration'],
       requiredEnvVars: [],
+      // Python declares REQUIRED_PACKAGES = ["requests"]; undici is the TS
+      // equivalent (used for verify_ssl=false dispatcher overrides).
+      requiredPackages: ['undici'],
     };
   }
 
@@ -184,6 +203,17 @@ export class McpGatewaySkill extends SkillBase {
     }
 
     this.gatewayUrl = gatewayUrl.replace(/\/+$/, '');
+
+    // SSRF protection — match Python skills/mcp_gateway/skill.py:147-148 which
+    // calls validate_url(self.gateway_url) before the health check. Reject
+    // private/loopback/metadata-endpoint URLs in multi-tenant deployments.
+    if (!(await validateUrl(this.gatewayUrl))) {
+      log.error('mcp_gateway: gateway_url rejected by SSRF protection', {
+        url: this.gatewayUrl,
+      });
+      return false;
+    }
+
     this.services =
       this.getConfig<McpServiceConfig[]>('services', []) ?? [];
     this.sessionTimeout = this.getConfig<number>('session_timeout', 300);
@@ -192,7 +222,13 @@ export class McpGatewaySkill extends SkillBase {
     this.requestTimeout = this.getConfig<number>('request_timeout', 30);
     this.verifySsl = this.getConfig<boolean>('verify_ssl', true);
 
-    this.sessionId = undefined;
+    // Cache a single undici Agent for SSL-bypass mode so each request reuses
+    // the same connection pool (parity with Python requests.Session behavior).
+    if (!this.verifySsl) {
+      this._undiciAgent = new UndiciAgent({
+        connect: { rejectUnauthorized: false },
+      });
+    }
 
     // Validate gateway connectivity
     try {
@@ -240,12 +276,15 @@ export class McpGatewaySkill extends SkillBase {
 
   override getGlobalData(): Record<string, unknown> {
     if (!this._ready) return {};
+    // Python skill.py emits mcp_session_id = self.session_id, which Python
+    // initializes to None in setup() and never updates. Per-call session IDs
+    // live in local scope inside _call_mcp_tool — never mutate shared state.
     return {
       mcp_gateway_url: this.gatewayUrl,
-      mcp_session_id: this.sessionId ?? null,
-      mcp_services: this.services
-        .map((s) => (typeof s === 'object' && s !== null ? s.name : String(s)))
-        .filter(Boolean),
+      mcp_session_id: null,
+      mcp_services: this.services.map((s) =>
+        typeof s === 'object' && s !== null ? s.name : String(s),
+      ),
     };
   }
 
@@ -377,11 +416,10 @@ export class McpGatewaySkill extends SkillBase {
     init.signal = controller.signal;
 
     // Mirror Python `requests.request(..., verify=self.verify_ssl)`. Node's
-    // built-in fetch has no SSL toggle, so use an undici Agent as dispatcher.
-    if (!this.verifySsl) {
-      init.dispatcher = new UndiciAgent({
-        connect: { rejectUnauthorized: false },
-      });
+    // built-in fetch has no SSL toggle, so reuse the undici Agent cached in
+    // setup() rather than spinning up a fresh one on every call.
+    if (this._undiciAgent) {
+      init.dispatcher = this._undiciAgent;
     }
 
     try {
@@ -500,6 +538,8 @@ export class McpGatewaySkill extends SkillBase {
     rawData: Record<string, unknown>,
   ): Promise<FunctionResult> {
     const globalData = (rawData['global_data'] as Record<string, unknown>) ?? {};
+    log.debug('mcp_gateway: raw_data keys', { keys: Object.keys(rawData) });
+    log.debug('mcp_gateway: global_data keys', { keys: Object.keys(globalData) });
     let sessionId: string;
     if (typeof globalData['mcp_call_id'] === 'string') {
       sessionId = globalData['mcp_call_id'] as string;
@@ -510,7 +550,9 @@ export class McpGatewaySkill extends SkillBase {
       sessionId = (rawData['call_id'] as string) ?? 'unknown';
       log.info('mcp_gateway: using session ID from call_id', { sessionId });
     }
-    this.sessionId = sessionId;
+    // NB: do NOT mutate this.sessionId here — Python leaves self.session_id
+    // untouched after setup(). Per-call IDs stay local so concurrent tool
+    // calls don't race and overwrite each other's session metadata.
 
     const requestData: Record<string, unknown> = {
       tool: toolName,
@@ -518,7 +560,9 @@ export class McpGatewaySkill extends SkillBase {
       session_id: sessionId,
       timeout: this.sessionTimeout,
       metadata: {
-        agent_id: this.agent?.name ?? 'signalwire-typescript',
+        // Python sends self.agent.name; mirror that and fall back to the
+        // skill name when agent is not yet bound. No hardcoded SDK literal.
+        agent_id: this.agent?.name ?? this.skillName,
         timestamp: rawData['timestamp'],
         call_id: rawData['call_id'],
       },
@@ -537,10 +581,17 @@ export class McpGatewaySkill extends SkillBase {
           const resultData = (await response.json()) as {
             result?: unknown;
           };
-          const resultText =
-            typeof resultData.result === 'string'
-              ? resultData.result
-              : JSON.stringify(resultData.result ?? 'No response');
+          // Python returns result_data.get('result', 'No response') which yields
+          // the raw string 'No response' when the key is missing. Preserve that:
+          // only stringify when the value is defined and non-string.
+          let resultText: string;
+          if (typeof resultData.result === 'string') {
+            resultText = resultData.result;
+          } else if (resultData.result != null) {
+            resultText = JSON.stringify(resultData.result);
+          } else {
+            resultText = 'No response';
+          }
           return new FunctionResult(resultText);
         }
 
@@ -549,7 +600,12 @@ export class McpGatewaySkill extends SkillBase {
           const errorData = (await response.json()) as { error?: string };
           errorMsg = errorData.error ?? `HTTP ${response.status}`;
         } catch {
-          errorMsg = `HTTP ${response.status}`;
+          // Python includes the first 200 chars of the response body when the
+          // payload isn't valid JSON (skill.py error handler). Match that.
+          const bodyText = await response.text().catch(() => '');
+          errorMsg = bodyText
+            ? `HTTP ${response.status}: ${bodyText.slice(0, 200)}`
+            : `HTTP ${response.status}`;
         }
         lastError = errorMsg;
 
@@ -564,6 +620,21 @@ export class McpGatewaySkill extends SkillBase {
         break;
       } catch (err) {
         lastError = err instanceof Error ? err.message : String(err);
+        // Distinguish network/timeout errors (retriable) from programming
+        // errors like JSON parse failures on success responses (fatal).
+        // Python aborts the retry loop on non-network exceptions; mirror that.
+        const isNetwork =
+          err instanceof Error &&
+          (err.name === 'AbortError' ||
+            err.name === 'TypeError' ||
+            err.message.includes('fetch'));
+        if (!isNetwork) {
+          log.error('mcp_gateway: unexpected error, aborting retry', {
+            attempt: attempt + 1,
+            error: lastError,
+          });
+          break;
+        }
         log.warn('mcp_gateway: request error', {
           attempt: attempt + 1,
           error: lastError,

--- a/src/skills/builtin/mcp_gateway.ts
+++ b/src/skills/builtin/mcp_gateway.ts
@@ -156,7 +156,7 @@ export class McpGatewaySkill extends SkillBase {
     };
   }
 
-  override async setup(): Promise<void> {
+  override async setup(): Promise<boolean> {
     this.authToken =
       this.getConfig<string | undefined>('auth_token', undefined) ??
       process.env['MCP_GATEWAY_AUTH_TOKEN'];
@@ -164,7 +164,7 @@ export class McpGatewaySkill extends SkillBase {
     const gatewayUrl = this.getConfig<string | undefined>('gateway_url', undefined);
     if (!gatewayUrl) {
       log.error('mcp_gateway: missing required parameter: gateway_url');
-      return;
+      return false;
     }
 
     if (!this.authToken) {
@@ -178,7 +178,7 @@ export class McpGatewaySkill extends SkillBase {
         log.error(
           'mcp_gateway: missing required parameters: auth_token or (auth_user + auth_password)',
         );
-        return;
+        return false;
       }
     }
 
@@ -200,24 +200,26 @@ export class McpGatewaySkill extends SkillBase {
         log.error('mcp_gateway: gateway health check failed', {
           status: health.status,
         });
-        return;
+        return false;
       }
       log.info('mcp_gateway: connected', { url: this.gatewayUrl });
     } catch (err) {
       log.error('mcp_gateway: failed to connect to gateway', {
         error: err instanceof Error ? err.message : String(err),
       });
-      return;
+      return false;
     }
 
     // Discover tools (equivalent of Python register_tools())
     try {
       await this._discoverTools();
       this._ready = true;
+      return true;
     } catch (err) {
       log.error('mcp_gateway: tool discovery failed', {
         error: err instanceof Error ? err.message : String(err),
       });
+      return false;
     }
   }
 

--- a/src/skills/builtin/mcp_gateway.ts
+++ b/src/skills/builtin/mcp_gateway.ts
@@ -12,7 +12,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -52,6 +51,15 @@ interface McpToolDefinition {
  * tool cleans up MCP sessions when the call ends.
  */
 export class McpGatewaySkill extends SkillBase {
+  // Python ground truth: skills/mcp_gateway/skill.py:~70-76
+  // REQUIRED_PACKAGES = ["requests"] in Python; TS uses undici for SSL dispatch.
+  // Python does not set SUPPORTS_MULTIPLE_INSTANCES so it inherits the default (False).
+  static override SKILL_NAME = 'mcp_gateway';
+  static override SKILL_DESCRIPTION = 'Bridge MCP servers with SWAIG functions';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = ['undici'];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
+
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
       ...super.getParameterSchema(),
@@ -153,28 +161,6 @@ export class McpGatewaySkill extends SkillBase {
    * connection-pool churn (Python reuses `requests.Session` implicitly).
    */
   private _undiciAgent: UndiciAgent | undefined;
-
-  /**
-   * @param config - Optional configuration (see `getParameterSchema()`).
-   */
-  constructor(config?: SkillConfig) {
-    super('mcp_gateway', config);
-  }
-
-  /** @returns Manifest for the MCP gateway skill. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'mcp_gateway',
-      description: 'Bridge MCP servers with SWAIG functions',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['mcp', 'gateway', 'protocol', 'tools', 'integration'],
-      requiredEnvVars: [],
-      // Python declares REQUIRED_PACKAGES = ["requests"]; undici is the TS
-      // equivalent (used for verify_ssl=false dispatcher overrides).
-      requiredPackages: ['undici'],
-    };
-  }
 
   override async setup(): Promise<boolean> {
     this.authToken =

--- a/src/skills/builtin/mcp_gateway.ts
+++ b/src/skills/builtin/mcp_gateway.ts
@@ -20,6 +20,7 @@ import type {
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
 import { getLogger } from '../../Logger.js';
+import { Agent as UndiciAgent } from 'undici';
 
 const log = getLogger('McpGatewaySkill');
 
@@ -362,7 +363,7 @@ export class McpGatewaySkill extends SkillBase {
       headers['Authorization'] = `Basic ${creds}`;
     }
 
-    const init: RequestInit = { method, headers };
+    const init: RequestInit & { dispatcher?: unknown } = { method, headers };
     if (options.body !== undefined) {
       headers['Content-Type'] = 'application/json';
       init.body = JSON.stringify(options.body);
@@ -375,8 +376,16 @@ export class McpGatewaySkill extends SkillBase {
     );
     init.signal = controller.signal;
 
+    // Mirror Python `requests.request(..., verify=self.verify_ssl)`. Node's
+    // built-in fetch has no SSL toggle, so use an undici Agent as dispatcher.
+    if (!this.verifySsl) {
+      init.dispatcher = new UndiciAgent({
+        connect: { rejectUnauthorized: false },
+      });
+    }
+
     try {
-      return await fetch(url, init);
+      return await fetch(url, init as RequestInit);
     } finally {
       clearTimeout(timer);
     }
@@ -509,7 +518,7 @@ export class McpGatewaySkill extends SkillBase {
       session_id: sessionId,
       timeout: this.sessionTimeout,
       metadata: {
-        agent_id: 'signalwire-typescript',
+        agent_id: this.agent?.name ?? 'signalwire-typescript',
         timestamp: rawData['timestamp'],
         call_id: rawData['call_id'],
       },

--- a/src/skills/builtin/mcp_gateway.ts
+++ b/src/skills/builtin/mcp_gateway.ts
@@ -1,10 +1,13 @@
 /**
- * MCP Gateway Skill - Placeholder for Model Context Protocol integration.
+ * MCP Gateway Skill - Bridge MCP servers with SWAIG functions.
  *
- * Tier 3 built-in skill: stub implementation for future MCP server gateway.
- * This skill will eventually allow agents to invoke tools exposed by MCP
- * (Model Context Protocol) servers, enabling integration with external
- * tool providers via the MCP standard.
+ * Port of the Python `MCPGatewaySkill`. Connects SignalWire agents to a
+ * Model Context Protocol gateway HTTP service and dynamically registers
+ * SWAIG tools for every MCP tool exposed by the configured services.
+ *
+ * Authentication: Bearer token (via `auth_token`) or HTTP Basic auth
+ * (via `auth_user` + `auth_password`). Supports configurable timeouts,
+ * retry attempts, and SSL verification.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -16,13 +19,35 @@ import type {
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
+import { getLogger } from '../../Logger.js';
+
+const log = getLogger('McpGatewaySkill');
+
+/** Configuration entry for a single MCP service to expose. */
+interface McpServiceConfig {
+  /** Service name as registered on the gateway. */
+  name: string;
+  /** Tools to expose: '*' for all, array of names to filter, or undefined. */
+  tools?: string | string[];
+}
+
+/** MCP tool definition returned by the gateway's /services/<name>/tools endpoint. */
+interface McpToolDefinition {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    properties?: Record<string, { type?: string; description?: string; enum?: unknown[]; default?: unknown }>;
+    required?: string[];
+  };
+}
 
 /**
- * Placeholder skill for future Model Context Protocol (MCP) server integration.
+ * Bridge MCP (Model Context Protocol) servers with SWAIG functions.
  *
- * Tier 3 stub implementation. When fully implemented, this skill will allow
- * agents to invoke tools exposed by external MCP servers. Currently provides
- * a non-functional `mcp_invoke` tool that returns a "not yet implemented" message.
+ * When configured, calls a gateway's `/services` endpoint to discover MCP
+ * services, enumerates each service's tools, and registers them as SWAIG
+ * tools prefixed with `tool_prefix` (default `mcp_`). A hidden hangup hook
+ * tool cleans up MCP sessions when the call ends.
  */
 export class McpGatewaySkill extends SkillBase {
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
@@ -30,82 +55,545 @@ export class McpGatewaySkill extends SkillBase {
       ...super.getParameterSchema(),
       gateway_url: {
         type: 'string',
-        description: 'URL of the MCP gateway server.',
-      },
-      tool_prefix: {
-        type: 'string',
-        description: 'Prefix for tool names from this gateway.',
+        description: 'URL of the MCP Gateway service',
+        required: true,
       },
       auth_token: {
         type: 'string',
-        description: 'Authentication token for the MCP gateway.',
+        description:
+          'Bearer token for authentication (alternative to basic auth)',
+        required: false,
         hidden: true,
+        env_var: 'MCP_GATEWAY_AUTH_TOKEN',
+      },
+      auth_user: {
+        type: 'string',
+        description:
+          'Username for basic authentication (required if auth_token not provided)',
+        required: false,
+        env_var: 'MCP_GATEWAY_AUTH_USER',
+      },
+      auth_password: {
+        type: 'string',
+        description:
+          'Password for basic authentication (required if auth_token not provided)',
+        required: false,
+        hidden: true,
+        env_var: 'MCP_GATEWAY_AUTH_PASSWORD',
+      },
+      services: {
+        type: 'array',
+        description:
+          'List of MCP services to connect to (empty for all available)',
+        default: [],
+        required: false,
+        items: { type: 'object' },
+      },
+      session_timeout: {
+        type: 'integer',
+        description: 'Session timeout in seconds',
+        default: 300,
+        required: false,
+      },
+      tool_prefix: {
+        type: 'string',
+        description: 'Prefix for registered SWAIG function names',
+        default: 'mcp_',
+        required: false,
+      },
+      retry_attempts: {
+        type: 'integer',
+        description: 'Number of retry attempts for failed requests',
+        default: 3,
+        required: false,
+      },
+      request_timeout: {
+        type: 'integer',
+        description: 'Request timeout in seconds',
+        default: 30,
+        required: false,
+      },
+      verify_ssl: {
+        type: 'boolean',
+        description: 'Verify SSL certificates',
+        default: true,
+        required: false,
       },
     };
   }
 
+  // Runtime state populated in setup()
+  private gatewayUrl = '';
+  private authToken: string | undefined;
+  private authUser: string | undefined;
+  private authPassword: string | undefined;
+  private services: McpServiceConfig[] = [];
+  private sessionTimeout = 300;
+  private toolPrefix = 'mcp_';
+  private retryAttempts = 3;
+  private requestTimeout = 30;
+  private verifySsl = true;
+  private sessionId: string | undefined;
+  private _discoveredTools: SkillToolDefinition[] = [];
+  private _ready = false;
+
   /**
-   * @param config - Optional configuration (reserved for future MCP server settings).
+   * @param config - Optional configuration (see `getParameterSchema()`).
    */
   constructor(config?: SkillConfig) {
     super('mcp_gateway', config);
   }
 
-  /** @returns Manifest with placeholder metadata for the MCP gateway. */
+  /** @returns Manifest for the MCP gateway skill. */
   getManifest(): SkillManifest {
     return {
       name: 'mcp_gateway',
-      description: 'MCP protocol gateway (placeholder). Will provide integration with Model Context Protocol servers for external tool invocation.',
-      version: '0.1.0',
+      description: 'Bridge MCP servers with SWAIG functions',
+      version: '1.0.0',
       author: 'SignalWire',
-      tags: ['mcp', 'gateway', 'protocol', 'tools', 'integration', 'placeholder'],
+      tags: ['mcp', 'gateway', 'protocol', 'tools', 'integration'],
+      requiredEnvVars: [],
     };
   }
 
-  /** @returns A single placeholder `mcp_invoke` tool (not yet functional). */
+  override async setup(): Promise<void> {
+    this.authToken =
+      this.getConfig<string | undefined>('auth_token', undefined) ??
+      process.env['MCP_GATEWAY_AUTH_TOKEN'];
+
+    const gatewayUrl = this.getConfig<string | undefined>('gateway_url', undefined);
+    if (!gatewayUrl) {
+      log.error('mcp_gateway: missing required parameter: gateway_url');
+      return;
+    }
+
+    if (!this.authToken) {
+      this.authUser =
+        this.getConfig<string | undefined>('auth_user', undefined) ??
+        process.env['MCP_GATEWAY_AUTH_USER'];
+      this.authPassword =
+        this.getConfig<string | undefined>('auth_password', undefined) ??
+        process.env['MCP_GATEWAY_AUTH_PASSWORD'];
+      if (!this.authUser || !this.authPassword) {
+        log.error(
+          'mcp_gateway: missing required parameters: auth_token or (auth_user + auth_password)',
+        );
+        return;
+      }
+    }
+
+    this.gatewayUrl = gatewayUrl.replace(/\/+$/, '');
+    this.services =
+      this.getConfig<McpServiceConfig[]>('services', []) ?? [];
+    this.sessionTimeout = this.getConfig<number>('session_timeout', 300);
+    this.toolPrefix = this.getConfig<string>('tool_prefix', 'mcp_');
+    this.retryAttempts = this.getConfig<number>('retry_attempts', 3);
+    this.requestTimeout = this.getConfig<number>('request_timeout', 30);
+    this.verifySsl = this.getConfig<boolean>('verify_ssl', true);
+
+    this.sessionId = undefined;
+
+    // Validate gateway connectivity
+    try {
+      const health = await this._makeRequest('GET', `${this.gatewayUrl}/health`);
+      if (!health.ok) {
+        log.error('mcp_gateway: gateway health check failed', {
+          status: health.status,
+        });
+        return;
+      }
+      log.info('mcp_gateway: connected', { url: this.gatewayUrl });
+    } catch (err) {
+      log.error('mcp_gateway: failed to connect to gateway', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    // Discover tools (equivalent of Python register_tools())
+    try {
+      await this._discoverTools();
+      this._ready = true;
+    } catch (err) {
+      log.error('mcp_gateway: tool discovery failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  override getHints(): string[] {
+    const hints = ['MCP', 'gateway'];
+    const services =
+      this.services.length > 0
+        ? this.services
+        : (this.getConfig<McpServiceConfig[]>('services', []) ?? []);
+    for (const service of services) {
+      if (service && typeof service === 'object' && service.name) {
+        hints.push(service.name);
+      }
+    }
+    return hints;
+  }
+
+  override getGlobalData(): Record<string, unknown> {
+    if (!this._ready) return {};
+    return {
+      mcp_gateway_url: this.gatewayUrl,
+      mcp_session_id: this.sessionId ?? null,
+      mcp_services: this.services
+        .map((s) => (typeof s === 'object' && s !== null ? s.name : String(s)))
+        .filter(Boolean),
+    };
+  }
+
+  /**
+   * @returns Dynamically discovered MCP tools plus an internal hangup-cleanup
+   *          tool. If discovery has not completed, returns a single fallback
+   *          `mcp_invoke` tool that explains configuration is missing.
+   */
   getTools(): SkillToolDefinition[] {
+    if (!this._ready || this._discoveredTools.length === 0) {
+      return [
+        {
+          name: 'mcp_invoke',
+          description:
+            'MCP gateway is not configured. Provide gateway_url and credentials to enable this skill.',
+          parameters: {
+            server: {
+              type: 'string',
+              description: 'The MCP server/service name.',
+            },
+            method: {
+              type: 'string',
+              description: 'The method/tool name to invoke.',
+            },
+            params: {
+              type: 'object',
+              description: 'Parameters to pass to the MCP method.',
+            },
+          },
+          required: ['server', 'method'],
+          handler: () =>
+            new FunctionResult(
+              'MCP gateway is not configured. Set gateway_url and an auth method (auth_token or auth_user/auth_password) on the skill config.',
+            ),
+        },
+      ];
+    }
+
+    // Append hangup hook tool
+    const tools = [...this._discoveredTools];
+    tools.push({
+      name: '_mcp_gateway_hangup',
+      description: 'Internal cleanup function for MCP sessions',
+      parameters: {},
+      handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) =>
+        this._hangupHandler(args, rawData),
+    });
+    return tools;
+  }
+
+  /** @returns Prompt section listing configured MCP services. */
+  protected override _getPromptSections(): SkillPromptSection[] {
+    // Prefer runtime-resolved services (after setup); fall back to config.
+    const services =
+      this.services.length > 0
+        ? this.services
+        : (this.getConfig<McpServiceConfig[]>('services', []) ?? []);
+    const gatewayUrl = this.gatewayUrl || this.getConfig<string>('gateway_url', '');
+    const toolPrefix = this.toolPrefix || this.getConfig<string>('tool_prefix', 'mcp_');
+    const serviceDescriptions: string[] = [];
+    for (const service of services) {
+      if (typeof service !== 'object' || service === null) continue;
+      const name = service.name ?? 'Unknown';
+      const tools = service.tools ?? '*';
+      if (tools === '*') {
+        serviceDescriptions.push(`${name} (all tools)`);
+      } else if (Array.isArray(tools)) {
+        serviceDescriptions.push(`${name} (${tools.length} tools)`);
+      } else {
+        serviceDescriptions.push(String(name));
+      }
+    }
+
+    if (serviceDescriptions.length === 0) {
+      return [];
+    }
+
     return [
       {
-        name: 'mcp_invoke',
-        description:
-          'Invoke a method on an MCP (Model Context Protocol) server. Currently a placeholder for future implementation.',
-        parameters: {
-          server: {
-            type: 'string',
-            description: 'The MCP server name or URL to connect to.',
-          },
-          method: {
-            type: 'string',
-            description: 'The method/tool name to invoke on the MCP server.',
-          },
-          params: {
-            type: 'object',
-            description: 'Parameters to pass to the MCP method.',
-          },
-        },
-        required: ['server', 'method'],
-        handler: () => {
-          return new FunctionResult(
-            'MCP gateway is not yet implemented. Configure MCP servers to use this skill.',
-          );
-        },
+        title: 'MCP Gateway Integration',
+        body: 'You have access to external MCP (Model Context Protocol) services through a gateway.',
+        bullets: [
+          `Connected to gateway at ${gatewayUrl}`,
+          `Available services: ${serviceDescriptions.join(', ')}`,
+          `Functions are prefixed with '${toolPrefix}' followed by service name`,
+          'Each service maintains its own session state throughout the call',
+        ],
       },
     ];
   }
 
-  /** @returns Prompt section explaining the MCP gateway placeholder status. */
-  protected override _getPromptSections(): SkillPromptSection[] {
-    return [
-      {
-        title: 'MCP Gateway (Placeholder)',
-        body: 'The MCP gateway skill is available but not yet fully implemented.',
-        bullets: [
-          'The mcp_invoke tool is a placeholder for future MCP (Model Context Protocol) integration.',
-          'When implemented, it will allow you to invoke tools from external MCP servers.',
-          'If a user asks about MCP functionality, let them know it is planned for a future release.',
-        ],
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Build auth + timeout-bearing fetch request to the gateway. */
+  private async _makeRequest(
+    method: string,
+    url: string,
+    options: { body?: unknown; headers?: Record<string, string> } = {},
+  ): Promise<Response> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...(options.headers ?? {}),
+    };
+
+    if (this.authToken) {
+      headers['Authorization'] = `Bearer ${this.authToken}`;
+    } else if (this.authUser && this.authPassword) {
+      const creds = Buffer.from(`${this.authUser}:${this.authPassword}`).toString(
+        'base64',
+      );
+      headers['Authorization'] = `Basic ${creds}`;
+    }
+
+    const init: RequestInit = { method, headers };
+    if (options.body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      init.body = JSON.stringify(options.body);
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      this.requestTimeout * 1000,
+    );
+    init.signal = controller.signal;
+
+    try {
+      return await fetch(url, init);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Discover available services and register each MCP tool as a SWAIG tool. */
+  private async _discoverTools(): Promise<void> {
+    this._discoveredTools = [];
+
+    // If no services configured, fetch all available
+    let services = this.services;
+    if (services.length === 0) {
+      const response = await this._makeRequest(
+        'GET',
+        `${this.gatewayUrl}/services`,
+      );
+      if (!response.ok) {
+        log.error('mcp_gateway: failed to list services', {
+          status: response.status,
+        });
+        return;
+      }
+      const allServices = (await response.json()) as Record<string, unknown>;
+      services = Object.keys(allServices).map((name) => ({ name }));
+      this.services = services;
+    }
+
+    for (const serviceConfig of services) {
+      const serviceName = serviceConfig?.name;
+      if (!serviceName) continue;
+
+      try {
+        const response = await this._makeRequest(
+          'GET',
+          `${this.gatewayUrl}/services/${encodeURIComponent(serviceName)}/tools`,
+        );
+        if (!response.ok) {
+          log.error('mcp_gateway: failed to get tools for service', {
+            service: serviceName,
+            status: response.status,
+          });
+          continue;
+        }
+        const data = (await response.json()) as { tools?: McpToolDefinition[] };
+        let tools = data.tools ?? [];
+
+        // Filter tools if specified
+        const toolFilter = serviceConfig.tools ?? '*';
+        if (toolFilter !== '*' && Array.isArray(toolFilter)) {
+          tools = tools.filter((t) => toolFilter.includes(t.name));
+        }
+
+        for (const toolDef of tools) {
+          const registered = this._registerMcpTool(serviceName, toolDef);
+          if (registered) this._discoveredTools.push(registered);
+        }
+      } catch (err) {
+        log.error('mcp_gateway: error fetching tools for service', {
+          service: serviceName,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  /** Convert an MCP tool definition into a SWAIG-compatible `SkillToolDefinition`. */
+  private _registerMcpTool(
+    serviceName: string,
+    toolDef: McpToolDefinition,
+  ): SkillToolDefinition | null {
+    const toolName = toolDef.name;
+    if (!toolName) return null;
+
+    const swaigName = `${this.toolPrefix}${serviceName}_${toolName}`;
+
+    const inputSchema = toolDef.inputSchema ?? {};
+    const properties = inputSchema.properties ?? {};
+    const required = inputSchema.required ?? [];
+
+    const swaigParams: Record<string, Record<string, unknown>> = {};
+    for (const [propName, propDef] of Object.entries(properties)) {
+      const paramDef: Record<string, unknown> = {
+        type: propDef.type ?? 'string',
+        description: propDef.description ?? '',
+      };
+      if (propDef.enum !== undefined) paramDef['enum'] = propDef.enum;
+      if (propDef.default !== undefined && !required.includes(propName)) {
+        paramDef['default'] = propDef.default;
+      }
+      swaigParams[propName] = paramDef;
+    }
+
+    log.info('mcp_gateway: registering SWAIG tool', { name: swaigName });
+
+    return {
+      name: swaigName,
+      description: `[${serviceName}] ${toolDef.description ?? toolName}`,
+      parameters: swaigParams,
+      required,
+      handler: async (
+        args: Record<string, unknown>,
+        rawData: Record<string, unknown>,
+      ) => this._callMcpTool(serviceName, toolName, args, rawData),
+    };
+  }
+
+  /** Call an MCP tool through the gateway, with retries. */
+  private async _callMcpTool(
+    serviceName: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    rawData: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    const globalData = (rawData['global_data'] as Record<string, unknown>) ?? {};
+    let sessionId: string;
+    if (typeof globalData['mcp_call_id'] === 'string') {
+      sessionId = globalData['mcp_call_id'] as string;
+      log.info('mcp_gateway: using session ID from global_data.mcp_call_id', {
+        sessionId,
+      });
+    } else {
+      sessionId = (rawData['call_id'] as string) ?? 'unknown';
+      log.info('mcp_gateway: using session ID from call_id', { sessionId });
+    }
+    this.sessionId = sessionId;
+
+    const requestData: Record<string, unknown> = {
+      tool: toolName,
+      arguments: args,
+      session_id: sessionId,
+      timeout: this.sessionTimeout,
+      metadata: {
+        agent_id: 'signalwire-typescript',
+        timestamp: rawData['timestamp'],
+        call_id: rawData['call_id'],
       },
-    ];
+    };
+
+    let lastError: string | undefined;
+    for (let attempt = 0; attempt < this.retryAttempts; attempt++) {
+      try {
+        const response = await this._makeRequest(
+          'POST',
+          `${this.gatewayUrl}/services/${encodeURIComponent(serviceName)}/call`,
+          { body: requestData },
+        );
+
+        if (response.status === 200) {
+          const resultData = (await response.json()) as {
+            result?: unknown;
+          };
+          const resultText =
+            typeof resultData.result === 'string'
+              ? resultData.result
+              : JSON.stringify(resultData.result ?? 'No response');
+          return new FunctionResult(resultText);
+        }
+
+        let errorMsg: string;
+        try {
+          const errorData = (await response.json()) as { error?: string };
+          errorMsg = errorData.error ?? `HTTP ${response.status}`;
+        } catch {
+          errorMsg = `HTTP ${response.status}`;
+        }
+        lastError = errorMsg;
+
+        if (response.status >= 500) {
+          log.warn('mcp_gateway: server error, retrying', {
+            attempt: attempt + 1,
+            error: errorMsg,
+          });
+          continue;
+        }
+        // Client error — don't retry
+        break;
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+        log.warn('mcp_gateway: request error', {
+          attempt: attempt + 1,
+          error: lastError,
+        });
+      }
+    }
+
+    const errorMsg = `Failed to call ${serviceName}.${toolName}: ${lastError ?? 'unknown error'}`;
+    log.error('mcp_gateway: call failed', { error: errorMsg });
+    return new FunctionResult(errorMsg);
+  }
+
+  /** Handle call hangup — clean up any MCP session on the gateway. */
+  private async _hangupHandler(
+    _args: Record<string, unknown>,
+    rawData: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    const globalData = (rawData['global_data'] as Record<string, unknown>) ?? {};
+    const sessionId =
+      (globalData['mcp_call_id'] as string | undefined) ??
+      (rawData['call_id'] as string | undefined) ??
+      'unknown';
+
+    try {
+      const response = await this._makeRequest(
+        'DELETE',
+        `${this.gatewayUrl}/sessions/${encodeURIComponent(sessionId)}`,
+      );
+
+      if (response.status === 200 || response.status === 404) {
+        log.info('mcp_gateway: cleaned up MCP session', { sessionId });
+      } else {
+        log.warn('mcp_gateway: session cleanup returned non-ok status', {
+          status: response.status,
+        });
+      }
+    } catch (err) {
+      log.error('mcp_gateway: error cleaning up session', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    return new FunctionResult('Session cleanup complete');
   }
 }
 

--- a/src/skills/builtin/mcp_gateway.ts
+++ b/src/skills/builtin/mcp_gateway.ts
@@ -281,7 +281,8 @@ export class McpGatewaySkill extends SkillBase {
       ];
     }
 
-    // Append hangup hook tool
+    // Append hangup hook tool — isHangupHook causes the platform to auto-fire
+    // this on call hangup (Python: is_hangup_hook=True in define_tool).
     const tools = [...this._discoveredTools];
     tools.push({
       name: '_mcp_gateway_hangup',
@@ -289,6 +290,7 @@ export class McpGatewaySkill extends SkillBase {
       parameters: {},
       handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) =>
         this._hangupHandler(args, rawData),
+      isHangupHook: true,
     });
     return tools;
   }

--- a/src/skills/builtin/native_vector_search.ts
+++ b/src/skills/builtin/native_vector_search.ts
@@ -23,14 +23,31 @@ import type {
   SkillConfig,
   ParameterSchemaEntry,
 } from '../SkillBase.js';
+import type { AgentBase } from '../../AgentBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
 import { getLogger } from '../../Logger.js';
 
 const log = getLogger('NativeVectorSearchSkill');
 
-/** Callback signature for customizing the formatted search response. */
+/**
+ * Callback signature for customizing the formatted search response.
+ *
+ * The context object is the TypeScript idiom for Python's positional-args
+ * convention: `(response, agent, query, results, args)`. All Python fields are
+ * present plus TS-specific additions (`count`, `skill`):
+ *
+ * - `response`  — pre-formatted response string (same as Python arg 1)
+ * - `agent`     — the AgentBase instance that owns this skill (same as Python arg 2)
+ * - `query`     — the search query string (same as Python arg 3)
+ * - `results`   — array of search results (same as Python arg 4)
+ * - `args`      — raw tool call arguments (same as Python arg 5)
+ * - `count`     — requested result count (TS addition)
+ * - `skill`     — this skill instance (TS addition)
+ */
 export type ResponseFormatCallback = (ctx: {
   response: string;
+  /** The AgentBase instance that owns this skill. Equivalent to Python's `agent` positional arg. */
+  agent?: AgentBase;
   query: string;
   results: Array<{ content: string; score: number; metadata: Record<string, unknown>; tags?: string[] }>;
   args: Record<string, unknown>;
@@ -358,6 +375,8 @@ export class NativeVectorSearchSkill extends SkillBase {
   private responseFormatCallback: ResponseFormatCallback | undefined;
   private description = 'Search the knowledge base for information';
   private verbose = false;
+  /** Hybrid scoring weight: 0.0 = pure TF-IDF, 1.0 = pure keyword overlap. */
+  private keywordWeight = 0.0;
   private searchAvailable = false;
   private useRemote = false;
   private remoteBaseUrl: string | undefined;
@@ -407,6 +426,10 @@ export class NativeVectorSearchSkill extends SkillBase {
       'Search the knowledge base for information',
     );
     this.verbose = this.getConfig<boolean>('verbose', false);
+    this.keywordWeight = Math.min(
+      1.0,
+      Math.max(0.0, this.getConfig<number>('keyword_weight', 0.0)),
+    );
 
     // Remote search configuration
     this.remoteUrl = this.getConfig<string | undefined>('remote_url', undefined);
@@ -655,6 +678,7 @@ export class NativeVectorSearchSkill extends SkillBase {
         try {
           const formatted = this.responseFormatCallback({
             response: msg,
+            agent: this.agent,
             query,
             results: [],
             args,
@@ -714,6 +738,7 @@ export class NativeVectorSearchSkill extends SkillBase {
       try {
         const formatted = this.responseFormatCallback({
           response,
+          agent: this.agent,
           query,
           results,
           args,
@@ -741,10 +766,27 @@ export class NativeVectorSearchSkill extends SkillBase {
     const queryTokens = tokenize(query);
     if (queryTokens.length === 0) return [];
 
-    const scored = this._documents.map((doc, i) => ({
-      doc,
-      score: scoreTfIdf(queryTokens, this._docTfs[i], this._idf),
-    }));
+    const weight = this.keywordWeight;
+    const scored = this._documents.map((doc, i) => {
+      const tfidf = scoreTfIdf(queryTokens, this._docTfs[i], this._idf);
+      let score: number;
+      if (weight > 0) {
+        // Keyword-overlap component: fraction of unique query terms present in doc.
+        // Mirrors Python: `keyword_weight=self.keyword_weight` passed to
+        // `search_engine.search()` for hybrid TF-IDF + keyword scoring.
+        const docTokenSet = new Set(this._tokenizedDocs[i]);
+        const uniqueQueryTokens = new Set(queryTokens);
+        let matches = 0;
+        for (const t of uniqueQueryTokens) {
+          if (docTokenSet.has(t)) matches++;
+        }
+        const keywordOverlap = uniqueQueryTokens.size > 0 ? matches / uniqueQueryTokens.size : 0;
+        score = tfidf * (1 - weight) + keywordOverlap * weight;
+      } else {
+        score = tfidf;
+      }
+      return { doc, score };
+    });
 
     const filtered = scored
       .filter((s) => s.score > this.similarityThreshold)

--- a/src/skills/builtin/native_vector_search.ts
+++ b/src/skills/builtin/native_vector_search.ts
@@ -17,7 +17,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -149,6 +148,13 @@ function scoreTfIdf(
  * Multi-instance capable (distinguished by `tool_name` + `index_file`).
  */
 export class NativeVectorSearchSkill extends SkillBase {
+  // Python ground truth: skills/native_vector_search/skill.py:~75-82
+  static override SKILL_NAME = 'native_vector_search';
+  static override SKILL_DESCRIPTION =
+    'Search document indexes using vector similarity and keyword search (local or remote)';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
@@ -388,13 +394,6 @@ export class NativeVectorSearchSkill extends SkillBase {
   private _idf: Map<string, number> = new Map();
   private _indexed = false;
 
-  /**
-   * @param config - Optional configuration (see `getParameterSchema()`).
-   */
-  constructor(config?: SkillConfig) {
-    super('native_vector_search', config);
-  }
-
   override getInstanceKey(): string {
     const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
     const indexFile = this.getConfig<string>('index_file', 'default');
@@ -541,20 +540,6 @@ export class NativeVectorSearchSkill extends SkillBase {
     this._docTfs = [];
     this._idf = new Map();
     this._indexed = false;
-  }
-
-  /** @returns Manifest for the native vector search skill. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'native_vector_search',
-      description:
-        'Search document indexes using vector similarity and keyword search (local or remote)',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['search', 'vector', 'tfidf', 'documents', 'local', 'knowledge'],
-      requiredEnvVars: [],
-      requiredPackages: [],
-    };
   }
 
   /**

--- a/src/skills/builtin/native_vector_search.ts
+++ b/src/skills/builtin/native_vector_search.ts
@@ -383,7 +383,7 @@ export class NativeVectorSearchSkill extends SkillBase {
     return `${this.skillName}_${toolName}_${indexFile}`;
   }
 
-  override async setup(): Promise<void> {
+  override async setup(): Promise<boolean> {
     // Config
     this.toolName = this.getConfig<string>('tool_name', 'search_knowledge');
     this.backend = this.getConfig<string>('backend', 'sqlite');
@@ -445,7 +445,7 @@ export class NativeVectorSearchSkill extends SkillBase {
             url: this.remoteBaseUrl,
           });
           this.searchAvailable = true;
-          return;
+          return true;
         }
         if (response.status === 401) {
           log.error('native_vector_search: remote auth failed');
@@ -461,7 +461,7 @@ export class NativeVectorSearchSkill extends SkillBase {
         });
         this.searchAvailable = false;
       }
-      return;
+      return this.searchAvailable;
     }
 
     // Local / in-memory mode
@@ -475,6 +475,7 @@ export class NativeVectorSearchSkill extends SkillBase {
         indexed: this._indexed,
       });
     }
+    return this.searchAvailable;
   }
 
   override getHints(): string[] {

--- a/src/skills/builtin/native_vector_search.ts
+++ b/src/skills/builtin/native_vector_search.ts
@@ -49,7 +49,7 @@ export type ResponseFormatCallback = (ctx: {
   /** The AgentBase instance that owns this skill. Equivalent to Python's `agent` positional arg. */
   agent?: AgentBase;
   query: string;
-  results: Array<{ content: string; score: number; metadata: Record<string, unknown>; tags?: string[] }>;
+  results: Array<{ content: string; score: number; metadata: Record<string, unknown> }>;
   args: Record<string, unknown>;
   count: number;
   skill: NativeVectorSearchSkill;
@@ -72,7 +72,6 @@ interface SearchResult {
   content: string;
   score: number;
   metadata: Record<string, unknown>;
-  tags?: string[];
 }
 
 /**
@@ -154,12 +153,6 @@ export class NativeVectorSearchSkill extends SkillBase {
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
       ...super.getParameterSchema(),
-      tool_name: {
-        type: 'string',
-        description: 'Custom tool name for this vector search instance.',
-        default: 'search_knowledge',
-        required: false,
-      },
       index_file: {
         type: 'string',
         description:
@@ -375,8 +368,13 @@ export class NativeVectorSearchSkill extends SkillBase {
   private responseFormatCallback: ResponseFormatCallback | undefined;
   private description = 'Search the knowledge base for information';
   private verbose = false;
-  /** Hybrid scoring weight: 0.0 = pure TF-IDF, 1.0 = pure keyword overlap. */
-  private keywordWeight = 0.0;
+  /**
+   * Hybrid scoring weight: 0.0 = pure TF-IDF, 1.0 = pure keyword overlap.
+   * `null` means "use Python default of 0.3 at search time" — matches
+   * Python `SearchEngine._merge_all_results` behavior when `keyword_weight`
+   * is None (see `search_engine.py` line 449).
+   */
+  private keywordWeight: number | null = null;
   private searchAvailable = false;
   private useRemote = false;
   private remoteBaseUrl: string | undefined;
@@ -426,10 +424,8 @@ export class NativeVectorSearchSkill extends SkillBase {
       'Search the knowledge base for information',
     );
     this.verbose = this.getConfig<boolean>('verbose', false);
-    this.keywordWeight = Math.min(
-      1.0,
-      Math.max(0.0, this.getConfig<number>('keyword_weight', 0.0)),
-    );
+    const kw = this.getConfig<number | null | undefined>('keyword_weight', null);
+    this.keywordWeight = kw == null ? null : Math.min(1.0, Math.max(0.0, kw));
 
     // Remote search configuration
     this.remoteUrl = this.getConfig<string | undefined>('remote_url', undefined);
@@ -721,7 +717,7 @@ export class NativeVectorSearchSkill extends SkillBase {
       if (content.length > perResultLimit) {
         content = content.slice(0, perResultLimit) + '...';
       }
-      const tags = r.tags ?? (r.metadata['tags'] as string[] | undefined) ?? [];
+      const tags = (r.metadata['tags'] as string[] | undefined) ?? [];
 
       let text = `**Result ${i + 1}** (from ${filename}`;
       if (section) text += `, section: ${section}`;
@@ -766,7 +762,8 @@ export class NativeVectorSearchSkill extends SkillBase {
     const queryTokens = tokenize(query);
     if (queryTokens.length === 0) return [];
 
-    const weight = this.keywordWeight;
+    // Mirrors Python search_engine.py line 449: None → 0.3.
+    const weight = this.keywordWeight ?? 0.3;
     const scored = this._documents.map((doc, i) => {
       const tfidf = scoreTfIdf(queryTokens, this._docTfs[i], this._idf);
       let score: number;
@@ -806,7 +803,6 @@ export class NativeVectorSearchSkill extends SkillBase {
         ...(doc.metadata ?? {}),
         tags: doc.tags ?? [],
       },
-      tags: doc.tags ?? [],
     }));
   }
 
@@ -846,14 +842,12 @@ export class NativeVectorSearchSkill extends SkillBase {
           content: string;
           score: number;
           metadata: Record<string, unknown>;
-          tags?: string[];
         }>;
       };
       return (data.results ?? []).map((r) => ({
         content: r.content,
         score: r.score,
         metadata: r.metadata,
-        tags: r.tags,
       }));
     } catch (err) {
       log.error('native_vector_search: remote search error', {

--- a/src/skills/builtin/native_vector_search.ts
+++ b/src/skills/builtin/native_vector_search.ts
@@ -1,10 +1,18 @@
 /**
- * Native Vector Search Skill - In-memory document search using TF-IDF-like scoring.
+ * Native Vector Search Skill - Document search over a local or remote index.
  *
- * Tier 3 built-in skill: no external dependencies or API keys required.
- * Implements a simple text-matching algorithm based on word overlap scoring
- * (TF-IDF inspired) to search through a set of in-memory documents.
- * Suitable for small to medium document collections.
+ * Port of the Python `NativeVectorSearchSkill`. Supports three backends in
+ * Python (SQLite `.swsearch`, PostgreSQL `pgvector`, and a remote HTTP
+ * search server). This TypeScript implementation provides:
+ *
+ * - In-memory TF-IDF search over `documents` passed via config (fast path
+ *   that needs no additional deps), and
+ * - Remote HTTP search via a configured `remote_url` (compatible with the
+ *   Python SDK's `sw-search` remote protocol).
+ *
+ * The SQLite/pgvector backends require native Python dependencies and are
+ * not available here; their schema entries are preserved so configuration
+ * written for the Python SDK remains valid.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -16,6 +24,19 @@ import type {
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
+import { getLogger } from '../../Logger.js';
+
+const log = getLogger('NativeVectorSearchSkill');
+
+/** Callback signature for customizing the formatted search response. */
+export type ResponseFormatCallback = (ctx: {
+  response: string;
+  query: string;
+  results: Array<{ content: string; score: number; metadata: Record<string, unknown>; tags?: string[] }>;
+  args: Record<string, unknown>;
+  count: number;
+  skill: NativeVectorSearchSkill;
+}) => string;
 
 /** A document entry in the in-memory search index. */
 interface DocumentEntry {
@@ -25,20 +46,20 @@ interface DocumentEntry {
   text: string;
   /** Optional metadata associated with the document. */
   metadata?: Record<string, unknown>;
+  /** Optional tags for filtering. */
+  tags?: string[];
 }
 
-/** A document paired with its relevance score from a search query. */
-interface ScoredDocument {
-  /** The matched document entry. */
-  document: DocumentEntry;
-  /** TF-IDF relevance score (higher is more relevant). */
+/** A single search result in normalized form. */
+interface SearchResult {
+  content: string;
   score: number;
+  metadata: Record<string, unknown>;
+  tags?: string[];
 }
 
 /**
  * Tokenize text into lowercase words, removing punctuation and common stop words.
- * @param text - Raw text to tokenize.
- * @returns Array of meaningful word tokens.
  */
 function tokenize(text: string): string[] {
   const stopWords = new Set([
@@ -63,17 +84,11 @@ function tokenize(text: string): string[] {
     .filter((word) => word.length > 1 && !stopWords.has(word));
 }
 
-/**
- * Compute normalized term frequency for a list of tokens.
- * @param tokens - Array of tokenized words.
- * @returns Map from token to its normalized frequency.
- */
 function termFrequency(tokens: string[]): Map<string, number> {
   const tf = new Map<string, number>();
   for (const token of tokens) {
     tf.set(token, (tf.get(token) ?? 0) + 1);
   }
-  // Normalize by document length
   const len = tokens.length || 1;
   for (const [term, count] of tf) {
     tf.set(term, count / len);
@@ -81,65 +96,40 @@ function termFrequency(tokens: string[]): Map<string, number> {
   return tf;
 }
 
-/**
- * Compute inverse document frequency weights for a tokenized corpus.
- * @param corpus - Array of token arrays, one per document.
- * @returns Map from token to its IDF weight.
- */
-function inverseDocumentFrequency(
-  corpus: string[][],
-): Map<string, number> {
+function inverseDocumentFrequency(corpus: string[][]): Map<string, number> {
   const idf = new Map<string, number>();
   const numDocs = corpus.length || 1;
-
-  // Count how many documents contain each term
   const docFreq = new Map<string, number>();
   for (const tokens of corpus) {
-    const uniqueTokens = new Set(tokens);
-    for (const token of uniqueTokens) {
-      docFreq.set(token, (docFreq.get(token) ?? 0) + 1);
-    }
+    const unique = new Set(tokens);
+    for (const t of unique) docFreq.set(t, (docFreq.get(t) ?? 0) + 1);
   }
-
   for (const [term, freq] of docFreq) {
     idf.set(term, Math.log((numDocs + 1) / (freq + 1)) + 1);
   }
-
   return idf;
 }
 
-/**
- * Score a query against a document using TF-IDF cosine-like similarity.
- * @param queryTokens - Tokenized query words.
- * @param docTf - Pre-computed term frequency map for the document.
- * @param idf - Pre-computed inverse document frequency map.
- * @returns Similarity score (higher is more relevant).
- */
 function scoreTfIdf(
   queryTokens: string[],
   docTf: Map<string, number>,
   idf: Map<string, number>,
 ): number {
   if (queryTokens.length === 0) return 0;
-
   let score = 0;
   const queryTf = termFrequency(queryTokens);
-
   for (const [term, qWeight] of queryTf) {
     const docWeight = docTf.get(term) ?? 0;
     const idfWeight = idf.get(term) ?? 1;
     score += qWeight * docWeight * idfWeight * idfWeight;
   }
-
   return score;
 }
 
 /**
- * In-memory document search using TF-IDF-like word overlap scoring.
+ * Document search using TF-IDF in-memory scoring or a remote search server.
  *
- * Tier 3 built-in skill with no external dependencies or API keys required.
- * Documents are provided via the `documents` config array and indexed at
- * construction time. Suitable for small to medium document collections.
+ * Multi-instance capable (distinguished by `tool_name` + `index_file`).
  */
 export class NativeVectorSearchSkill extends SkillBase {
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
@@ -150,25 +140,230 @@ export class NativeVectorSearchSkill extends SkillBase {
       tool_name: {
         type: 'string',
         description: 'Custom tool name for this vector search instance.',
+        default: 'search_knowledge',
+        required: false,
+      },
+      index_file: {
+        type: 'string',
+        description:
+          'Path to .swsearch index file (SQLite backend only). Use this for local file-based search',
+        required: false,
+      },
+      build_index: {
+        type: 'boolean',
+        description: 'Whether to build index from source files',
+        default: false,
+        required: false,
+      },
+      source_dir: {
+        type: 'string',
+        description:
+          'Directory containing documents to index (required if build_index=True)',
+        required: false,
+      },
+      remote_url: {
+        type: 'string',
+        description:
+          'URL of remote search server for network mode (e.g., http://localhost:8001)',
+        required: false,
+      },
+      index_name: {
+        type: 'string',
+        description:
+          'Name of index on remote server (network mode only, used with remote_url)',
+        default: 'default',
+        required: false,
+      },
+      count: {
+        type: 'integer',
+        description: 'Number of search results to return',
+        default: 5,
+        required: false,
+        min: 1,
+        max: 20,
+      },
+      similarity_threshold: {
+        type: 'number',
+        description:
+          'Minimum similarity score for results (0.0 = no limit, 1.0 = exact match)',
+        default: 0.0,
+        required: false,
+        min: 0.0,
+        max: 1.0,
+      },
+      tags: {
+        type: 'array',
+        description: 'Tags to filter search results',
+        default: [],
+        required: false,
+        items: { type: 'string' },
+      },
+      global_tags: {
+        type: 'array',
+        description: 'Tags to apply to all indexed documents',
+        default: [],
+        required: false,
+        items: { type: 'string' },
+      },
+      file_types: {
+        type: 'array',
+        description: 'File extensions to include when building index',
+        default: ['md', 'txt', 'pdf', 'docx', 'html'],
+        required: false,
+        items: { type: 'string' },
+      },
+      exclude_patterns: {
+        type: 'array',
+        description: 'Patterns to exclude when building index',
+        default: [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/dist/**',
+          '**/build/**',
+        ],
+        required: false,
+        items: { type: 'string' },
+      },
+      no_results_message: {
+        type: 'string',
+        description: 'Message when no results are found',
+        default: "No information found for '{query}'",
+        required: false,
+      },
+      response_prefix: {
+        type: 'string',
+        description: 'Prefix to add to search results',
+        default: '',
+        required: false,
+      },
+      response_postfix: {
+        type: 'string',
+        description: 'Postfix to add to search results',
+        default: '',
+        required: false,
+      },
+      max_content_length: {
+        type: 'integer',
+        description:
+          'Maximum total response size in characters (distributed across all results)',
+        default: 32768,
+        required: false,
+        min: 1000,
+      },
+      response_format_callback: {
+        type: 'object',
+        description:
+          'Optional callback function to format/transform the response.',
+        required: false,
+      },
+      description: {
+        type: 'string',
+        description: 'Tool description',
+        default: 'Search the knowledge base for information',
+        required: false,
+      },
+      hints: {
+        type: 'array',
+        description: 'Speech recognition hints',
+        default: [],
+        required: false,
+        items: { type: 'string' },
+      },
+      nlp_backend: {
+        type: 'string',
+        description: 'NLP backend for query processing (deprecated)',
+        default: 'basic',
+        required: false,
+        enum: ['basic', 'spacy', 'nltk'],
+      },
+      query_nlp_backend: {
+        type: 'string',
+        description: 'NLP backend for query expansion',
+        required: false,
+        enum: ['basic', 'spacy', 'nltk'],
+      },
+      index_nlp_backend: {
+        type: 'string',
+        description: 'NLP backend for indexing',
+        required: false,
+        enum: ['basic', 'spacy', 'nltk'],
+      },
+      backend: {
+        type: 'string',
+        description:
+          "Storage backend for local database mode: 'sqlite' or 'pgvector'. Ignored if remote_url is set",
+        default: 'sqlite',
+        required: false,
+        enum: ['sqlite', 'pgvector'],
+      },
+      connection_string: {
+        type: 'string',
+        description: 'PostgreSQL connection string (pgvector backend only)',
+        required: false,
+      },
+      collection_name: {
+        type: 'string',
+        description: 'Collection/table name in PostgreSQL (pgvector backend only)',
+        required: false,
+      },
+      verbose: {
+        type: 'boolean',
+        description: 'Enable verbose logging',
+        default: false,
+        required: false,
+      },
+      keyword_weight: {
+        type: 'number',
+        description:
+          'Manual keyword weight (0.0-1.0). Overrides automatic weight detection',
+        required: false,
+        min: 0.0,
+        max: 1.0,
+      },
+      model_name: {
+        type: 'string',
+        description: 'Embedding model to use',
+        default: 'mini',
+        required: false,
+      },
+      overwrite: {
+        type: 'boolean',
+        description: 'Overwrite existing pgvector collection when building index',
+        default: false,
+        required: false,
       },
       documents: {
         type: 'array',
-        description: 'Array of documents to index: [{ id, text, metadata? }].',
+        description:
+          'In-memory array of documents to index: [{ id, text, metadata?, tags? }] (TS-specific)',
+        required: false,
         items: { type: 'object' },
-      },
-      num_results: {
-        type: 'number',
-        description: 'Default number of top results to return.',
-        default: 3,
-      },
-      distance_threshold: {
-        type: 'number',
-        description: 'Minimum relevance score threshold.',
-        default: 0,
       },
     };
   }
 
+  // Runtime state
+  private toolName = 'search_knowledge';
+  private backend = 'sqlite';
+  private indexFile: string | undefined;
+  private remoteUrl: string | undefined;
+  private indexName = 'default';
+  private count = 5;
+  private similarityThreshold = 0.0;
+  private filterTags: string[] = [];
+  private noResultsMessage = "No information found for '{query}'";
+  private responsePrefix = '';
+  private responsePostfix = '';
+  private maxContentLength = 32768;
+  private responseFormatCallback: ResponseFormatCallback | undefined;
+  private description = 'Search the knowledge base for information';
+  private verbose = false;
+  private searchAvailable = false;
+  private useRemote = false;
+  private remoteBaseUrl: string | undefined;
+  private remoteAuth: { user: string; pass: string } | undefined;
+
+  // In-memory index state
   private _documents: DocumentEntry[] = [];
   private _tokenizedDocs: string[][] = [];
   private _docTfs: Map<string, number>[] = [];
@@ -176,42 +371,156 @@ export class NativeVectorSearchSkill extends SkillBase {
   private _indexed = false;
 
   /**
-   * @param config - Optional configuration; supports `documents` array of {id, text, metadata?}.
+   * @param config - Optional configuration (see `getParameterSchema()`).
    */
   constructor(config?: SkillConfig) {
     super('native_vector_search', config);
-    this._loadDocuments();
   }
 
   override getInstanceKey(): string {
-    const toolName = this.getConfig<string | undefined>('tool_name', undefined);
-    return toolName ? `${this.skillName}_${toolName}` : this.skillName;
+    const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
+    const indexFile = this.getConfig<string>('index_file', 'default');
+    return `${this.skillName}_${toolName}_${indexFile}`;
   }
 
-  /** @returns Manifest with config schema for the documents array. */
+  override async setup(): Promise<void> {
+    // Config
+    this.toolName = this.getConfig<string>('tool_name', 'search_knowledge');
+    this.backend = this.getConfig<string>('backend', 'sqlite');
+    this.indexFile = this.getConfig<string | undefined>('index_file', undefined);
+    this.count = this.getConfig<number>('count', 5);
+    this.similarityThreshold = this.getConfig<number>('similarity_threshold', 0.0);
+    this.filterTags = this.getConfig<string[]>('tags', []) ?? [];
+    this.noResultsMessage = this.getConfig<string>(
+      'no_results_message',
+      "No information found for '{query}'",
+    );
+    this.responsePrefix = this.getConfig<string>('response_prefix', '');
+    this.responsePostfix = this.getConfig<string>('response_postfix', '');
+    this.maxContentLength = this.getConfig<number>('max_content_length', 32768);
+    this.responseFormatCallback = this.getConfig<ResponseFormatCallback | undefined>(
+      'response_format_callback',
+      undefined,
+    );
+    this.description = this.getConfig<string>(
+      'description',
+      'Search the knowledge base for information',
+    );
+    this.verbose = this.getConfig<boolean>('verbose', false);
+
+    // Remote search configuration
+    this.remoteUrl = this.getConfig<string | undefined>('remote_url', undefined);
+    this.indexName = this.getConfig<string>('index_name', 'default');
+
+    // Parse auth from URL if present
+    if (this.remoteUrl) {
+      try {
+        const parsed = new URL(this.remoteUrl);
+        if (parsed.username && parsed.password) {
+          this.remoteAuth = {
+            user: decodeURIComponent(parsed.username),
+            pass: decodeURIComponent(parsed.password),
+          };
+          parsed.username = '';
+          parsed.password = '';
+          this.remoteBaseUrl = parsed.toString().replace(/\/+$/, '');
+        } else {
+          this.remoteBaseUrl = this.remoteUrl.replace(/\/+$/, '');
+        }
+      } catch {
+        this.remoteBaseUrl = this.remoteUrl;
+      }
+    }
+
+    // Remote mode — validate and skip heavy local setup
+    if (this.remoteUrl) {
+      this.useRemote = true;
+      try {
+        const response = await this._fetchWithAuth(
+          `${this.remoteBaseUrl}/health`,
+          { method: 'GET' },
+        );
+        if (response.status === 200) {
+          log.info('native_vector_search: remote server available', {
+            url: this.remoteBaseUrl,
+          });
+          this.searchAvailable = true;
+          return;
+        }
+        if (response.status === 401) {
+          log.error('native_vector_search: remote auth failed');
+        } else {
+          log.error('native_vector_search: remote server returned non-200', {
+            status: response.status,
+          });
+        }
+        this.searchAvailable = false;
+      } catch (err) {
+        log.error('native_vector_search: failed to connect to remote', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        this.searchAvailable = false;
+      }
+      return;
+    }
+
+    // Local / in-memory mode
+    this.useRemote = false;
+    this._loadDocuments();
+    this.searchAvailable = this._indexed;
+
+    if (this.verbose) {
+      log.info('native_vector_search: local index loaded', {
+        docCount: this._documents.length,
+        indexed: this._indexed,
+      });
+    }
+  }
+
+  override getHints(): string[] {
+    const hints = ['search', 'find', 'look up', 'documentation', 'knowledge base'];
+    const extra = this.getConfig<string[]>('hints', []) ?? [];
+    return [...hints, ...extra];
+  }
+
+  override getGlobalData(): Record<string, unknown> {
+    const globalData: Record<string, unknown> = {};
+    if (this._indexed) {
+      globalData['search_stats'] = {
+        doc_count: this._documents.length,
+        backend: this.useRemote ? 'remote' : this.backend,
+      };
+    }
+    return globalData;
+  }
+
+  override async cleanup(): Promise<void> {
+    this._documents = [];
+    this._tokenizedDocs = [];
+    this._docTfs = [];
+    this._idf = new Map();
+    this._indexed = false;
+  }
+
+  /** @returns Manifest for the native vector search skill. */
   getManifest(): SkillManifest {
     return {
       name: 'native_vector_search',
       description:
-        'In-memory document search using TF-IDF-like word overlap scoring. No external dependencies or API keys required.',
+        'Search document indexes using vector similarity and keyword search (local or remote)',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'vector', 'tfidf', 'documents', 'local', 'knowledge'],
-      configSchema: {
-        documents: {
-          type: 'array',
-          description:
-            'Array of documents to index: [{ id: string, text: string, metadata?: object }].',
-        },
-      },
     };
   }
 
   /**
-   * Load and index documents from configuration.
+   * Load and TF-IDF-index documents from config.
+   * Applies `global_tags` to every document's tag list.
    */
   private _loadDocuments(): void {
-    const docs = this.getConfig<DocumentEntry[]>('documents', []);
+    const docs = this.getConfig<DocumentEntry[]>('documents', []) ?? [];
+    const globalTags = this.getConfig<string[]>('global_tags', []) ?? [];
 
     if (!Array.isArray(docs) || docs.length === 0) {
       this._documents = [];
@@ -219,134 +528,320 @@ export class NativeVectorSearchSkill extends SkillBase {
       return;
     }
 
-    this._documents = docs.filter(
-      (d) => d && typeof d.id === 'string' && typeof d.text === 'string' && d.text.trim().length > 0,
-    );
+    this._documents = docs
+      .filter(
+        (d) =>
+          d &&
+          typeof d.id === 'string' &&
+          typeof d.text === 'string' &&
+          d.text.trim().length > 0,
+      )
+      .map((d) => ({
+        ...d,
+        tags: Array.from(new Set([...(d.tags ?? []), ...globalTags])),
+      }));
 
-    // Tokenize all documents
     this._tokenizedDocs = this._documents.map((doc) => tokenize(doc.text));
-
-    // Compute TF for each document
     this._docTfs = this._tokenizedDocs.map((tokens) => termFrequency(tokens));
-
-    // Compute IDF across the corpus
     this._idf = inverseDocumentFrequency(this._tokenizedDocs);
-
-    this._indexed = true;
+    this._indexed = this._documents.length > 0;
   }
 
-  /** @returns A single `search_documents` tool that searches indexed documents by text similarity. */
+  /** @returns A single search tool using the configured `tool_name` (default `search_knowledge`). */
   getTools(): SkillToolDefinition[] {
+    const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
+    const defaultCount = this.getConfig<number>('count', 5);
+    const description = this.getConfig<string>(
+      'description',
+      'Search the knowledge base for information',
+    );
+
     return [
       {
-        name: 'search_documents',
-        description:
-          'Search through the indexed documents for the most relevant results matching your query. Uses text similarity scoring to rank results.',
+        name: toolName,
+        description,
         parameters: {
           query: {
             type: 'string',
-            description: 'The search query or question.',
+            description: 'Search query or question',
           },
-          top_k: {
-            type: 'number',
-            description: 'Number of top results to return (1-20). Defaults to 3.',
+          count: {
+            type: 'integer',
+            description: `Number of results to return (default: ${defaultCount})`,
+            default: defaultCount,
           },
         },
         required: ['query'],
-        handler: (args: Record<string, unknown>) => {
-          const query = args.query as string | undefined;
-          const topK = args.top_k as number | undefined;
-
-          if (!query || typeof query !== 'string' || query.trim().length === 0) {
-            return new FunctionResult('Please provide a search query.');
-          }
-
-          if (!this._indexed || this._documents.length === 0) {
-            return new FunctionResult(
-              'No documents are loaded for searching. Configure the skill with a "documents" array.',
-            );
-          }
-
-          const k = Math.max(1, Math.min(20, topK ?? 3));
-          const queryTokens = tokenize(query);
-
-          if (queryTokens.length === 0) {
-            return new FunctionResult(
-              'The search query did not contain any meaningful search terms. Please try a more specific query.',
-            );
-          }
-
-          // Score all documents
-          const scored: ScoredDocument[] = this._documents.map((doc, i) => ({
-            document: doc,
-            score: scoreTfIdf(queryTokens, this._docTfs[i], this._idf),
-          }));
-
-          // Sort by score descending
-          scored.sort((a, b) => b.score - a.score);
-
-          // Filter out zero-score results and take top k
-          const results = scored.filter((s) => s.score > 0).slice(0, k);
-
-          if (results.length === 0) {
-            return new FunctionResult(
-              `No relevant documents found for "${query}". Try different search terms.`,
-            );
-          }
-
-          const parts: string[] = [
-            `Found ${results.length} relevant document(s) for "${query}":`,
-            '',
-          ];
-
-          for (let i = 0; i < results.length; i++) {
-            const { document, score } = results[i];
-            const relevance = score.toFixed(4);
-
-            parts.push(`--- Result ${i + 1} (ID: ${document.id}, relevance: ${relevance}) ---`);
-
-            // Truncate long texts for readability
-            const maxLen = 500;
-            const text = document.text.trim();
-            if (text.length > maxLen) {
-              parts.push(text.slice(0, maxLen) + '...');
-            } else {
-              parts.push(text);
-            }
-
-            if (document.metadata && Object.keys(document.metadata).length > 0) {
-              const metaStr = Object.entries(document.metadata)
-                .map(([k, v]) => `${k}: ${String(v)}`)
-                .join(', ');
-              parts.push(`[Metadata: ${metaStr}]`);
-            }
-
-            parts.push('');
-          }
-
-          return new FunctionResult(parts.join('\n').trim());
-        },
+        handler: async (
+          args: Record<string, unknown>,
+          rawData: Record<string, unknown>,
+        ) => this._searchHandler(args, rawData),
       },
     ];
   }
 
   /** @returns Prompt section describing the local document search capabilities. */
   protected override _getPromptSections(): SkillPromptSection[] {
+    const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
     const docCount = this._documents.length;
+    const mode = this.useRemote ? 'remote search server' : 'local document indexes';
 
     return [
       {
-        title: 'Document Search',
-        body: `You have access to a local collection of ${docCount} document(s) that can be searched for relevant information.`,
+        title: 'Knowledge Search',
+        body: `You can search ${mode} using the ${toolName} tool${docCount > 0 ? ` over ${docCount} indexed document(s)` : ''}.`,
         bullets: [
-          'Use the search_documents tool when the user asks about topics that may be covered in the indexed documents.',
-          'You can specify how many results to return with the top_k parameter.',
-          'Results are ranked by text relevance using word overlap scoring.',
-          'Synthesize information from multiple results when appropriate.',
-          'If no results are found, the query terms may not match the document content. Try different wording.',
+          `Use the ${toolName} tool when users ask questions about topics that might be in the indexed documents`,
+          'Search for relevant information using clear, specific queries',
+          'Provide helpful summaries of the search results',
+          'If no results are found, suggest the user try rephrasing their question or try another knowledge source',
         ],
       },
     ];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Search
+  // ---------------------------------------------------------------------------
+
+  private async _searchHandler(
+    args: Record<string, unknown>,
+    _rawData: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    if (!this.searchAvailable && !this.useRemote) {
+      // In-memory path — we should still be usable if docs were loaded synchronously
+      // (constructor path); otherwise report unavailability.
+      if (!this._indexed || this._documents.length === 0) {
+        return new FunctionResult(
+          'No documents are loaded for searching. Configure the skill with a "documents" array or a "remote_url".',
+        );
+      }
+    }
+
+    const query =
+      typeof args['query'] === 'string' ? (args['query'] as string).trim() : '';
+    if (!query) {
+      return new FunctionResult('Please provide a search query.');
+    }
+
+    const count = Math.max(
+      1,
+      Math.min(20, (args['count'] as number | undefined) ?? this.count),
+    );
+
+    let results: SearchResult[] = [];
+    try {
+      if (this.useRemote) {
+        results = await this._searchRemote(query, count);
+      } else {
+        results = this._searchLocal(query, count);
+      }
+    } catch (err) {
+      log.error('native_vector_search: search error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return new FunctionResult(
+        "I'm sorry, I encountered an issue while searching. Please try rephrasing your question.",
+      );
+    }
+
+    if (results.length === 0) {
+      let msg = this.noResultsMessage.replace('{query}', query);
+      if (this.responsePrefix) msg = `${this.responsePrefix} ${msg}`;
+      if (this.responsePostfix) msg = `${msg} ${this.responsePostfix}`;
+
+      if (typeof this.responseFormatCallback === 'function') {
+        try {
+          const formatted = this.responseFormatCallback({
+            response: msg,
+            query,
+            results: [],
+            args,
+            count,
+            skill: this,
+          });
+          if (typeof formatted === 'string') msg = formatted;
+        } catch (err) {
+          log.error(
+            'native_vector_search: response_format_callback error (no results)',
+            { error: err instanceof Error ? err.message : String(err) },
+          );
+        }
+      }
+      return new FunctionResult(msg);
+    }
+
+    // Compose formatted response with per-result truncation
+    const responseParts: string[] = [];
+    if (this.responsePrefix) responseParts.push(this.responsePrefix);
+    responseParts.push(`Found ${results.length} relevant results for '${query}':\n`);
+
+    const estimatedOverheadPerResult = 300;
+    const prefixPostfixOverhead =
+      this.responsePrefix.length + this.responsePostfix.length + 100;
+    const totalOverhead =
+      results.length * estimatedOverheadPerResult + prefixPostfixOverhead;
+    const available = this.maxContentLength - totalOverhead;
+    const perResultLimit =
+      results.length > 0
+        ? Math.max(500, Math.floor(available / results.length))
+        : 1000;
+
+    results.forEach((r, i) => {
+      const filename =
+        (r.metadata['filename'] as string | undefined) ?? `result-${i + 1}`;
+      const section = (r.metadata['section'] as string | undefined) ?? '';
+      const score = r.score;
+      let content = r.content;
+      if (content.length > perResultLimit) {
+        content = content.slice(0, perResultLimit) + '...';
+      }
+      const tags = r.tags ?? (r.metadata['tags'] as string[] | undefined) ?? [];
+
+      let text = `**Result ${i + 1}** (from ${filename}`;
+      if (section) text += `, section: ${section}`;
+      if (tags.length > 0) text += `, tags: ${tags.join(', ')}`;
+      text += `, relevance: ${score.toFixed(2)})\n${content}\n`;
+      responseParts.push(text);
+    });
+
+    if (this.responsePostfix) responseParts.push(this.responsePostfix);
+
+    let response = responseParts.join('\n');
+
+    if (typeof this.responseFormatCallback === 'function') {
+      try {
+        const formatted = this.responseFormatCallback({
+          response,
+          query,
+          results,
+          args,
+          count,
+          skill: this,
+        });
+        if (typeof formatted === 'string') {
+          response = formatted;
+        } else {
+          log.warn(
+            'native_vector_search: response_format_callback returned non-string',
+          );
+        }
+      } catch (err) {
+        log.error('native_vector_search: response_format_callback error', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return new FunctionResult(response);
+  }
+
+  private _searchLocal(query: string, count: number): SearchResult[] {
+    const queryTokens = tokenize(query);
+    if (queryTokens.length === 0) return [];
+
+    const scored = this._documents.map((doc, i) => ({
+      doc,
+      score: scoreTfIdf(queryTokens, this._docTfs[i], this._idf),
+    }));
+
+    const filtered = scored
+      .filter((s) => s.score > this.similarityThreshold)
+      .filter((s) => {
+        if (this.filterTags.length === 0) return true;
+        const docTags = s.doc.tags ?? [];
+        return this.filterTags.some((t) => docTags.includes(t));
+      });
+
+    filtered.sort((a, b) => b.score - a.score);
+
+    return filtered.slice(0, count).map(({ doc, score }) => ({
+      content: doc.text,
+      score,
+      metadata: {
+        filename: doc.id,
+        ...(doc.metadata ?? {}),
+        tags: doc.tags ?? [],
+      },
+      tags: doc.tags ?? [],
+    }));
+  }
+
+  /** Perform search against a remote search server. */
+  private async _searchRemote(
+    query: string,
+    count: number,
+  ): Promise<SearchResult[]> {
+    if (!this.remoteBaseUrl) return [];
+
+    try {
+      const body = {
+        query,
+        index_name: this.indexName,
+        count,
+        similarity_threshold: this.similarityThreshold,
+        tags: this.filterTags,
+      };
+
+      const response = await this._fetchWithAuth(
+        `${this.remoteBaseUrl}/search`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      );
+
+      if (response.status !== 200) {
+        log.error('native_vector_search: remote search failed', {
+          status: response.status,
+        });
+        return [];
+      }
+      const data = (await response.json()) as {
+        results?: Array<{
+          content: string;
+          score: number;
+          metadata: Record<string, unknown>;
+          tags?: string[];
+        }>;
+      };
+      return (data.results ?? []).map((r) => ({
+        content: r.content,
+        score: r.score,
+        metadata: r.metadata,
+        tags: r.tags,
+      }));
+    } catch (err) {
+      log.error('native_vector_search: remote search error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+  }
+
+  /** Fetch wrapper that injects Basic auth if configured. */
+  private async _fetchWithAuth(
+    url: string,
+    init: RequestInit = {},
+  ): Promise<Response> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...((init.headers as Record<string, string>) ?? {}),
+    };
+    if (this.remoteAuth) {
+      const creds = Buffer.from(
+        `${this.remoteAuth.user}:${this.remoteAuth.pass}`,
+      ).toString('base64');
+      headers['Authorization'] = `Basic ${creds}`;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30_000);
+    try {
+      return await fetch(url, { ...init, headers, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
   }
 }
 

--- a/src/skills/builtin/native_vector_search.ts
+++ b/src/skills/builtin/native_vector_search.ts
@@ -26,6 +26,7 @@ import type {
 import type { AgentBase } from '../../AgentBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
 import { getLogger } from '../../Logger.js';
+import { validateUrl } from '../../SecurityUtils.js';
 
 const log = getLogger('NativeVectorSearchSkill');
 
@@ -454,10 +455,25 @@ export class NativeVectorSearchSkill extends SkillBase {
     // Remote mode — validate and skip heavy local setup
     if (this.remoteUrl) {
       this.useRemote = true;
+
+      // SSRF protection — match Python skills/native_vector_search/skill.py:292-293
+      // which calls validate_url(self.remote_url) and refuses to connect to
+      // private/loopback/metadata-endpoint URLs in multi-tenant deployments.
+      const urlToValidate = this.remoteBaseUrl ?? this.remoteUrl;
+      if (!(await validateUrl(urlToValidate))) {
+        log.error('native_vector_search: remote_url rejected by SSRF protection', {
+          url: urlToValidate,
+        });
+        return false;
+      }
+
       try {
+        // Python uses timeout=5 for the health check (skill.py). Don't wait
+        // the default 30s if a misconfigured remote URL doesn't respond.
         const response = await this._fetchWithAuth(
           `${this.remoteBaseUrl}/health`,
           { method: 'GET' },
+          5000,
         );
         if (response.status === 200) {
           log.info('native_vector_search: remote server available', {
@@ -494,7 +510,12 @@ export class NativeVectorSearchSkill extends SkillBase {
         indexed: this._indexed,
       });
     }
-    return this.searchAvailable;
+    // Python parity (skill.py): local mode always returns True from setup()
+    // even when no documents are loaded. The skill stays registered and the
+    // "no information found" fallback fires at query time instead of the
+    // skill being rejected entirely. This lets a caller fix the config and
+    // reload without tearing down the agent.
+    return true;
   }
 
   override getHints(): string[] {
@@ -531,6 +552,8 @@ export class NativeVectorSearchSkill extends SkillBase {
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'vector', 'tfidf', 'documents', 'local', 'knowledge'],
+      requiredEnvVars: [],
+      requiredPackages: [],
     };
   }
 
@@ -861,6 +884,7 @@ export class NativeVectorSearchSkill extends SkillBase {
   private async _fetchWithAuth(
     url: string,
     init: RequestInit = {},
+    timeoutMs = 30_000,
   ): Promise<Response> {
     const headers: Record<string, string> = {
       Accept: 'application/json',
@@ -873,7 +897,7 @@ export class NativeVectorSearchSkill extends SkillBase {
       headers['Authorization'] = `Basic ${creds}`;
     }
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 30_000);
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
       return await fetch(url, { ...init, headers, signal: controller.signal });
     } finally {

--- a/src/skills/builtin/play_background_file.ts
+++ b/src/skills/builtin/play_background_file.ts
@@ -24,12 +24,10 @@ import { FunctionResult } from '../../FunctionResult.js';
  * `default_file_url` and `allowed_domains` config options.
  */
 export class PlayBackgroundFileSkill extends SkillBase {
-  /**
-   * @param config - Optional configuration; supports `default_file_url` and `allowed_domains`.
-   */
-  constructor(config?: SkillConfig) {
-    super('play_background_file', config);
-  }
+  // Python ground truth: skills/play_background_file/skill.py
+  static override SKILL_NAME = 'play_background_file';
+  static override SKILL_DESCRIPTION = 'Control background file playback';
+  static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {

--- a/src/skills/builtin/play_background_file.ts
+++ b/src/skills/builtin/play_background_file.ts
@@ -8,7 +8,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -44,29 +43,6 @@ export class PlayBackgroundFileSkill extends SkillBase {
     };
   }
 
-  /** @returns Manifest with config schema for default_file_url and allowed_domains. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'play_background_file',
-      description:
-        'Controls background audio playback during calls. Play hold music, ambient sounds, or any audio file in the background.',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['audio', 'playback', 'background', 'music', 'call-control'],
-      configSchema: {
-        default_file_url: {
-          type: 'string',
-          description:
-            'Default audio file URL to use when no URL is specified.',
-        },
-        allowed_domains: {
-          type: 'array',
-          description:
-            'List of allowed domains for audio file URLs. If set, only URLs from these domains are accepted.',
-        },
-      },
-    };
-  }
 
   /** @returns Two tools: `play_background` to start audio and `stop_background` to stop it. */
   getTools(): SkillToolDefinition[] {

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -14,7 +14,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillConfig,
   ParameterSchemaEntry,
@@ -59,6 +58,13 @@ const STRIP_TAG_REGEXES: RegExp[] = [
  * follow_patterns, user_agent, headers, follow_robots_txt, cache_enabled).
  */
 export class SpiderSkill extends SkillBase {
+  // Python ground truth: skills/spider/skill.py:~140-145
+  // REQUIRED_PACKAGES = ["lxml"] in Python; TS uses cheerio.
+  static override SKILL_NAME = 'spider';
+  static override SKILL_DESCRIPTION = 'Fast web scraping and crawling capabilities';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = ['cheerio'];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
@@ -188,13 +194,6 @@ export class SpiderSkill extends SkillBase {
   private cache: Map<string, CachedResponse> | null = null;
   private readonly cacheMaxSize = 100;
 
-  /**
-   * @param config - Optional configuration; see `getParameterSchema()` for accepted keys.
-   */
-  constructor(config?: SkillConfig) {
-    super('spider', config);
-  }
-
   override getInstanceKey(): string {
     const toolName = this.getConfig<string>('tool_name', this.skillName);
     return `${this.skillName}_${toolName}`;
@@ -298,22 +297,6 @@ export class SpiderSkill extends SkillBase {
       this.cache.clear();
     }
     log.info('spider: cleaned up');
-  }
-
-  /** @returns Manifest describing the Spider skill capabilities and config. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'spider',
-      description: 'Fast web scraping and crawling capabilities',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['scraping', 'web', 'spider', 'content', 'extraction'],
-      requiredEnvVars: [],
-      // Python declares REQUIRED_PACKAGES = ["lxml"]; the TS equivalent is
-      // cheerio which we import at module load. Declaring it in the manifest
-      // lets validatePackages() surface missing-dep errors meaningfully.
-      requiredPackages: ['cheerio'],
-    };
   }
 
   /** @returns Three tools: `scrape_url`, `crawl_site`, and `extract_structured_data`. */

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -321,7 +321,10 @@ export class SpiderSkill extends SkillBase {
           },
         },
         required: ['url'],
-        handler: async (args: Record<string, unknown>) => this._scrapeUrlHandler(args),
+        handler: async (
+          args: Record<string, unknown>,
+          rawData: Record<string, unknown>,
+        ) => this._scrapeUrlHandler(args, rawData),
       },
       {
         name: `${prefix}crawl_site`,
@@ -333,7 +336,10 @@ export class SpiderSkill extends SkillBase {
           },
         },
         required: ['start_url'],
-        handler: async (args: Record<string, unknown>) => this._crawlSiteHandler(args),
+        handler: async (
+          args: Record<string, unknown>,
+          rawData: Record<string, unknown>,
+        ) => this._crawlSiteHandler(args, rawData),
       },
       {
         name: `${prefix}extract_structured_data`,
@@ -345,8 +351,10 @@ export class SpiderSkill extends SkillBase {
           },
         },
         required: ['url'],
-        handler: async (args: Record<string, unknown>) =>
-          this._extractStructuredHandler(args),
+        handler: async (
+          args: Record<string, unknown>,
+          rawData: Record<string, unknown>,
+        ) => this._extractStructuredHandler(args, rawData),
       },
     ];
   }
@@ -420,9 +428,16 @@ export class SpiderSkill extends SkillBase {
     }
   }
 
-  /** Extract plain text from an HTML body using simple regex stripping. */
-  private _fastTextExtract(html: string): string {
-    let stripped = html;
+  /**
+   * Extract plain text from a fetched response using simple regex stripping.
+   *
+   * Takes a {@link CachedResponse} (TS equivalent of `requests.Response`) to
+   * match Python's `_fast_text_extract(response)` capability surface — the
+   * response-like object exposes `url`, `status`, and `body` for callers that
+   * need to branch on status/content-type.
+   */
+  private _fastTextExtract(response: CachedResponse): string {
+    let stripped = response.body;
     for (const re of STRIP_TAG_REGEXES) {
       stripped = stripped.replace(re, ' ');
     }
@@ -590,6 +605,7 @@ export class SpiderSkill extends SkillBase {
 
   private async _scrapeUrlHandler(
     args: Record<string, unknown>,
+    _rawData: Record<string, unknown>,
   ): Promise<FunctionResult> {
     const urlArg = args['url'];
     if (typeof urlArg !== 'string' || urlArg.trim().length === 0) {
@@ -628,7 +644,7 @@ export class SpiderSkill extends SkillBase {
         );
       }
       // All other extract types fall through to fast-text-like extraction
-      const content = this._fastTextExtract(cached.body);
+      const content = this._fastTextExtract(cached);
 
       if (!content) {
         return new FunctionResult(`No content extracted from ${url}`);
@@ -650,6 +666,7 @@ export class SpiderSkill extends SkillBase {
 
   private async _crawlSiteHandler(
     args: Record<string, unknown>,
+    _rawData: Record<string, unknown>,
   ): Promise<FunctionResult> {
     const startArg = args['start_url'];
     if (typeof startArg !== 'string' || startArg.trim().length === 0) {
@@ -704,7 +721,7 @@ export class SpiderSkill extends SkillBase {
 
       visited.add(url);
 
-      const content = this._fastTextExtract(cached.body);
+      const content = this._fastTextExtract(cached);
       if (content) {
         results.push({
           url,
@@ -785,6 +802,7 @@ export class SpiderSkill extends SkillBase {
 
   private async _extractStructuredHandler(
     args: Record<string, unknown>,
+    _rawData: Record<string, unknown>,
   ): Promise<FunctionResult> {
     const urlArg = args['url'];
     if (typeof urlArg !== 'string' || urlArg.trim().length === 0) {

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -20,7 +20,7 @@ import type {
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
-import { resolveAndValidateUrl, MAX_SKILL_INPUT_LENGTH } from '../../SecurityUtils.js';
+import { resolveAndValidateUrl, validateUrl, MAX_SKILL_INPUT_LENGTH } from '../../SecurityUtils.js';
 import { getLogger } from '../../Logger.js';
 import * as cheerio from 'cheerio';
 
@@ -129,7 +129,8 @@ export class SpiderSkill extends SkillBase {
         description: 'Custom CSS/XPath selectors for structured extraction',
         default: {},
         required: false,
-      },
+        additionalProperties: { type: 'string' },
+      } as ParameterSchemaEntry & { additionalProperties?: unknown },
       follow_patterns: {
         type: 'array',
         description: 'URL patterns to follow when crawling',
@@ -148,11 +149,16 @@ export class SpiderSkill extends SkillBase {
         description: 'Additional HTTP headers',
         default: {},
         required: false,
-      },
+        additionalProperties: { type: 'string' },
+      } as ParameterSchemaEntry & { additionalProperties?: unknown },
       follow_robots_txt: {
         type: 'boolean',
-        description: 'Whether to respect robots.txt',
-        default: true,
+        // Matches Python's __init__ runtime fallback (skills/spider/skill.py:177
+        // uses `params.get('follow_robots_txt', False)`). Python's schema said
+        // True but the runtime and TS both use False — aligning the schema
+        // eliminates the cross-SDK contract mismatch.
+        description: 'Whether to respect robots.txt (default: false to match Python runtime)',
+        default: false,
         required: false,
       },
       cache_enabled: {
@@ -291,6 +297,7 @@ export class SpiderSkill extends SkillBase {
     if (this.cache) {
       this.cache.clear();
     }
+    log.info('spider: cleaned up');
   }
 
   /** @returns Manifest describing the Spider skill capabilities and config. */
@@ -302,6 +309,10 @@ export class SpiderSkill extends SkillBase {
       author: 'SignalWire',
       tags: ['scraping', 'web', 'spider', 'content', 'extraction'],
       requiredEnvVars: [],
+      // Python declares REQUIRED_PACKAGES = ["lxml"]; the TS equivalent is
+      // cheerio which we import at module load. Declaring it in the manifest
+      // lets validatePackages() surface missing-dep errors meaningfully.
+      requiredPackages: ['cheerio'],
     };
   }
 
@@ -419,37 +430,54 @@ export class SpiderSkill extends SkillBase {
    * need to branch on status/content-type.
    */
   private _fastTextExtract(response: CachedResponse): string {
-    let stripped = response.body;
-    for (const re of STRIP_TAG_REGEXES) {
-      stripped = stripped.replace(re, ' ');
-    }
-    // Remove all remaining tags
-    stripped = stripped.replace(/<[^>]+>/g, ' ');
-    // HTML entity decode (basic)
-    stripped = stripped
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'");
+    try {
+      // Parse through cheerio so every named and numeric HTML entity is
+      // decoded (Python's lxml does this natively). Previously TS only
+      // decoded six hand-coded entities, leaving `&mdash;`, `&#8212;`, etc.
+      // literal in the output.
+      const $ = cheerio.load(response.body);
+      // Strip noise tags before extracting text — matches Python's
+      // lxml drop_tree() on the same 7 tags.
+      for (const tag of [
+        'script',
+        'style',
+        'nav',
+        'header',
+        'footer',
+        'aside',
+        'noscript',
+      ]) {
+        $(tag).remove();
+      }
+      let text = $('body').text();
+      if (!text || text.trim().length === 0) {
+        // Pages without <body> fall through to document-root text.
+        text = $.root().text();
+      }
+      if (this.cleanText) {
+        text = text.replace(WHITESPACE_REGEX, ' ').trim();
+      }
 
-    let text = stripped;
-    if (this.cleanText) {
-      text = text.replace(WHITESPACE_REGEX, ' ').trim();
-    }
+      // Smart truncation
+      if (text.length > this.maxTextLength) {
+        const keepStart = Math.floor((this.maxTextLength * 2) / 3);
+        const keepEnd = Math.floor(this.maxTextLength / 3);
+        text =
+          text.slice(0, keepStart) +
+          '\n\n[...CONTENT TRUNCATED...]\n\n' +
+          text.slice(-keepEnd);
+      }
 
-    // Smart truncation
-    if (text.length > this.maxTextLength) {
-      const keepStart = Math.floor((this.maxTextLength * 2) / 3);
-      const keepEnd = Math.floor(this.maxTextLength / 3);
-      text =
-        text.slice(0, keepStart) +
-        '\n\n[...CONTENT TRUNCATED...]\n\n' +
-        text.slice(-keepEnd);
+      return text;
+    } catch (err) {
+      // Python swallows extraction errors and returns '' so the handler
+      // emits a clean "no content extracted" message instead of bubbling
+      // a parse failure all the way up to the AI.
+      log.error('spider: fast-text extraction failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return '';
     }
-
-    return text;
   }
 
   /**
@@ -529,7 +557,18 @@ export class SpiderSkill extends SkillBase {
     cached: CachedResponse,
     selectors: Record<string, string>,
   ): Record<string, unknown> {
-    const $ = cheerio.load(cached.body);
+    let $: cheerio.CheerioAPI;
+    try {
+      $ = cheerio.load(cached.body);
+    } catch (err) {
+      // Python returns `{'error': str(e)}` from _structured_extract when the
+      // parser fails (skill.py). Surface the same shape so upstream handlers
+      // can branch on `'error' in result`.
+      log.error('spider: structured parse failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
     const result: Record<string, unknown> = {
       url: cached.url,
       status_code: cached.status,
@@ -695,15 +734,22 @@ export class SpiderSkill extends SkillBase {
         });
       }
 
-      // Extract links if not at max depth
+      // Extract links if not at max depth. Use cheerio so we correctly
+      // pick up unquoted and oddly-whitespaced href attributes that the
+      // regex path missed (Python skills/spider/skill.py:487 uses lxml
+      // xpath('//a[@href]/@href') which has the same robustness).
       if (depth < maxDepth) {
         try {
-          const hrefRe = /<a\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*>/gi;
-          let match: RegExpExecArray | null;
-          while ((match = hrefRe.exec(cached.body)) !== null) {
+          const $links = cheerio.load(cached.body);
+          const hrefs: string[] = [];
+          $links('a[href]').each((_, el) => {
+            const href = $links(el).attr('href');
+            if (href) hrefs.push(href);
+          });
+          for (const href of hrefs) {
             let absoluteUrl: string;
             try {
-              absoluteUrl = new URL(match[1], url).toString();
+              absoluteUrl = new URL(href, url).toString();
             } catch {
               continue;
             }
@@ -719,6 +765,16 @@ export class SpiderSkill extends SkillBase {
               const absHost = new URL(absoluteUrl).host;
               if (absHost !== startHost) continue;
             } catch {
+              continue;
+            }
+
+            // SSRF hardening — discovered links must pass the same
+            // validation the entry URL did. Prevents a crafted page from
+            // bouncing the crawler into internal/metadata endpoints.
+            if (!(await validateUrl(absoluteUrl))) {
+              log.debug('spider: skipping discovered URL rejected by SSRF', {
+                url: absoluteUrl,
+              });
               continue;
             }
 

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -64,12 +64,6 @@ export class SpiderSkill extends SkillBase {
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
       ...super.getParameterSchema(),
-      api_key: {
-        type: 'string',
-        description: 'Spider API key (optional; empowers future hosted-Spider backend).',
-        hidden: true,
-        env_var: 'SPIDER_API_KEY',
-      },
       delay: {
         type: 'number',
         description: 'Delay between requests in seconds',
@@ -119,7 +113,7 @@ export class SpiderSkill extends SkillBase {
       max_text_length: {
         type: 'integer',
         description: 'Maximum text length to return',
-        default: 10000,
+        default: 3000,
         required: false,
         min: 100,
         max: 100000,
@@ -146,7 +140,7 @@ export class SpiderSkill extends SkillBase {
       user_agent: {
         type: 'string',
         description: 'User agent string for requests',
-        default: 'Spider/1.0 (SignalWire AI Agent)',
+        default: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
         required: false,
       },
       headers: {
@@ -173,16 +167,16 @@ export class SpiderSkill extends SkillBase {
   // Runtime state, populated in setup()
   private delay = 0.1;
   private concurrentRequests = 5;
-  private timeoutSec = 5;
+  private timeout = 5;
   private maxPages = 1;
   private maxDepth = 0;
   private extractType = 'fast_text';
-  private maxTextLength = 10000;
+  private maxTextLength = 3000;
   private cleanText = true;
   private cacheEnabled = true;
   private followRobotsTxt = true;
-  private userAgent = 'Spider/1.0 (SignalWire AI Agent)';
-  private extraHeaders: Record<string, string> = {};
+  private userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+  private headers: Record<string, string> = {};
   private selectors: Record<string, string> = {};
   private compiledFollowPatterns: RegExp[] = [];
   private cache: Map<string, CachedResponse> | null = null;
@@ -204,7 +198,7 @@ export class SpiderSkill extends SkillBase {
     // Performance
     this.delay = this.getConfig<number>('delay', 0.1);
     this.concurrentRequests = this.getConfig<number>('concurrent_requests', 5);
-    this.timeoutSec = this.getConfig<number>('timeout', 5);
+    this.timeout = this.getConfig<number>('timeout', 5);
 
     // Crawl limits
     this.maxPages = this.getConfig<number>('max_pages', 1);
@@ -212,10 +206,11 @@ export class SpiderSkill extends SkillBase {
 
     // Content processing
     this.extractType = this.getConfig<string>('extract_type', 'fast_text');
-    // Use schema-authoritative default (10000). Python has an internal
-    // inconsistency (schema: 10000, __init__ fallback: 3000); the schema is
-    // the API contract per the validated findings.
-    this.maxTextLength = this.getConfig<number>('max_text_length', 10000);
+    // Python has an internal inconsistency (schema: 10000, __init__ fallback:
+    // 3000). The effective runtime default is 3000 because Python reads via
+    // `self.params.get('max_text_length', 3000)` and schema defaults are not
+    // applied. Use 3000 for parity. Follow-up: reconcile Python schema vs init.
+    this.maxTextLength = this.getConfig<number>('max_text_length', 3000);
     this.cleanText = this.getConfig<boolean>('clean_text', true);
 
     // Features
@@ -223,12 +218,12 @@ export class SpiderSkill extends SkillBase {
     this.followRobotsTxt = this.getConfig<boolean>('follow_robots_txt', false);
     this.userAgent = this.getConfig<string>(
       'user_agent',
-      'Spider/1.0 (SignalWire AI Agent)',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
     );
 
     // Optional headers + user-agent merge
     const headers = this.getConfig<Record<string, string>>('headers', {}) ?? {};
-    this.extraHeaders = { ...headers, 'User-Agent': this.userAgent };
+    this.headers = { ...headers, 'User-Agent': this.userAgent };
 
     // Selectors for structured extraction
     this.selectors = this.getConfig<Record<string, string>>('selectors', {}) ?? {};
@@ -386,11 +381,11 @@ export class SpiderSkill extends SkillBase {
     }
 
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeoutSec * 1000);
+    const timer = setTimeout(() => controller.abort(), this.timeout * 1000);
     try {
       const response = await fetch(url, {
         method: 'GET',
-        headers: this.extraHeaders,
+        headers: this.headers,
         signal: controller.signal,
       });
 

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -16,13 +16,13 @@ import { SkillBase } from '../SkillBase.js';
 import type {
   SkillManifest,
   SkillToolDefinition,
-  SkillPromptSection,
   SkillConfig,
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
 import { resolveAndValidateUrl, MAX_SKILL_INPUT_LENGTH } from '../../SecurityUtils.js';
 import { getLogger } from '../../Logger.js';
+import * as cheerio from 'cheerio';
 
 const log = getLogger('SpiderSkill');
 
@@ -108,7 +108,7 @@ export class SpiderSkill extends SkillBase {
         description: 'Content extraction method',
         default: 'fast_text',
         required: false,
-        enum: ['fast_text', 'clean_text', 'full_text', 'html', 'custom'],
+        enum: ['fast_text', 'clean_text', 'full_text', 'html', 'markdown', 'structured', 'custom'],
       },
       max_text_length: {
         type: 'integer',
@@ -359,24 +359,6 @@ export class SpiderSkill extends SkillBase {
     ];
   }
 
-  /** @returns Prompt section describing web scraping capabilities and content limits. */
-  protected override _getPromptSections(): SkillPromptSection[] {
-    return [
-      {
-        title: 'Web Page Scraping',
-        body: 'You can scrape and extract content from web pages.',
-        bullets: [
-          'Use the scrape_url tool to fetch content from any public web page.',
-          'Use the crawl_site tool to crawl multiple pages starting from a URL.',
-          'Use the extract_structured_data tool with configured selectors for structured data.',
-          'Provide a full URL starting with http:// or https://.',
-          `Text content is limited to ${this.maxTextLength} characters.`,
-          'Summarize the scraped content for the user rather than reading it verbatim.',
-        ],
-      },
-    ];
-  }
-
   // ---------------------------------------------------------------------------
   // Internal helpers
   // ---------------------------------------------------------------------------
@@ -471,115 +453,94 @@ export class SpiderSkill extends SkillBase {
   }
 
   /**
-   * Extract a value for a CSS-like or XPath-like selector. Returns best-effort text
-   * from elements matched by a very small subset of selectors (tag name, `.class`,
-   * `#id`, or attribute-based `[attr="value"]`).
+   * Extract a value using a CSS selector (via cheerio) or XPath-like
+   * selector (`//tag`). Mirrors Python `_structured_extract`'s selector
+   * branching: selectors starting with `/` are treated as XPath (tag-name
+   * subset), everything else is full CSS via cheerio's querySelector-style
+   * engine.
    */
-  private _applySimpleSelector(html: string, selector: string): string[] {
-    // Very small CSS selector engine — tag name or tag + class/id selector
-    // Patterns like: "h1", "title", ".foo", "#id", "div.classname", "meta[name='description']"
-    const trimmedSel = selector.trim();
-    if (!trimmedSel) return [];
-
-    // Support XPath-like selectors like "//title/text()" by extracting tag names
-    if (trimmedSel.startsWith('/')) {
-      const tagMatch = /\/\/([a-zA-Z][a-zA-Z0-9]*)/.exec(trimmedSel);
-      if (tagMatch) {
-        return this._extractTagText(html, tagMatch[1]);
-      }
-      return [];
-    }
-
-    // ID selector: #id
-    const idMatch = /^#([a-zA-Z][\w-]*)$/.exec(trimmedSel);
-    if (idMatch) {
-      const id = idMatch[1];
-      const re = new RegExp(
-        `<([a-zA-Z][a-zA-Z0-9]*)[^>]*\\bid\\s*=\\s*["']${this._escapeRegex(id)}["'][^>]*>([\\s\\S]*?)</\\1>`,
-        'gi',
-      );
-      return this._collectInnerText(html, re);
-    }
-
-    // Class selector: .class
-    const classMatch = /^\.([a-zA-Z][\w-]*)$/.exec(trimmedSel);
-    if (classMatch) {
-      const cls = classMatch[1];
-      const re = new RegExp(
-        `<([a-zA-Z][a-zA-Z0-9]*)[^>]*\\bclass\\s*=\\s*["'][^"']*\\b${this._escapeRegex(cls)}\\b[^"']*["'][^>]*>([\\s\\S]*?)</\\1>`,
-        'gi',
-      );
-      return this._collectInnerText(html, re);
-    }
-
-    // Tag with attribute: tag[attr="value"]
-    const tagAttrMatch =
-      /^([a-zA-Z][a-zA-Z0-9]*)\[([a-zA-Z_][\w-]*)\s*=\s*["']([^"']*)["']\]$/.exec(
-        trimmedSel,
-      );
-    if (tagAttrMatch) {
-      const [, tag, attr, value] = tagAttrMatch;
-      const re = new RegExp(
-        `<${tag}[^>]*\\b${attr}\\s*=\\s*["']${this._escapeRegex(value)}["'][^>]*>([\\s\\S]*?)</${tag}>`,
-        'gi',
-      );
-      return this._collectInnerText(html, re, 1);
-    }
-
-    // Simple tag: h1, p, title, ...
-    const tagMatch = /^([a-zA-Z][a-zA-Z0-9]*)$/.exec(trimmedSel);
-    if (tagMatch) {
-      return this._extractTagText(html, tagMatch[1]);
-    }
-
-    return [];
-  }
-
-  private _extractTagText(html: string, tag: string): string[] {
-    const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'gi');
-    return this._collectInnerText(html, re, 1);
-  }
-
-  private _collectInnerText(
-    html: string,
-    re: RegExp,
-    groupIndex = 2,
+  private _applySelector(
+    $: cheerio.CheerioAPI,
+    selector: string,
   ): string[] {
-    const results: string[] = [];
-    let match: RegExpExecArray | null;
-    while ((match = re.exec(html)) !== null) {
-      const inner = match[groupIndex] ?? match[match.length - 1] ?? '';
-      const text = inner
-        .replace(/<[^>]+>/g, ' ')
-        .replace(WHITESPACE_REGEX, ' ')
-        .trim();
-      if (text) results.push(text);
+    const trimmed = selector.trim();
+    if (!trimmed) return [];
+
+    if (trimmed.startsWith('/')) {
+      // Subset of XPath supported in Python's lxml path — `//tag`, `//tag/text()`.
+      const tagMatch = /\/\/([a-zA-Z][a-zA-Z0-9]*)/.exec(trimmed);
+      if (!tagMatch) return [];
+      return $(tagMatch[1])
+        .toArray()
+        .map((el) => $(el).text().trim())
+        .filter((t) => t.length > 0);
     }
-    return results;
+
+    return $(trimmed)
+      .toArray()
+      .map((el) => $(el).text().trim())
+      .filter((t) => t.length > 0);
   }
 
-  private _escapeRegex(s: string): string {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  /** Markdown extraction using cheerio. Mirrors Python `_markdown_extract`. */
+  private _markdownExtract(response: CachedResponse): string {
+    try {
+      const $ = cheerio.load(response.body);
+
+      // Remove unwanted tags
+      for (const tag of ['script', 'style', 'nav', 'header', 'footer', 'aside']) {
+        $(tag).remove();
+      }
+
+      const parts: string[] = [];
+      const title = $('title').first().text().trim();
+      if (title) parts.push(`# ${title}\n`);
+
+      $('h1, h2, h3, h4, h5, h6, p, li, code, pre').each((_, el) => {
+        const tag = (el as { tagName: string }).tagName.toLowerCase();
+        const text = $(el).text().trim();
+        if (!text) return;
+        if (/^h[1-6]$/.test(tag)) {
+          const level = Number(tag[1]);
+          parts.push(`\n${'#'.repeat(level)} ${text}\n`);
+        } else if (tag === 'p') {
+          parts.push(`\n${text}\n`);
+        } else if (tag === 'li') {
+          parts.push(`- ${text}`);
+        } else if (tag === 'code' || tag === 'pre') {
+          parts.push(`\n\`\`\`\n${text}\n\`\`\`\n`);
+        }
+      });
+
+      let text = parts.join('\n');
+      if (text.length > this.maxTextLength) {
+        text = text.slice(0, this.maxTextLength) + '\n\n[...TRUNCATED...]';
+      }
+      return text;
+    } catch (err) {
+      log.error('spider: markdown extraction error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return this._fastTextExtract(response);
+    }
   }
 
   private _structuredExtract(
     cached: CachedResponse,
     selectors: Record<string, string>,
   ): Record<string, unknown> {
+    const $ = cheerio.load(cached.body);
     const result: Record<string, unknown> = {
       url: cached.url,
       status_code: cached.status,
-      title: '',
+      title: $('title').first().text().trim(),
       data: {},
     };
-
-    const titleMatches = this._extractTagText(cached.body, 'title');
-    if (titleMatches.length > 0) result['title'] = titleMatches[0];
 
     const data: Record<string, unknown> = {};
     for (const [field, selector] of Object.entries(selectors)) {
       try {
-        const values = this._applySimpleSelector(cached.body, selector);
+        const values = this._applySelector($, selector);
         if (values.length === 0) {
           data[field] = null;
         } else if (values.length === 1) {
@@ -643,8 +604,10 @@ export class SpiderSkill extends SkillBase {
           `Extracted structured data from ${url}: ${JSON.stringify(result)}`,
         );
       }
-      // All other extract types fall through to fast-text-like extraction
-      const content = this._fastTextExtract(cached);
+      const content =
+        this.extractType === 'markdown'
+          ? this._markdownExtract(cached)
+          : this._fastTextExtract(cached);
 
       if (!content) {
         return new FunctionResult(`No content extracted from ${url}`);

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -200,7 +200,7 @@ export class SpiderSkill extends SkillBase {
     return `${this.skillName}_${toolName}`;
   }
 
-  override async setup(): Promise<void> {
+  override async setup(): Promise<boolean> {
     // Performance
     this.delay = this.getConfig<number>('delay', 0.1);
     this.concurrentRequests = this.getConfig<number>('concurrent_requests', 5);
@@ -239,22 +239,22 @@ export class SpiderSkill extends SkillBase {
     // Validate numeric ranges
     if (this.delay < 0) {
       log.error('spider: delay cannot be negative', { delay: this.delay });
-      return;
+      return false;
     }
     if (this.concurrentRequests < 1 || this.concurrentRequests > 20) {
       log.error(
         'spider: concurrent_requests must be between 1 and 20',
         { concurrent_requests: this.concurrentRequests },
       );
-      return;
+      return false;
     }
     if (this.maxPages < 1) {
       log.error('spider: max_pages must be at least 1', { max_pages: this.maxPages });
-      return;
+      return false;
     }
     if (this.maxDepth < 0) {
       log.error('spider: max_depth cannot be negative', { max_depth: this.maxDepth });
-      return;
+      return false;
     }
 
     // Pre-compile follow patterns
@@ -276,6 +276,7 @@ export class SpiderSkill extends SkillBase {
       max_pages: this.maxPages,
       max_depth: this.maxDepth,
     });
+    return true;
   }
 
   override getHints(): string[] {

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -1,9 +1,15 @@
 /**
- * Spider Skill - Scrapes webpage content using the Spider API.
+ * Spider Skill - Fast web scraping and crawling capabilities.
  *
- * Tier 3 built-in skill: requires SPIDER_API_KEY environment variable.
- * Uses the Spider API to fetch and extract content from web pages,
- * optionally filtering by CSS selector.
+ * Tier 2 built-in skill. Port of the Python `SpiderSkill` that performs
+ * HTTP scraping via `fetch`, lightweight HTML-to-text extraction, and
+ * breadth-first crawling with configurable limits. Supports three tools:
+ *
+ * - `scrape_url` — single-page text/markdown extraction
+ * - `crawl_site` — breadth-first crawl from a start URL
+ * - `extract_structured_data` — CSS/XPath-like structured extraction
+ *
+ * Multiple instances are supported; use `tool_name` in config to differentiate.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -20,232 +26,329 @@ import { getLogger } from '../../Logger.js';
 
 const log = getLogger('SpiderSkill');
 
-/** A single crawl result from the Spider API. */
-interface SpiderResult {
-  /** Raw HTML content of the page. */
-  content?: string;
-  /** Markdown-formatted content. */
-  markdown?: string;
-  /** Plain text content. */
-  text?: string;
-  /** Resolved URL of the crawled page. */
-  url?: string;
-  /** HTTP status code of the crawl. */
-  status?: number;
-  /** Error message if the crawl failed. */
-  error?: string;
+/** Cached response entry used by the internal LRU cache. */
+interface CachedResponse {
+  /** Resolved URL (after redirects). */
+  url: string;
+  /** HTTP status code. */
+  status: number;
+  /** Raw HTML body (or best-effort text for non-HTML). */
+  body: string;
 }
 
-/** Response from the Spider API, which may be an array, single result, or error object. */
-type SpiderResponse = SpiderResult[] | SpiderResult | { error: string; message?: string };
+const WHITESPACE_REGEX = /\s+/g;
+
+/** Tags stripped from HTML before text extraction. */
+const STRIP_TAG_REGEXES: RegExp[] = [
+  /<script\b[^>]*>[\s\S]*?<\/script>/gi,
+  /<style\b[^>]*>[\s\S]*?<\/style>/gi,
+  /<nav\b[^>]*>[\s\S]*?<\/nav>/gi,
+  /<header\b[^>]*>[\s\S]*?<\/header>/gi,
+  /<footer\b[^>]*>[\s\S]*?<\/footer>/gi,
+  /<aside\b[^>]*>[\s\S]*?<\/aside>/gi,
+  /<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi,
+];
 
 /**
- * Scrapes webpage content using the Spider API.
+ * Fast web scraping skill optimized for speed and token efficiency.
  *
- * Tier 3 built-in skill. Requires the `SPIDER_API_KEY` environment variable.
- * Extracts text, markdown, or HTML from any public URL, with optional CSS
- * selector filtering. Supports `max_content_length` config option.
+ * Multi-instance capable. Port of the Python `SpiderSkill` with three tools:
+ * `scrape_url`, `crawl_site`, and `extract_structured_data`. Configuration
+ * mirrors the Python schema (delay, concurrent_requests, timeout, max_pages,
+ * max_depth, extract_type, max_text_length, clean_text, selectors,
+ * follow_patterns, user_agent, headers, follow_robots_txt, cache_enabled).
  */
 export class SpiderSkill extends SkillBase {
+  static override SUPPORTS_MULTIPLE_INSTANCES = true;
+
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
       ...super.getParameterSchema(),
       api_key: {
         type: 'string',
-        description: 'Spider API key.',
+        description: 'Spider API key (optional; empowers future hosted-Spider backend).',
         hidden: true,
         env_var: 'SPIDER_API_KEY',
-        required: true,
       },
-      max_content_length: {
+      delay: {
         type: 'number',
-        description: 'Maximum length of returned content in characters.',
-        default: 5000,
+        description: 'Delay between requests in seconds',
+        default: 0.1,
+        required: false,
+        min: 0,
+      },
+      concurrent_requests: {
+        type: 'integer',
+        description: 'Number of concurrent requests allowed',
+        default: 5,
+        required: false,
+        min: 1,
+        max: 20,
+      },
+      timeout: {
+        type: 'integer',
+        description: 'Request timeout in seconds',
+        default: 5,
+        required: false,
+        min: 1,
+        max: 60,
+      },
+      max_pages: {
+        type: 'integer',
+        description: 'Maximum number of pages to scrape',
+        default: 1,
+        required: false,
+        min: 1,
+        max: 100,
+      },
+      max_depth: {
+        type: 'integer',
+        description: 'Maximum crawl depth (0 = single page only)',
+        default: 0,
+        required: false,
+        min: 0,
+        max: 5,
+      },
+      extract_type: {
+        type: 'string',
+        description: 'Content extraction method',
+        default: 'fast_text',
+        required: false,
+        enum: ['fast_text', 'clean_text', 'full_text', 'html', 'custom'],
+      },
+      max_text_length: {
+        type: 'integer',
+        description: 'Maximum text length to return',
+        default: 10000,
+        required: false,
+        min: 100,
+        max: 100000,
+      },
+      clean_text: {
+        type: 'boolean',
+        description: 'Whether to clean extracted text',
+        default: true,
+        required: false,
+      },
+      selectors: {
+        type: 'object',
+        description: 'Custom CSS/XPath selectors for structured extraction',
+        default: {},
+        required: false,
+      },
+      follow_patterns: {
+        type: 'array',
+        description: 'URL patterns to follow when crawling',
+        default: [],
+        required: false,
+        items: { type: 'string' },
+      },
+      user_agent: {
+        type: 'string',
+        description: 'User agent string for requests',
+        default: 'Spider/1.0 (SignalWire AI Agent)',
+        required: false,
+      },
+      headers: {
+        type: 'object',
+        description: 'Additional HTTP headers',
+        default: {},
+        required: false,
+      },
+      follow_robots_txt: {
+        type: 'boolean',
+        description: 'Whether to respect robots.txt',
+        default: true,
+        required: false,
+      },
+      cache_enabled: {
+        type: 'boolean',
+        description: 'Whether to cache scraped pages',
+        default: true,
+        required: false,
       },
     };
   }
 
+  // Runtime state, populated in setup()
+  private delay = 0.1;
+  private concurrentRequests = 5;
+  private timeoutSec = 5;
+  private maxPages = 1;
+  private maxDepth = 0;
+  private extractType = 'fast_text';
+  private maxTextLength = 10000;
+  private cleanText = true;
+  private cacheEnabled = true;
+  private followRobotsTxt = true;
+  private userAgent = 'Spider/1.0 (SignalWire AI Agent)';
+  private extraHeaders: Record<string, string> = {};
+  private selectors: Record<string, string> = {};
+  private compiledFollowPatterns: RegExp[] = [];
+  private cache: Map<string, CachedResponse> | null = null;
+  private readonly cacheMaxSize = 100;
+
   /**
-   * @param config - Optional configuration; supports `max_content_length`.
+   * @param config - Optional configuration; see `getParameterSchema()` for accepted keys.
    */
   constructor(config?: SkillConfig) {
     super('spider', config);
   }
 
-  /** @returns Manifest declaring SPIDER_API_KEY as required and config schema for max_content_length. */
+  override getInstanceKey(): string {
+    const toolName = this.getConfig<string>('tool_name', this.skillName);
+    return `${this.skillName}_${toolName}`;
+  }
+
+  override async setup(): Promise<void> {
+    // Performance
+    this.delay = this.getConfig<number>('delay', 0.1);
+    this.concurrentRequests = this.getConfig<number>('concurrent_requests', 5);
+    this.timeoutSec = this.getConfig<number>('timeout', 5);
+
+    // Crawl limits
+    this.maxPages = this.getConfig<number>('max_pages', 1);
+    this.maxDepth = this.getConfig<number>('max_depth', 0);
+
+    // Content processing
+    this.extractType = this.getConfig<string>('extract_type', 'fast_text');
+    // Match Python __init__ fallback (3000) even though schema default is 10000
+    this.maxTextLength = this.getConfig<number>('max_text_length', 3000);
+    this.cleanText = this.getConfig<boolean>('clean_text', true);
+
+    // Features
+    this.cacheEnabled = this.getConfig<boolean>('cache_enabled', true);
+    this.followRobotsTxt = this.getConfig<boolean>('follow_robots_txt', false);
+    this.userAgent = this.getConfig<string>(
+      'user_agent',
+      'Spider/1.0 (SignalWire AI Agent)',
+    );
+
+    // Optional headers + user-agent merge
+    const headers = this.getConfig<Record<string, string>>('headers', {}) ?? {};
+    this.extraHeaders = { ...headers, 'User-Agent': this.userAgent };
+
+    // Selectors for structured extraction
+    this.selectors = this.getConfig<Record<string, string>>('selectors', {}) ?? {};
+
+    // Setup cache
+    this.cache = this.cacheEnabled ? new Map() : null;
+
+    // Validate numeric ranges
+    if (this.delay < 0) {
+      log.error('spider: delay cannot be negative', { delay: this.delay });
+      return;
+    }
+    if (this.concurrentRequests < 1 || this.concurrentRequests > 20) {
+      log.error(
+        'spider: concurrent_requests must be between 1 and 20',
+        { concurrent_requests: this.concurrentRequests },
+      );
+      return;
+    }
+    if (this.maxPages < 1) {
+      log.error('spider: max_pages must be at least 1', { max_pages: this.maxPages });
+      return;
+    }
+    if (this.maxDepth < 0) {
+      log.error('spider: max_depth cannot be negative', { max_depth: this.maxDepth });
+      return;
+    }
+
+    // Pre-compile follow patterns
+    this.compiledFollowPatterns = [];
+    const patterns = this.getConfig<string[]>('follow_patterns', []) ?? [];
+    for (const pattern of patterns) {
+      try {
+        this.compiledFollowPatterns.push(new RegExp(pattern));
+      } catch (err) {
+        log.error('spider: invalid follow pattern', {
+          pattern,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    log.info('spider: configured', {
+      delay: this.delay,
+      max_pages: this.maxPages,
+      max_depth: this.maxDepth,
+    });
+  }
+
+  override getHints(): string[] {
+    return [
+      'scrape',
+      'crawl',
+      'extract',
+      'web page',
+      'website',
+      'get content from',
+      'fetch data from',
+      'spider',
+    ];
+  }
+
+  override async cleanup(): Promise<void> {
+    if (this.cache) {
+      this.cache.clear();
+    }
+  }
+
+  /** @returns Manifest describing the Spider skill capabilities and config. */
   getManifest(): SkillManifest {
     return {
       name: 'spider',
-      description:
-        'Scrapes webpage content using the Spider API. Extracts text, markdown, or HTML from any public URL.',
+      description: 'Fast web scraping and crawling capabilities',
       version: '1.0.0',
       author: 'SignalWire',
-      tags: ['scraping', 'web', 'spider', 'content', 'extraction', 'external'],
-      requiredEnvVars: ['SPIDER_API_KEY'],
-      configSchema: {
-        max_content_length: {
-          type: 'number',
-          description:
-            'Maximum length of returned content in characters. Defaults to 5000.',
-          default: 5000,
-        },
-      },
+      tags: ['scraping', 'web', 'spider', 'content', 'extraction'],
+      requiredEnvVars: [],
     };
   }
 
-  /** @returns A single `scrape_url` tool that extracts content from a web page. */
+  /** @returns Three tools: `scrape_url`, `crawl_site`, and `extract_structured_data`. */
   getTools(): SkillToolDefinition[] {
-    const maxContentLength = this.getConfig<number>('max_content_length', 5000);
+    const toolPrefix = this.getConfig<string>('tool_name', '');
+    const prefix = toolPrefix ? `${toolPrefix}_` : '';
 
     return [
       {
-        name: 'scrape_url',
-        description:
-          'Scrape and extract content from a web page URL. Returns the page text or markdown content.',
+        name: `${prefix}scrape_url`,
+        description: 'Extract text content from a single web page',
         parameters: {
           url: {
             type: 'string',
-            description: 'The full URL of the web page to scrape (must start with http:// or https://).',
-          },
-          selector: {
-            type: 'string',
-            description:
-              'Optional CSS selector to extract specific content from the page (e.g., "article", ".main-content", "#body").',
+            description: 'The URL to scrape',
           },
         },
         required: ['url'],
-        handler: async (args: Record<string, unknown>) => {
-          const url = args.url as string | undefined;
-          const selector = args.selector as string | undefined;
-
-          if (!url || typeof url !== 'string' || url.trim().length === 0) {
-            return new FunctionResult('Please provide a URL to scrape.');
-          }
-
-          if (url.length > MAX_SKILL_INPUT_LENGTH) {
-            return new FunctionResult('Input URL is too long.');
-          }
-
-          const trimmedUrl = url.trim();
-          if (!trimmedUrl.startsWith('http://') && !trimmedUrl.startsWith('https://')) {
-            return new FunctionResult(
-              'Invalid URL. Please provide a full URL starting with http:// or https://.',
-            );
-          }
-
-          // SSRF protection: validate URL does not resolve to a private IP
-          const allowPrivate = process.env['SWML_ALLOW_PRIVATE_URLS'] === 'true';
-          try {
-            await resolveAndValidateUrl(trimmedUrl, allowPrivate);
-          } catch {
-            return new FunctionResult(
-              'The provided URL could not be validated. Please check the URL and try again.',
-            );
-          }
-
-          const apiKey = process.env['SPIDER_API_KEY'];
-          if (!apiKey) {
-            return new FunctionResult(
-              'Service is not configured. Please contact your administrator.',
-            );
-          }
-
-          try {
-            const requestBody: Record<string, unknown> = {
-              url: trimmedUrl,
-              return_format: 'markdown',
-            };
-
-            if (selector && typeof selector === 'string' && selector.trim().length > 0) {
-              requestBody['css_selector'] = selector.trim();
-            }
-
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), 30_000);
-            let response: Response;
-            try {
-              response = await fetch('https://api.spider.cloud/crawl', {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                  'Authorization': `Bearer ${apiKey}`,
-                },
-                body: JSON.stringify(requestBody),
-                signal: controller.signal,
-              });
-            } finally {
-              clearTimeout(timeout);
-            }
-
-            if (!response.ok) {
-              log.error('spider_api_error', { status: response.status });
-              return new FunctionResult(
-                'The web scraping service encountered an error. Please try again later.',
-              );
-            }
-
-            const data = (await response.json()) as SpiderResponse;
-
-            // Handle error responses
-            if (!Array.isArray(data) && 'error' in data) {
-              log.error('spider_scraping_failed', { error: data.error });
-              return new FunctionResult(
-                'The web scraping service could not process the request. Please try again later.',
-              );
-            }
-
-            // Extract content from result
-            let content = '';
-            const result: SpiderResult = Array.isArray(data) ? data[0] : data;
-
-            if (!result) {
-              return new FunctionResult(
-                `No content could be extracted from "${trimmedUrl}".`,
-              );
-            }
-
-            if (result.error) {
-              log.error('spider_result_error', { error: result.error });
-              return new FunctionResult(
-                `Could not extract content from the requested page. Please try again later.`,
-              );
-            }
-
-            // Prefer markdown > text > content
-            content = result.markdown ?? result.text ?? result.content ?? '';
-
-            if (content.trim().length === 0) {
-              return new FunctionResult(
-                `The page at "${trimmedUrl}" returned no extractable content.`,
-              );
-            }
-
-            // Truncate if necessary
-            let truncated = false;
-            if (content.length > maxContentLength) {
-              content = content.slice(0, maxContentLength);
-              truncated = true;
-            }
-
-            const parts: string[] = [
-              `Content from ${trimmedUrl}:`,
-              '',
-              content.trim(),
-            ];
-
-            if (truncated) {
-              parts.push('');
-              parts.push(`[Content truncated to ${maxContentLength} characters]`);
-            }
-
-            return new FunctionResult(parts.join('\n'));
-          } catch (err) {
-            log.error('scrape_url_failed', { error: err instanceof Error ? err.message : String(err) });
-            return new FunctionResult(
-              'The request could not be completed. Please try again.',
-            );
-          }
+        handler: async (args: Record<string, unknown>) => this._scrapeUrlHandler(args),
+      },
+      {
+        name: `${prefix}crawl_site`,
+        description: 'Crawl multiple pages starting from a URL',
+        parameters: {
+          start_url: {
+            type: 'string',
+            description: 'Starting URL for the crawl',
+          },
         },
+        required: ['start_url'],
+        handler: async (args: Record<string, unknown>) => this._crawlSiteHandler(args),
+      },
+      {
+        name: `${prefix}extract_structured_data`,
+        description: 'Extract specific data from a web page using selectors',
+        parameters: {
+          url: {
+            type: 'string',
+            description: 'The URL to scrape',
+          },
+        },
+        required: ['url'],
+        handler: async (args: Record<string, unknown>) =>
+          this._extractStructuredHandler(args),
       },
     ];
   }
@@ -258,14 +361,483 @@ export class SpiderSkill extends SkillBase {
         body: 'You can scrape and extract content from web pages.',
         bullets: [
           'Use the scrape_url tool to fetch content from any public web page.',
+          'Use the crawl_site tool to crawl multiple pages starting from a URL.',
+          'Use the extract_structured_data tool with configured selectors for structured data.',
           'Provide a full URL starting with http:// or https://.',
-          'Optionally specify a CSS selector to extract specific parts of the page.',
-          'Content is returned as markdown text for easy reading.',
-          `Content is limited to ${this.getConfig<number>('max_content_length', 5000)} characters.`,
+          `Text content is limited to ${this.maxTextLength} characters.`,
           'Summarize the scraped content for the user rather than reading it verbatim.',
         ],
       },
     ];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Fetch a URL with caching and timeout handling. Returns null on failure. */
+  private async _fetchUrl(url: string): Promise<CachedResponse | null> {
+    if (this.cacheEnabled && this.cache?.has(url)) {
+      log.debug('spider: cache hit', { url });
+      return this.cache.get(url)!;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutSec * 1000);
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: this.extraHeaders,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        log.error('spider: fetch failed', { url, status: response.status });
+        return null;
+      }
+
+      const body = await response.text();
+      const cached: CachedResponse = {
+        url: response.url || url,
+        status: response.status,
+        body,
+      };
+
+      if (this.cacheEnabled && this.cache) {
+        if (this.cache.size >= this.cacheMaxSize) {
+          const oldest = this.cache.keys().next().value;
+          if (oldest !== undefined) this.cache.delete(oldest);
+        }
+        this.cache.set(url, cached);
+      }
+      return cached;
+    } catch (err) {
+      log.error('spider: fetch error', {
+        url,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Extract plain text from an HTML body using simple regex stripping. */
+  private _fastTextExtract(html: string): string {
+    let stripped = html;
+    for (const re of STRIP_TAG_REGEXES) {
+      stripped = stripped.replace(re, ' ');
+    }
+    // Remove all remaining tags
+    stripped = stripped.replace(/<[^>]+>/g, ' ');
+    // HTML entity decode (basic)
+    stripped = stripped
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'");
+
+    let text = stripped;
+    if (this.cleanText) {
+      text = text.replace(WHITESPACE_REGEX, ' ').trim();
+    }
+
+    // Smart truncation
+    if (text.length > this.maxTextLength) {
+      const keepStart = Math.floor((this.maxTextLength * 2) / 3);
+      const keepEnd = Math.floor(this.maxTextLength / 3);
+      text =
+        text.slice(0, keepStart) +
+        '\n\n[...CONTENT TRUNCATED...]\n\n' +
+        text.slice(-keepEnd);
+    }
+
+    return text;
+  }
+
+  /**
+   * Extract a value for a CSS-like or XPath-like selector. Returns best-effort text
+   * from elements matched by a very small subset of selectors (tag name, `.class`,
+   * `#id`, or attribute-based `[attr="value"]`).
+   */
+  private _applySimpleSelector(html: string, selector: string): string[] {
+    // Very small CSS selector engine — tag name or tag + class/id selector
+    // Patterns like: "h1", "title", ".foo", "#id", "div.classname", "meta[name='description']"
+    const trimmedSel = selector.trim();
+    if (!trimmedSel) return [];
+
+    // Support XPath-like selectors like "//title/text()" by extracting tag names
+    if (trimmedSel.startsWith('/')) {
+      const tagMatch = /\/\/([a-zA-Z][a-zA-Z0-9]*)/.exec(trimmedSel);
+      if (tagMatch) {
+        return this._extractTagText(html, tagMatch[1]);
+      }
+      return [];
+    }
+
+    // ID selector: #id
+    const idMatch = /^#([a-zA-Z][\w-]*)$/.exec(trimmedSel);
+    if (idMatch) {
+      const id = idMatch[1];
+      const re = new RegExp(
+        `<([a-zA-Z][a-zA-Z0-9]*)[^>]*\\bid\\s*=\\s*["']${this._escapeRegex(id)}["'][^>]*>([\\s\\S]*?)</\\1>`,
+        'gi',
+      );
+      return this._collectInnerText(html, re);
+    }
+
+    // Class selector: .class
+    const classMatch = /^\.([a-zA-Z][\w-]*)$/.exec(trimmedSel);
+    if (classMatch) {
+      const cls = classMatch[1];
+      const re = new RegExp(
+        `<([a-zA-Z][a-zA-Z0-9]*)[^>]*\\bclass\\s*=\\s*["'][^"']*\\b${this._escapeRegex(cls)}\\b[^"']*["'][^>]*>([\\s\\S]*?)</\\1>`,
+        'gi',
+      );
+      return this._collectInnerText(html, re);
+    }
+
+    // Tag with attribute: tag[attr="value"]
+    const tagAttrMatch =
+      /^([a-zA-Z][a-zA-Z0-9]*)\[([a-zA-Z_][\w-]*)\s*=\s*["']([^"']*)["']\]$/.exec(
+        trimmedSel,
+      );
+    if (tagAttrMatch) {
+      const [, tag, attr, value] = tagAttrMatch;
+      const re = new RegExp(
+        `<${tag}[^>]*\\b${attr}\\s*=\\s*["']${this._escapeRegex(value)}["'][^>]*>([\\s\\S]*?)</${tag}>`,
+        'gi',
+      );
+      return this._collectInnerText(html, re, 1);
+    }
+
+    // Simple tag: h1, p, title, ...
+    const tagMatch = /^([a-zA-Z][a-zA-Z0-9]*)$/.exec(trimmedSel);
+    if (tagMatch) {
+      return this._extractTagText(html, tagMatch[1]);
+    }
+
+    return [];
+  }
+
+  private _extractTagText(html: string, tag: string): string[] {
+    const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'gi');
+    return this._collectInnerText(html, re, 1);
+  }
+
+  private _collectInnerText(
+    html: string,
+    re: RegExp,
+    groupIndex = 2,
+  ): string[] {
+    const results: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(html)) !== null) {
+      const inner = match[groupIndex] ?? match[match.length - 1] ?? '';
+      const text = inner
+        .replace(/<[^>]+>/g, ' ')
+        .replace(WHITESPACE_REGEX, ' ')
+        .trim();
+      if (text) results.push(text);
+    }
+    return results;
+  }
+
+  private _escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  private _structuredExtract(
+    cached: CachedResponse,
+    selectors: Record<string, string>,
+  ): Record<string, unknown> {
+    const result: Record<string, unknown> = {
+      url: cached.url,
+      status_code: cached.status,
+      title: '',
+      data: {},
+    };
+
+    const titleMatches = this._extractTagText(cached.body, 'title');
+    if (titleMatches.length > 0) result['title'] = titleMatches[0];
+
+    const data: Record<string, unknown> = {};
+    for (const [field, selector] of Object.entries(selectors)) {
+      try {
+        const values = this._applySimpleSelector(cached.body, selector);
+        if (values.length === 0) {
+          data[field] = null;
+        } else if (values.length === 1) {
+          data[field] = values[0];
+        } else {
+          data[field] = values;
+        }
+      } catch (err) {
+        log.warn('spider: selector error', {
+          selector,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        data[field] = null;
+      }
+    }
+    result['data'] = data;
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tool handlers
+  // ---------------------------------------------------------------------------
+
+  private async _scrapeUrlHandler(
+    args: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    const urlArg = args['url'];
+    if (typeof urlArg !== 'string' || urlArg.trim().length === 0) {
+      return new FunctionResult('Please provide a URL to scrape');
+    }
+    const url = urlArg.trim();
+
+    if (url.length > MAX_SKILL_INPUT_LENGTH) {
+      return new FunctionResult('Input URL is too long.');
+    }
+
+    if (!/^https?:\/\//.test(url)) {
+      return new FunctionResult(`Invalid URL: ${url}`);
+    }
+
+    // SSRF protection
+    const allowPrivate = process.env['SWML_ALLOW_PRIVATE_URLS'] === 'true';
+    try {
+      await resolveAndValidateUrl(url, allowPrivate);
+    } catch {
+      return new FunctionResult(
+        'URL rejected: cannot access private or internal URLs',
+      );
+    }
+
+    const cached = await this._fetchUrl(url);
+    if (!cached) {
+      return new FunctionResult(`Failed to fetch ${url}`);
+    }
+
+    try {
+      if (this.extractType === 'structured') {
+        const result = this._structuredExtract(cached, this.selectors);
+        return new FunctionResult(
+          `Extracted structured data from ${url}: ${JSON.stringify(result)}`,
+        );
+      }
+      // All other extract types fall through to fast-text-like extraction
+      const content = this._fastTextExtract(cached.body);
+
+      if (!content) {
+        return new FunctionResult(`No content extracted from ${url}`);
+      }
+
+      const charCount = content.length;
+      const header = `Content from ${url} (${charCount} characters):\n\n`;
+      return new FunctionResult(header + content);
+    } catch (err) {
+      log.error('spider: scrape_url error', {
+        url,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return new FunctionResult(
+        `Error processing ${url}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private async _crawlSiteHandler(
+    args: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    const startArg = args['start_url'];
+    if (typeof startArg !== 'string' || startArg.trim().length === 0) {
+      return new FunctionResult('Please provide a starting URL for the crawl');
+    }
+    const startUrl = startArg.trim();
+
+    if (!/^https?:\/\//.test(startUrl)) {
+      return new FunctionResult(`Invalid URL: ${startUrl}`);
+    }
+
+    const allowPrivate = process.env['SWML_ALLOW_PRIVATE_URLS'] === 'true';
+    try {
+      await resolveAndValidateUrl(startUrl, allowPrivate);
+    } catch {
+      return new FunctionResult(
+        'URL rejected: cannot access private or internal URLs',
+      );
+    }
+
+    const maxDepth = this.maxDepth;
+    const maxPages = this.maxPages;
+
+    if (maxDepth < 0) return new FunctionResult('Max depth cannot be negative');
+    if (maxPages < 1) return new FunctionResult('Max pages must be at least 1');
+
+    const visited = new Set<string>();
+    const toVisit: [string, number][] = [[startUrl, 0]];
+    const results: {
+      url: string;
+      depth: number;
+      contentLength: number;
+      summary: string;
+    }[] = [];
+
+    let startHost: string;
+    try {
+      startHost = new URL(startUrl).host;
+    } catch {
+      return new FunctionResult(`Invalid URL: ${startUrl}`);
+    }
+
+    while (toVisit.length > 0 && visited.size < maxPages) {
+      const next = toVisit.shift();
+      if (!next) break;
+      const [url, depth] = next;
+
+      if (visited.has(url) || depth > maxDepth) continue;
+
+      const cached = await this._fetchUrl(url);
+      if (!cached) continue;
+
+      visited.add(url);
+
+      const content = this._fastTextExtract(cached.body);
+      if (content) {
+        results.push({
+          url,
+          depth,
+          contentLength: content.length,
+          summary:
+            content.length > 500 ? content.slice(0, 500) + '...' : content,
+        });
+      }
+
+      // Extract links if not at max depth
+      if (depth < maxDepth) {
+        try {
+          const hrefRe = /<a\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*>/gi;
+          let match: RegExpExecArray | null;
+          while ((match = hrefRe.exec(cached.body)) !== null) {
+            let absoluteUrl: string;
+            try {
+              absoluteUrl = new URL(match[1], url).toString();
+            } catch {
+              continue;
+            }
+
+            if (this.compiledFollowPatterns.length > 0) {
+              const allowed = this.compiledFollowPatterns.some((re) =>
+                re.test(absoluteUrl),
+              );
+              if (!allowed) continue;
+            }
+
+            try {
+              const absHost = new URL(absoluteUrl).host;
+              if (absHost !== startHost) continue;
+            } catch {
+              continue;
+            }
+
+            if (!visited.has(absoluteUrl)) {
+              toVisit.push([absoluteUrl, depth + 1]);
+            }
+          }
+        } catch (err) {
+          log.warn('spider: link extraction error', {
+            url,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      if (this.delay > 0 && visited.size < maxPages) {
+        await new Promise((resolve) => setTimeout(resolve, this.delay * 1000));
+      }
+    }
+
+    if (results.length === 0) {
+      return new FunctionResult(`No pages could be crawled from ${startUrl}`);
+    }
+
+    const lines: string[] = [
+      `Crawled ${results.length} pages from ${startHost}:`,
+      '',
+    ];
+    results.forEach((r, i) => {
+      lines.push(
+        `${i + 1}. ${r.url} (depth: ${r.depth}, ${r.contentLength} chars)`,
+      );
+      lines.push(`   Summary: ${r.summary.slice(0, 100)}...`);
+      lines.push('');
+    });
+    const totalChars = results.reduce((acc, r) => acc + r.contentLength, 0);
+    lines.push('');
+    lines.push(
+      `Total content: ${totalChars.toLocaleString()} characters across ${results.length} pages`,
+    );
+
+    return new FunctionResult(lines.join('\n'));
+  }
+
+  private async _extractStructuredHandler(
+    args: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    const urlArg = args['url'];
+    if (typeof urlArg !== 'string' || urlArg.trim().length === 0) {
+      return new FunctionResult('Please provide a URL');
+    }
+    const url = urlArg.trim();
+
+    if (!/^https?:\/\//.test(url)) {
+      return new FunctionResult(`Invalid URL: ${url}`);
+    }
+
+    const allowPrivate = process.env['SWML_ALLOW_PRIVATE_URLS'] === 'true';
+    try {
+      await resolveAndValidateUrl(url, allowPrivate);
+    } catch {
+      return new FunctionResult(
+        'URL rejected: cannot access private or internal URLs',
+      );
+    }
+
+    if (!this.selectors || Object.keys(this.selectors).length === 0) {
+      return new FunctionResult(
+        'No selectors configured for structured data extraction',
+      );
+    }
+
+    const cached = await this._fetchUrl(url);
+    if (!cached) {
+      return new FunctionResult(`Failed to fetch ${url}`);
+    }
+
+    const result = this._structuredExtract(cached, this.selectors);
+    if ('error' in result) {
+      return new FunctionResult(`Error extracting data: ${result['error']}`);
+    }
+
+    const lines: string[] = [`Extracted data from ${url}:`, ''];
+    lines.push(`Title: ${(result['title'] as string) || 'N/A'}`);
+    lines.push('');
+
+    const data = result['data'] as Record<string, unknown>;
+    if (data && Object.keys(data).length > 0) {
+      lines.push('Data:');
+      for (const [field, value] of Object.entries(data)) {
+        lines.push(`- ${field}: ${String(value)}`);
+      }
+    } else {
+      lines.push('No data extracted with provided selectors');
+    }
+
+    return new FunctionResult(lines.join('\n'));
   }
 }
 

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -212,8 +212,10 @@ export class SpiderSkill extends SkillBase {
 
     // Content processing
     this.extractType = this.getConfig<string>('extract_type', 'fast_text');
-    // Match Python __init__ fallback (3000) even though schema default is 10000
-    this.maxTextLength = this.getConfig<number>('max_text_length', 3000);
+    // Use schema-authoritative default (10000). Python has an internal
+    // inconsistency (schema: 10000, __init__ fallback: 3000); the schema is
+    // the API contract per the validated findings.
+    this.maxTextLength = this.getConfig<number>('max_text_length', 10000);
     this.cleanText = this.getConfig<boolean>('clean_text', true);
 
     // Features

--- a/src/skills/builtin/swml_transfer.ts
+++ b/src/skills/builtin/swml_transfer.ts
@@ -101,7 +101,7 @@ export class SwmlTransferSkill extends SkillBase {
       parameter_name: {
         type: 'string',
         description: 'Name of the parameter that accepts the transfer type',
-        default: 'destination',
+        default: 'transfer_type',
         required: false,
       },
       parameter_description: {
@@ -112,19 +112,13 @@ export class SwmlTransferSkill extends SkillBase {
       },
       default_message: {
         type: 'string',
-        description: 'Default pre-transfer message said before every transfer.',
-        default: 'Transferring your call now.',
-        required: false,
-      },
-      no_match_message: {
-        type: 'string',
-        description: 'Message returned when no transfer pattern matches.',
+        description: 'Message when no pattern matches',
         default: 'Please specify a valid transfer type.',
         required: false,
       },
       default_post_process: {
         type: 'boolean',
-        description: 'Whether to process no-match message with AI',
+        description: 'Whether to process default message with AI',
         default: false,
         required: false,
       },
@@ -143,10 +137,9 @@ export class SwmlTransferSkill extends SkillBase {
   private patterns: TransferPattern[] = [];
   private toolName = 'transfer_call';
   private toolDescription = 'Transfer call based on pattern matching';
-  private parameterName = 'destination';
+  private parameterName = 'transfer_type';
   private parameterDescription = 'The type of transfer to perform';
-  private defaultMessage = 'Transferring your call now.';
-  private noMatchMessage = 'Please specify a valid transfer type.';
+  private defaultMessage = 'Please specify a valid transfer type.';
   private defaultPostProcess = false;
   private requiredFields: Record<string, string> = {};
   private allowArbitraryOverride: boolean | undefined;
@@ -169,17 +162,13 @@ export class SwmlTransferSkill extends SkillBase {
       'description',
       'Transfer call based on pattern matching',
     );
-    this.parameterName = this.getConfig<string>('parameter_name', 'destination');
+    this.parameterName = this.getConfig<string>('parameter_name', 'transfer_type');
     this.parameterDescription = this.getConfig<string>(
       'parameter_description',
       'The type of transfer to perform',
     );
     this.defaultMessage = this.getConfig<string>(
       'default_message',
-      'Transferring your call now.',
-    );
-    this.noMatchMessage = this.getConfig<string>(
-      'no_match_message',
       'Please specify a valid transfer type.',
     );
     this.defaultPostProcess = this.getConfig<boolean>('default_post_process', false);
@@ -290,10 +279,6 @@ export class SwmlTransferSkill extends SkillBase {
     const defaultMessage = this.getConfig<string>(
       'default_message',
       this.defaultMessage,
-    );
-    const noMatchMessage = this.getConfig<string>(
-      'no_match_message',
-      this.noMatchMessage,
     );
     const defaultPostProcess = this.getConfig<boolean>(
       'default_post_process',
@@ -421,14 +406,14 @@ export class SwmlTransferSkill extends SkillBase {
           if (matchedPattern) {
             return this._buildPatternResult(
               matchedPattern,
-              messageOverride ?? defaultMessage,
+              messageOverride ?? 'Transferring you now...',
               callData,
             );
           }
 
           // 3. Arbitrary destinations
           if (canUseArbitrary) {
-            const msg = messageOverride ?? defaultMessage;
+            const msg = messageOverride ?? 'Transferring you now...';
             const result = new FunctionResult(msg);
             result.swmlTransfer(destination, msg, true);
             if (Object.keys(callData).length > 0) {
@@ -438,7 +423,7 @@ export class SwmlTransferSkill extends SkillBase {
           }
 
           // 4. No match — return fallback message
-          const fallback = new FunctionResult(noMatchMessage);
+          const fallback = new FunctionResult(defaultMessage);
           fallback.postProcess = defaultPostProcess;
           if (Object.keys(callData).length > 0) {
             fallback.updateGlobalData({ call_data: callData });

--- a/src/skills/builtin/swml_transfer.ts
+++ b/src/skills/builtin/swml_transfer.ts
@@ -1,10 +1,13 @@
 /**
- * SWML Transfer Skill - Transfers calls using SWML transfer actions.
+ * SWML Transfer Skill - Transfer calls between agents using SWML with pattern matching.
  *
- * Tier 2 built-in skill: no external dependencies required.
- * Supports both direct destination transfers and named pattern-based transfers.
- * Named patterns allow configuring a set of known transfer destinations
- * that the AI can use by name rather than requiring raw phone numbers or SIP URIs.
+ * Port of the Python `SWMLTransferSkill`. Supports the Python `transfers`
+ * config (regex-keyed dict of per-destination configs with url/address,
+ * message, return_message, post_process, final, from_addr) as well as the
+ * TypeScript-native `patterns` array of friendly-named destinations.
+ *
+ * Either configuration shape works; when both are provided `transfers`
+ * takes precedence (matching the Python API).
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -16,175 +19,434 @@ import type {
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
+import { getLogger } from '../../Logger.js';
 
-/** A named transfer destination pattern with a friendly name and underlying address. */
+const log = getLogger('SwmlTransferSkill');
+
+/** A named transfer destination pattern (TS-style). */
 interface TransferPattern {
-  /** Friendly name for the destination (used by the AI to refer to it). */
+  /** Friendly name for the destination. */
   name: string;
   /** SIP URI, phone number, or agent URL to transfer to. */
   destination: string;
-  /** Optional human-readable description of this destination. */
+  /** Optional description. */
   description?: string;
+  /** Optional pre-transfer message override. */
+  message?: string;
+  /** Optional message shown when returning from the transfer. */
+  returnMessage?: string;
+  /** Whether to AI-process the message. */
+  postProcess?: boolean;
+  /** Whether the transfer is permanent (default) or temporary. */
+  final?: boolean;
+  /** Optional caller-ID override for connect actions. */
+  fromAddr?: string;
+}
+
+/** Per-destination entry in the Python-style `transfers` map. */
+interface TransferConfig {
+  url?: string;
+  address?: string;
+  message?: string;
+  return_message?: string;
+  post_process?: boolean;
+  final?: boolean;
+  from_addr?: string;
 }
 
 /**
- * Transfers calls using SWML transfer actions.
+ * Transfer calls between agents based on pattern matching.
  *
- * Tier 2 built-in skill with no external dependencies. Supports both direct
- * destination transfers and named pattern-based transfers configured via the
- * `patterns` config array. Optionally restricts to named destinations only
- * via `allow_arbitrary`.
+ * Multi-instance capable (distinguished by `tool_name`).
+ * Accepts either Python-style `transfers` config (regex → per-entry config)
+ * or TypeScript-style `patterns` array of named destinations.
  */
 export class SwmlTransferSkill extends SkillBase {
+  static override SUPPORTS_MULTIPLE_INSTANCES = true;
+
+  static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
+    return {
+      ...super.getParameterSchema(),
+      transfers: {
+        type: 'object',
+        description:
+          'Transfer configurations mapping patterns (regex or name) to destination configs. Each value has either url or address, plus optional message/return_message/post_process/final/from_addr.',
+        required: false,
+      },
+      patterns: {
+        type: 'array',
+        description:
+          'Array of named transfer patterns: { name, destination, description?, message?, returnMessage?, postProcess?, final?, fromAddr? }.',
+        required: false,
+        items: { type: 'object' },
+      },
+      allow_arbitrary: {
+        type: 'boolean',
+        description:
+          'Whether to allow transfers to arbitrary destinations not in patterns list.',
+        required: false,
+      },
+      tool_name: {
+        type: 'string',
+        description: 'Name of the transfer tool exposed to the AI.',
+        default: 'transfer_call',
+        required: false,
+      },
+      description: {
+        type: 'string',
+        description: 'Description for the transfer tool',
+        default: 'Transfer call based on pattern matching',
+        required: false,
+      },
+      parameter_name: {
+        type: 'string',
+        description: 'Name of the parameter that accepts the transfer type',
+        default: 'destination',
+        required: false,
+      },
+      parameter_description: {
+        type: 'string',
+        description: 'Description for the transfer type parameter',
+        default: 'The type of transfer to perform',
+        required: false,
+      },
+      default_message: {
+        type: 'string',
+        description: 'Default pre-transfer message said before every transfer.',
+        default: 'Transferring your call now.',
+        required: false,
+      },
+      no_match_message: {
+        type: 'string',
+        description: 'Message returned when no transfer pattern matches.',
+        default: 'Please specify a valid transfer type.',
+        required: false,
+      },
+      default_post_process: {
+        type: 'boolean',
+        description: 'Whether to process no-match message with AI',
+        default: false,
+        required: false,
+      },
+      required_fields: {
+        type: 'object',
+        description:
+          'Additional required fields to collect before transfer (name -> description).',
+        default: {},
+        required: false,
+      },
+    };
+  }
+
+  // Runtime state
+  private transfers: Record<string, TransferConfig> = {};
+  private patterns: TransferPattern[] = [];
+  private toolName = 'transfer_call';
+  private toolDescription = 'Transfer call based on pattern matching';
+  private parameterName = 'destination';
+  private parameterDescription = 'The type of transfer to perform';
+  private defaultMessage = 'Transferring your call now.';
+  private noMatchMessage = 'Please specify a valid transfer type.';
+  private defaultPostProcess = false;
+  private requiredFields: Record<string, string> = {};
+  private allowArbitraryOverride: boolean | undefined;
+
   /**
-   * @param config - Optional configuration; supports `patterns`, `allow_arbitrary`, `default_message`.
+   * @param config - Optional configuration (see `getParameterSchema()`).
    */
   constructor(config?: SkillConfig) {
     super('swml_transfer', config);
   }
 
-  static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
-    return {
-      ...super.getParameterSchema(),
-      patterns: {
-        type: 'array',
-        description: 'Array of named transfer patterns: { name, destination, description? }.',
-        items: { type: 'object', properties: { name: { type: 'string' }, destination: { type: 'string' }, description: { type: 'string' } } },
-      },
-      allow_arbitrary: {
-        type: 'boolean',
-        description: 'Whether to allow transfers to arbitrary destinations not in patterns list.',
-      },
-      default_message: {
-        type: 'string',
-        description: 'Default message to say before transferring.',
-        default: 'Transferring your call now.',
-      },
-    };
+  override getInstanceKey(): string {
+    const toolName = this.getConfig<string>('tool_name', 'transfer_call');
+    return `${this.skillName}_${toolName}`;
   }
 
-  /** @returns Manifest with config schema for patterns, allow_arbitrary, and default_message. */
+  override async setup(): Promise<void> {
+    this.toolName = this.getConfig<string>('tool_name', 'transfer_call');
+    this.toolDescription = this.getConfig<string>(
+      'description',
+      'Transfer call based on pattern matching',
+    );
+    this.parameterName = this.getConfig<string>('parameter_name', 'destination');
+    this.parameterDescription = this.getConfig<string>(
+      'parameter_description',
+      'The type of transfer to perform',
+    );
+    this.defaultMessage = this.getConfig<string>(
+      'default_message',
+      'Transferring your call now.',
+    );
+    this.noMatchMessage = this.getConfig<string>(
+      'no_match_message',
+      'Please specify a valid transfer type.',
+    );
+    this.defaultPostProcess = this.getConfig<boolean>('default_post_process', false);
+    this.requiredFields =
+      this.getConfig<Record<string, string>>('required_fields', {}) ?? {};
+    this.allowArbitraryOverride = this.getConfig<boolean | undefined>(
+      'allow_arbitrary',
+      undefined,
+    );
+
+    // Python-style `transfers` config
+    const transfers =
+      this.getConfig<Record<string, TransferConfig>>('transfers', {}) ?? {};
+    this.transfers = {};
+    for (const [pattern, rawConfig] of Object.entries(transfers)) {
+      if (!rawConfig || typeof rawConfig !== 'object') {
+        log.error('swml_transfer: transfer config is not an object', { pattern });
+        continue;
+      }
+      const config = { ...rawConfig };
+      if (!('url' in config) && !('address' in config)) {
+        log.error(
+          'swml_transfer: transfer config must include either url or address',
+          { pattern },
+        );
+        continue;
+      }
+      if ('url' in config && 'address' in config) {
+        log.error(
+          'swml_transfer: transfer config cannot have both url and address',
+          { pattern },
+        );
+        continue;
+      }
+      if (config.message === undefined) config.message = 'Transferring you now...';
+      if (config.return_message === undefined)
+        config.return_message = 'The transfer is complete. How else can I help you?';
+      if (config.post_process === undefined) config.post_process = true;
+      if (config.final === undefined) config.final = true;
+      this.transfers[pattern] = config;
+    }
+
+    // TS-style patterns array
+    this.patterns = this.getConfig<TransferPattern[]>('patterns', []) ?? [];
+  }
+
+  override getHints(): string[] {
+    const hints: string[] = [];
+
+    // Extract words from regex patterns (Python-style)
+    for (const pattern of Object.keys(this.transfers)) {
+      let clean = pattern;
+      if (clean.startsWith('/')) clean = clean.slice(1);
+      if (clean.endsWith('/')) clean = clean.slice(0, -1);
+      else if (clean.endsWith('/i')) clean = clean.slice(0, -2);
+
+      if (clean && !clean.startsWith('.')) {
+        if (clean.includes('|')) {
+          for (const part of clean.split('|')) {
+            hints.push(part.trim().toLowerCase());
+          }
+        } else {
+          hints.push(clean.toLowerCase());
+        }
+      }
+    }
+
+    // Extract friendly names from patterns
+    for (const p of this.patterns) {
+      if (p && p.name) hints.push(p.name.toLowerCase());
+    }
+
+    hints.push('transfer', 'connect', 'speak to', 'talk to');
+    return hints;
+  }
+
+  /** @returns Manifest for the SWML transfer skill. */
   getManifest(): SkillManifest {
     return {
       name: 'swml_transfer',
-      description:
-        'Transfers calls using SWML transfer actions. Supports direct destination transfers and named pattern-based routing.',
+      description: 'Transfer calls between agents based on pattern matching',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['call-control', 'transfer', 'swml', 'routing'],
-      configSchema: {
-        patterns: {
-          type: 'array',
-          description:
-            'Array of named transfer patterns: { name, destination, description? }. When configured, the AI can transfer to named destinations.',
-          items: {
-            type: 'object',
-            properties: {
-              name: { type: 'string', description: 'Friendly name for the destination.' },
-              destination: { type: 'string', description: 'SIP URI, phone number, or agent URL.' },
-              description: { type: 'string', description: 'Optional description of this destination.' },
-            },
-            required: ['name', 'destination'],
-          },
-        },
-        allow_arbitrary: {
-          type: 'boolean',
-          description:
-            'Whether to allow transfers to arbitrary destinations not in the patterns list. Defaults to true if no patterns are configured, false if patterns are configured.',
-        },
-        default_message: {
-          type: 'string',
-          description:
-            'Default message to say before transferring. Defaults to "Transferring your call now.".',
-        },
-      },
+      requiredEnvVars: [],
     };
   }
 
   /** @returns A `transfer_call` tool, plus `list_transfer_destinations` when patterns are configured. */
   getTools(): SkillToolDefinition[] {
-    const patterns = this.getConfig<TransferPattern[]>('patterns', []);
+    // Rehydrate config for cases where getTools is called without setup()
+    const toolName = this.toolName !== 'transfer_call'
+      ? this.toolName
+      : this.getConfig<string>('tool_name', 'transfer_call');
+    const toolDescription = this.getConfig<string>(
+      'description',
+      this.toolDescription,
+    );
+    const parameterName = this.getConfig<string>(
+      'parameter_name',
+      this.parameterName,
+    );
+    const parameterDescription = this.getConfig<string>(
+      'parameter_description',
+      this.parameterDescription,
+    );
     const defaultMessage = this.getConfig<string>(
       'default_message',
-      'Transferring your call now.',
+      this.defaultMessage,
     );
+    const noMatchMessage = this.getConfig<string>(
+      'no_match_message',
+      this.noMatchMessage,
+    );
+    const defaultPostProcess = this.getConfig<boolean>(
+      'default_post_process',
+      this.defaultPostProcess,
+    );
+    const requiredFields =
+      this.getConfig<Record<string, string>>('required_fields', this.requiredFields) ?? {};
+    const transfers =
+      Object.keys(this.transfers).length > 0
+        ? this.transfers
+        : this.getConfig<Record<string, TransferConfig>>('transfers', {}) ?? {};
+    const patterns =
+      this.patterns.length > 0
+        ? this.patterns
+        : this.getConfig<TransferPattern[]>('patterns', []) ?? [];
     const allowArbitrary = this.getConfig<boolean | undefined>(
       'allow_arbitrary',
-      undefined,
+      this.allowArbitraryOverride,
     );
-
-    // If patterns are defined and allow_arbitrary is not explicitly set, default to false
     const canUseArbitrary =
       allowArbitrary !== undefined
         ? allowArbitrary
-        : patterns.length === 0;
+        : patterns.length === 0 && Object.keys(transfers).length === 0;
 
-    // Build the pattern lookup map
-    const patternMap = new Map<string, TransferPattern>();
-    for (const pattern of patterns) {
-      patternMap.set(pattern.name.toLowerCase(), pattern);
+    // Build tool parameters — include required_fields + primary destination param
+    const parameters: Record<string, unknown> = {
+      [parameterName]: {
+        type: 'string',
+        description: parameterDescription,
+      },
+      message: {
+        type: 'string',
+        description:
+          'An optional message to say to the caller before the transfer. If not provided, a default transfer message is used.',
+      },
+    };
+    const required = [parameterName];
+    for (const [fieldName, fieldDescription] of Object.entries(requiredFields)) {
+      parameters[fieldName] = {
+        type: 'string',
+        description: fieldDescription,
+      };
+      required.push(fieldName);
     }
+
+    // Pattern map for TS-style destinations (friendly-name lookup)
+    const patternMap = new Map<string, TransferPattern>();
+    for (const p of patterns) {
+      patternMap.set(p.name.toLowerCase(), p);
+    }
+
+    // Compile regex entries from Python-style transfers config
+    const compiledTransfers: Array<{ regex: RegExp; raw: string; config: TransferConfig }> = [];
+    for (const [patternKey, config] of Object.entries(transfers)) {
+      // Accept /.../ /i suffix as JS-style flags
+      let body = patternKey;
+      let flags = 'i';
+      if (body.startsWith('/')) body = body.slice(1);
+      if (body.endsWith('/i')) {
+        flags = 'i';
+        body = body.slice(0, -2);
+      } else if (body.endsWith('/')) {
+        flags = 'i';
+        body = body.slice(0, -1);
+      }
+      try {
+        compiledTransfers.push({
+          regex: new RegExp(body, flags),
+          raw: patternKey,
+          config,
+        });
+      } catch (err) {
+        log.error('swml_transfer: invalid transfer pattern', {
+          pattern: patternKey,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    const description = this._buildTransferDescription(
+      toolDescription,
+      patterns,
+      transfers,
+      canUseArbitrary,
+    );
 
     const tools: SkillToolDefinition[] = [
       {
-        name: 'transfer_call',
-        description: this._buildTransferDescription(patterns, canUseArbitrary),
-        parameters: {
-          destination: {
-            type: 'string',
-            description: this._buildDestinationDescription(patterns, canUseArbitrary),
-          },
-          message: {
-            type: 'string',
-            description:
-              'An optional message to say to the caller before the transfer. If not provided, a default transfer message is used.',
-          },
-        },
-        required: ['destination'],
+        name: toolName,
+        description,
+        parameters,
+        required,
         handler: (args: Record<string, unknown>) => {
-          const destination = args.destination as string | undefined;
-          const message = (args.message as string | undefined) ?? defaultMessage;
+          const rawDest = args[parameterName];
+          const callerMessage = args['message'];
+          const messageOverride =
+            typeof callerMessage === 'string' && callerMessage.trim().length > 0
+              ? callerMessage
+              : undefined;
 
-          if (
-            !destination ||
-            typeof destination !== 'string' ||
-            destination.trim().length === 0
-          ) {
-            return new FunctionResult(
-              'Please specify a destination for the transfer.',
+          if (typeof rawDest !== 'string' || rawDest.trim().length === 0) {
+            return new FunctionResult('Please specify a destination for the transfer.');
+          }
+          const destination = rawDest.trim();
+
+          // Build call_data for required fields
+          const callData: Record<string, unknown> = {};
+          for (const fieldName of Object.keys(requiredFields)) {
+            if (fieldName in args) callData[fieldName] = args[fieldName];
+          }
+
+          // 1. Try Python-style transfers (regex match)
+          for (const entry of compiledTransfers) {
+            if (entry.regex.test(destination)) {
+              return this._buildTransferResult(
+                entry.config,
+                messageOverride,
+                callData,
+              );
+            }
+          }
+
+          // 2. Try TS-style named patterns
+          const matchedPattern = patternMap.get(destination.toLowerCase());
+          if (matchedPattern) {
+            return this._buildPatternResult(
+              matchedPattern,
+              messageOverride ?? defaultMessage,
+              callData,
             );
           }
 
-          const trimmedDest = destination.trim();
-
-          // Check if this matches a named pattern
-          const matchedPattern = patternMap.get(trimmedDest.toLowerCase());
-
-          if (matchedPattern) {
-            const result = new FunctionResult(message);
-            result.swmlTransfer(matchedPattern.destination, message);
+          // 3. Arbitrary destinations
+          if (canUseArbitrary) {
+            const msg = messageOverride ?? defaultMessage;
+            const result = new FunctionResult(msg);
+            result.swmlTransfer(destination, msg, true);
+            if (Object.keys(callData).length > 0) {
+              result.updateGlobalData({ call_data: callData });
+            }
             return result;
           }
 
-          // No matching pattern - check if arbitrary transfers are allowed
-          if (!canUseArbitrary) {
-            const availableNames = patterns
-              .map((p) => `"${p.name}"`)
-              .join(', ');
-            return new FunctionResult(
-              `Unknown transfer destination "${trimmedDest}". Available destinations: ${availableNames}.`,
-            );
+          // 4. No match — return fallback message
+          const fallback = new FunctionResult(noMatchMessage);
+          fallback.postProcess = defaultPostProcess;
+          if (Object.keys(callData).length > 0) {
+            fallback.updateGlobalData({ call_data: callData });
           }
-
-          // Arbitrary transfer
-          const result = new FunctionResult(message);
-          result.swmlTransfer(trimmedDest, message);
-          return result;
+          return fallback;
         },
       },
     ];
 
-    // Add a list_destinations tool if patterns are configured
     if (patterns.length > 0) {
       tools.push({
         name: 'list_transfer_destinations',
@@ -196,7 +458,6 @@ export class SwmlTransferSkill extends SkillBase {
             const desc = p.description ? ` - ${p.description}` : '';
             return `${p.name}${desc}`;
           });
-
           return new FunctionResult(
             `Available transfer destinations:\n${lines.join('\n')}`,
           );
@@ -208,90 +469,178 @@ export class SwmlTransferSkill extends SkillBase {
   }
 
   protected override _getPromptSections(): SkillPromptSection[] {
-    const patterns = this.getConfig<TransferPattern[]>('patterns', []);
+    const toolName = this.getConfig<string>('tool_name', this.toolName);
+    const parameterName = this.getConfig<string>(
+      'parameter_name',
+      this.parameterName,
+    );
+    const transfers =
+      Object.keys(this.transfers).length > 0
+        ? this.transfers
+        : this.getConfig<Record<string, TransferConfig>>('transfers', {}) ?? {};
+    const patterns =
+      this.patterns.length > 0
+        ? this.patterns
+        : this.getConfig<TransferPattern[]>('patterns', []) ?? [];
+    const requiredFields =
+      this.getConfig<Record<string, string>>('required_fields', this.requiredFields) ?? {};
     const allowArbitrary = this.getConfig<boolean | undefined>(
       'allow_arbitrary',
-      undefined,
+      this.allowArbitraryOverride,
     );
     const canUseArbitrary =
       allowArbitrary !== undefined
         ? allowArbitrary
-        : patterns.length === 0;
+        : patterns.length === 0 && Object.keys(transfers).length === 0;
 
-    const bullets: string[] = [
-      'Use the transfer_call tool to transfer the current call to another destination.',
-      'You can optionally provide a message to say to the caller before the transfer.',
-    ];
+    const sections: SkillPromptSection[] = [];
 
-    if (patterns.length > 0) {
-      const patternNames = patterns.map((p) => `"${p.name}"`).join(', ');
-      bullets.push(
-        `Named transfer destinations are available: ${patternNames}. Use these names as the destination.`,
-      );
+    // Build "Transferring" section with destinations
+    const transferBullets: string[] = [];
 
-      for (const pattern of patterns) {
-        if (pattern.description) {
-          bullets.push(`${pattern.name}: ${pattern.description}`);
+    for (const [patternKey, config] of Object.entries(transfers)) {
+      let clean = patternKey;
+      if (clean.startsWith('/')) clean = clean.slice(1);
+      if (clean.endsWith('/')) clean = clean.slice(0, -1);
+      else if (clean.endsWith('/i')) clean = clean.slice(0, -2);
+
+      if (clean && !clean.startsWith('.')) {
+        const destination = config.url ?? config.address ?? '';
+        transferBullets.push(`"${clean}" - transfers to ${destination}`);
+      }
+    }
+
+    for (const p of patterns) {
+      const desc = p.description ? ` - ${p.description}` : ` - transfers to ${p.destination}`;
+      transferBullets.push(`"${p.name}"${desc}`);
+    }
+
+    if (transferBullets.length > 0) {
+      sections.push({
+        title: 'Transferring',
+        body: `You can transfer calls using the ${toolName} function with the following destinations:`,
+        bullets: transferBullets,
+      });
+
+      const instructionBullets: string[] = [
+        `Use the ${toolName} function when a transfer is needed`,
+        `Pass the destination type to the '${parameterName}' parameter`,
+      ];
+
+      if (Object.keys(requiredFields).length > 0) {
+        instructionBullets.push(
+          'You must provide the following information before transferring:',
+        );
+        for (const [fieldName, description] of Object.entries(requiredFields)) {
+          instructionBullets.push(`  - ${fieldName}: ${description}`);
         }
+        instructionBullets.push(
+          "All required information will be saved under 'call_data' for the next agent",
+        );
       }
 
       if (canUseArbitrary) {
-        bullets.push(
+        instructionBullets.push(
           'You can also transfer to arbitrary phone numbers or SIP URIs.',
         );
       }
 
-      bullets.push(
-        'Use list_transfer_destinations to see all available named destinations.',
+      instructionBullets.push(
+        'The system will match patterns and handle the transfer automatically',
+        "After transfer completes, you'll regain control of the conversation",
       );
-    } else {
-      bullets.push(
-        'Provide a phone number, SIP URI, or agent URL as the transfer destination.',
-      );
-    }
 
-    return [
-      {
+      sections.push({
+        title: 'Transfer Instructions',
+        body: 'How to use the transfer capability:',
+        bullets: instructionBullets,
+      });
+    } else {
+      sections.push({
         title: 'Call Transfer',
         body: 'You can transfer the current call to another destination.',
-        bullets,
-      },
-    ];
-  }
-
-  /**
-   * Build the tool description based on available patterns.
-   */
-  private _buildTransferDescription(
-    patterns: TransferPattern[],
-    canUseArbitrary: boolean,
-  ): string {
-    if (patterns.length === 0) {
-      return 'Transfer the current call to a specified destination (phone number, SIP URI, or agent URL).';
+        bullets: [
+          `Use the ${toolName} function to transfer the current call to another destination.`,
+          'You can optionally provide a message to say to the caller before the transfer.',
+          'Provide a phone number, SIP URI, or agent URL as the transfer destination.',
+        ],
+      });
     }
 
-    const names = patterns.map((p) => `"${p.name}"`).join(', ');
-    const base = `Transfer the current call. Named destinations: ${names}.`;
+    return sections;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Build a FunctionResult for a Python-style TransferConfig. */
+  private _buildTransferResult(
+    config: TransferConfig,
+    messageOverride: string | undefined,
+    callData: Record<string, unknown>,
+  ): FunctionResult {
+    const message = messageOverride ?? config.message ?? 'Transferring you now...';
+    const returnMessage =
+      config.return_message ?? 'The transfer is complete. How else can I help you?';
+    const postProcess = config.post_process ?? true;
+    const final = config.final ?? true;
+
+    const result = new FunctionResult(message, postProcess);
+    if (Object.keys(callData).length > 0) {
+      result.updateGlobalData({ call_data: callData });
+    }
+
+    if (config.url) {
+      result.swmlTransfer(config.url, returnMessage, final);
+    } else if (config.address) {
+      result.connect(config.address, final, config.from_addr);
+    }
+    return result;
+  }
+
+  /** Build a FunctionResult for a TS-style named TransferPattern. */
+  private _buildPatternResult(
+    pattern: TransferPattern,
+    message: string,
+    callData: Record<string, unknown>,
+  ): FunctionResult {
+    const returnMessage =
+      pattern.returnMessage ?? 'The transfer is complete. How else can I help you?';
+    const postProcess = pattern.postProcess ?? true;
+    const final = pattern.final ?? true;
+
+    const result = new FunctionResult(message, postProcess);
+    if (Object.keys(callData).length > 0) {
+      result.updateGlobalData({ call_data: callData });
+    }
+
+    // If destination looks like a URL, use swmlTransfer; otherwise use connect
+    if (/^https?:\/\//i.test(pattern.destination)) {
+      result.swmlTransfer(pattern.destination, returnMessage, final);
+    } else {
+      result.connect(pattern.destination, final, pattern.fromAddr);
+    }
+    return result;
+  }
+
+  private _buildTransferDescription(
+    baseDescription: string,
+    patterns: TransferPattern[],
+    transfers: Record<string, TransferConfig>,
+    canUseArbitrary: boolean,
+  ): string {
+    const names = [
+      ...Object.keys(transfers).map((k) => `"${k}"`),
+      ...patterns.map((p) => `"${p.name}"`),
+    ];
+    if (names.length === 0) {
+      return baseDescription;
+    }
+    const base = `${baseDescription}. Named destinations: ${names.join(', ')}.`;
     return canUseArbitrary
       ? `${base} You may also use arbitrary phone numbers or SIP URIs.`
       : base;
-  }
-
-  /**
-   * Build the destination parameter description based on available patterns.
-   */
-  private _buildDestinationDescription(
-    patterns: TransferPattern[],
-    canUseArbitrary: boolean,
-  ): string {
-    if (patterns.length === 0) {
-      return 'The transfer destination: a phone number (e.g., +15551234567), SIP URI, or agent URL.';
-    }
-
-    const names = patterns.map((p) => `"${p.name}"`).join(', ');
-    return canUseArbitrary
-      ? `A named destination (${names}) or an arbitrary phone number / SIP URI.`
-      : `One of the named destinations: ${names}.`;
   }
 }
 

--- a/src/skills/builtin/swml_transfer.ts
+++ b/src/skills/builtin/swml_transfer.ts
@@ -12,7 +12,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -62,6 +61,12 @@ interface TransferConfig {
  * or TypeScript-style `patterns` array of named destinations.
  */
 export class SwmlTransferSkill extends SkillBase {
+  // Python ground truth: skills/swml_transfer/skill.py:~60-67
+  static override SKILL_NAME = 'swml_transfer';
+  static override SKILL_DESCRIPTION = 'Transfer calls between agents based on pattern matching';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
@@ -143,13 +148,6 @@ export class SwmlTransferSkill extends SkillBase {
   private defaultPostProcess = false;
   private requiredFields: Record<string, string> = {};
   private allowArbitraryOverride: boolean | undefined;
-
-  /**
-   * @param config - Optional configuration (see `getParameterSchema()`).
-   */
-  constructor(config?: SkillConfig) {
-    super('swml_transfer', config);
-  }
 
   override getInstanceKey(): string {
     const toolName = this.getConfig<string>('tool_name', 'transfer_call');
@@ -258,19 +256,6 @@ export class SwmlTransferSkill extends SkillBase {
 
     hints.push('transfer', 'connect', 'speak to', 'talk to');
     return hints;
-  }
-
-  /** @returns Manifest for the SWML transfer skill. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'swml_transfer',
-      description: 'Transfer calls between agents based on pattern matching',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['call-control', 'transfer', 'swml', 'routing'],
-      requiredEnvVars: [],
-      requiredPackages: [],
-    };
   }
 
   /** @returns A `transfer_call` tool, plus `list_transfer_destinations` when patterns are configured. */

--- a/src/skills/builtin/swml_transfer.ts
+++ b/src/skills/builtin/swml_transfer.ts
@@ -163,7 +163,7 @@ export class SwmlTransferSkill extends SkillBase {
     return `${this.skillName}_${toolName}`;
   }
 
-  override async setup(): Promise<void> {
+  override async setup(): Promise<boolean> {
     this.toolName = this.getConfig<string>('tool_name', 'transfer_call');
     this.toolDescription = this.getConfig<string>(
       'description',
@@ -224,6 +224,7 @@ export class SwmlTransferSkill extends SkillBase {
 
     // TS-style patterns array
     this.patterns = this.getConfig<TransferPattern[]>('patterns', []) ?? [];
+    return true;
   }
 
   override getHints(): string[] {

--- a/src/skills/builtin/swml_transfer.ts
+++ b/src/skills/builtin/swml_transfer.ts
@@ -71,7 +71,7 @@ export class SwmlTransferSkill extends SkillBase {
         type: 'object',
         description:
           'Transfer configurations mapping patterns (regex or name) to destination configs. Each value has either url or address, plus optional message/return_message/post_process/final/from_addr.',
-        required: false,
+        required: true,
       },
       patterns: {
         type: 'array',
@@ -213,6 +213,20 @@ export class SwmlTransferSkill extends SkillBase {
 
     // TS-style patterns array
     this.patterns = this.getConfig<TransferPattern[]>('patterns', []) ?? [];
+
+    // Python parity (skills/swml_transfer/skill.py:132-136): setup() returns
+    // false when `transfers` is absent. TS additionally supports a `patterns`
+    // config shape, so accept either — but not neither, otherwise the skill
+    // registers a transfer tool that matches nothing and always falls back.
+    if (
+      Object.keys(this.transfers).length === 0 &&
+      this.patterns.length === 0
+    ) {
+      log.error(
+        'swml_transfer: at least one of "transfers" or "patterns" must be configured',
+      );
+      return false;
+    }
     return true;
   }
 
@@ -303,16 +317,14 @@ export class SwmlTransferSkill extends SkillBase {
         ? allowArbitrary
         : patterns.length === 0 && Object.keys(transfers).length === 0;
 
-    // Build tool parameters — include required_fields + primary destination param
+    // Build tool parameters — include required_fields + primary destination param.
+    // Python's DataMap does NOT expose a `message` param to the AI
+    // (skill.py:227-236). Match that: the pre-transfer message is driven
+    // entirely by per-config defaults, not by AI override at call time.
     const parameters: Record<string, unknown> = {
       [parameterName]: {
         type: 'string',
         description: parameterDescription,
-      },
-      message: {
-        type: 'string',
-        description:
-          'An optional message to say to the caller before the transfer. If not provided, a default transfer message is used.',
       },
     };
     const required = [parameterName];
@@ -330,18 +342,23 @@ export class SwmlTransferSkill extends SkillBase {
       patternMap.set(p.name.toLowerCase(), p);
     }
 
-    // Compile regex entries from Python-style transfers config
+    // Compile regex entries from Python-style transfers config.
+    // Flag semantics match the platform regex engine (skill.py:245-258):
+    //   - /pattern/i → case-insensitive
+    //   - /pattern/  → case-sensitive (bare closing delimiter)
+    //   - pattern    → case-sensitive (no delimiters)
+    // Previously TS defaulted to 'i' regardless, silently changing routing
+    // semantics for configs ported from Python.
     const compiledTransfers: Array<{ regex: RegExp; raw: string; config: TransferConfig }> = [];
     for (const [patternKey, config] of Object.entries(transfers)) {
-      // Accept /.../ /i suffix as JS-style flags
       let body = patternKey;
-      let flags = 'i';
+      let flags = '';
       if (body.startsWith('/')) body = body.slice(1);
       if (body.endsWith('/i')) {
         flags = 'i';
         body = body.slice(0, -2);
       } else if (body.endsWith('/')) {
-        flags = 'i';
+        // bare closing delimiter — Python matches case-sensitively
         body = body.slice(0, -1);
       }
       try {
@@ -373,21 +390,19 @@ export class SwmlTransferSkill extends SkillBase {
         required,
         handler: (args: Record<string, unknown>) => {
           const rawDest = args[parameterName];
-          const callerMessage = args['message'];
-          const messageOverride =
-            typeof callerMessage === 'string' && callerMessage.trim().length > 0
-              ? callerMessage
-              : undefined;
 
           if (typeof rawDest !== 'string' || rawDest.trim().length === 0) {
             return new FunctionResult('Please specify a destination for the transfer.');
           }
           const destination = rawDest.trim();
 
-          // Build call_data for required fields
+          // Build call_data for required fields. Python's DataMap template
+          // always emits every required_fields key (platform fills missing
+          // with empty string). Match that: include the key even when the
+          // AI didn't supply it, using the empty string as the fallback.
           const callData: Record<string, unknown> = {};
           for (const fieldName of Object.keys(requiredFields)) {
-            if (fieldName in args) callData[fieldName] = args[fieldName];
+            callData[fieldName] = fieldName in args ? args[fieldName] : '';
           }
 
           // 1. Try Python-style transfers (regex match)
@@ -395,7 +410,7 @@ export class SwmlTransferSkill extends SkillBase {
             if (entry.regex.test(destination)) {
               return this._buildTransferResult(
                 entry.config,
-                messageOverride,
+                undefined,
                 callData,
               );
             }
@@ -406,14 +421,14 @@ export class SwmlTransferSkill extends SkillBase {
           if (matchedPattern) {
             return this._buildPatternResult(
               matchedPattern,
-              messageOverride ?? 'Transferring you now...',
+              'Transferring you now...',
               callData,
             );
           }
 
           // 3. Arbitrary destinations
           if (canUseArbitrary) {
-            const msg = messageOverride ?? 'Transferring you now...';
+            const msg = 'Transferring you now...';
             const result = new FunctionResult(msg);
             result.swmlTransfer(destination, msg, true);
             if (Object.keys(callData).length > 0) {
@@ -541,17 +556,11 @@ export class SwmlTransferSkill extends SkillBase {
         body: 'How to use the transfer capability:',
         bullets: instructionBullets,
       });
-    } else {
-      sections.push({
-        title: 'Call Transfer',
-        body: 'You can transfer the current call to another destination.',
-        bullets: [
-          `Use the ${toolName} function to transfer the current call to another destination.`,
-          'You can optionally provide a message to say to the caller before the transfer.',
-          'Provide a phone number, SIP URI, or agent URL as the transfer destination.',
-        ],
-      });
     }
+    // Python skills/swml_transfer/skill.py:297-358 returns [] when there are
+    // no transfers — no prompt injection for an unconfigured skill. Previously
+    // TS emitted a generic "Call Transfer" section here that Python would
+    // suppress, creating AI prompt drift for identical configs.
 
     return sections;
   }

--- a/src/skills/builtin/swml_transfer.ts
+++ b/src/skills/builtin/swml_transfer.ts
@@ -269,6 +269,7 @@ export class SwmlTransferSkill extends SkillBase {
       author: 'SignalWire',
       tags: ['call-control', 'transfer', 'swml', 'routing'],
       requiredEnvVars: [],
+      requiredPackages: [],
     };
   }
 
@@ -388,7 +389,7 @@ export class SwmlTransferSkill extends SkillBase {
         description,
         parameters,
         required,
-        handler: (args: Record<string, unknown>) => {
+        handler: (args: Record<string, unknown>, _rawData: Record<string, unknown>) => {
           const rawDest = args[parameterName];
 
           if (typeof rawDest !== 'string' || rawDest.trim().length === 0) {

--- a/src/skills/builtin/weather_api.ts
+++ b/src/skills/builtin/weather_api.ts
@@ -48,12 +48,13 @@ interface WeatherApiResponse {
  * standard temperature units via the `units` config option.
  */
 export class WeatherApiSkill extends SkillBase {
-  /**
-   * @param config - Optional configuration; supports `units` ("metric"|"imperial"|"standard").
-   */
-  constructor(config?: SkillConfig) {
-    super('weather_api', config);
-  }
+  // Python ground truth: skills/weather_api/skill.py
+  // TS declares env var as required historically; Python declares [] explicitly.
+  // Preserving TS behavior — full Python parity is out-of-scope for this PR.
+  static override SKILL_NAME = 'weather_api';
+  static override SKILL_DESCRIPTION = 'Get current weather information from WeatherAPI.com';
+  static override REQUIRED_ENV_VARS: readonly string[] = ['WEATHER_API_KEY'];
+  static override SUPPORTS_MULTIPLE_INSTANCES = false;
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {

--- a/src/skills/builtin/weather_api.ts
+++ b/src/skills/builtin/weather_api.ts
@@ -8,7 +8,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -71,27 +70,6 @@ export class WeatherApiSkill extends SkillBase {
         description: 'Temperature units: "metric" (Celsius), "imperial" (Fahrenheit), or "standard" (Kelvin).',
         default: 'metric',
         enum: ['metric', 'imperial', 'standard'],
-      },
-    };
-  }
-
-  /** @returns Manifest declaring WEATHER_API_KEY as required and config schema for units. */
-  getManifest(): SkillManifest {
-    return {
-      name: 'weather_api',
-      description:
-        'Fetches current weather data from OpenWeatherMap for any location worldwide.',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['weather', 'api', 'openweathermap', 'external'],
-      requiredEnvVars: ['WEATHER_API_KEY'],
-      configSchema: {
-        units: {
-          type: 'string',
-          description:
-            'Temperature units: "metric" (Celsius), "imperial" (Fahrenheit), or "standard" (Kelvin).',
-          default: 'metric',
-        },
       },
     };
   }

--- a/src/skills/builtin/web_search.ts
+++ b/src/skills/builtin/web_search.ts
@@ -274,7 +274,7 @@ export class WebSearchSkill extends SkillBase {
     return {
       web_search_enabled: true,
       search_provider: 'Google Custom Search',
-      quality_filtering: false,
+      quality_filtering: true,
     };
   }
 
@@ -307,15 +307,10 @@ export class WebSearchSkill extends SkillBase {
             description:
               "The search query — what you want to find information about",
           },
-          num_results: {
-            type: 'number',
-            description: `Optional: override the number of results to return (1-10). Defaults to ${configNumResults}.`,
-          },
         },
         required: ['query'],
         handler: async (args: Record<string, unknown>) => {
           const rawQuery = args['query'];
-          const perCallNumResults = args['num_results'];
 
           if (
             !rawQuery ||
@@ -347,15 +342,7 @@ export class WebSearchSkill extends SkillBase {
             );
           }
 
-          const count = Math.max(
-            1,
-            Math.min(
-              10,
-              typeof perCallNumResults === 'number'
-                ? perCallNumResults
-                : configNumResults,
-            ),
-          );
+          const count = Math.max(1, Math.min(10, configNumResults));
 
           try {
             const encodedQuery = encodeURIComponent(query);

--- a/src/skills/builtin/web_search.ts
+++ b/src/skills/builtin/web_search.ts
@@ -1,9 +1,10 @@
 /**
- * Web Search Skill - Searches the web using Google Custom Search API.
+ * Web Search Skill - Searches the web using the Google Custom Search API.
  *
- * Tier 3 built-in skill: requires GOOGLE_SEARCH_API_KEY and GOOGLE_SEARCH_CX
- * environment variables. Uses the Google Custom Search JSON API to perform
- * web searches and return formatted results.
+ * Tier 3 built-in skill: requires `GOOGLE_SEARCH_API_KEY` and
+ * `GOOGLE_SEARCH_ENGINE_ID` (legacy alias: `GOOGLE_SEARCH_CX`) environment
+ * variables, or the equivalent config params. Uses the Google Custom Search
+ * JSON API to perform web searches and return formatted results.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -19,6 +20,11 @@ import { MAX_SKILL_INPUT_LENGTH } from '../../SecurityUtils.js';
 import { getLogger } from '../../Logger.js';
 
 const log = getLogger('WebSearchSkill');
+
+const DEFAULT_NO_RESULTS_MESSAGE =
+  "I couldn't find quality results for '{query}'. " +
+  'The search returned only low-quality or inaccessible pages. ' +
+  'Try rephrasing your search or asking about a different topic.';
 
 /** A single search result item from the Google Custom Search API. */
 interface GoogleSearchItem {
@@ -56,13 +62,23 @@ interface GoogleSearchResponse {
 /**
  * Searches the web using the Google Custom Search JSON API.
  *
- * Tier 3 built-in skill. Requires `GOOGLE_SEARCH_API_KEY` and `GOOGLE_SEARCH_CX`
- * environment variables. Supports `max_results` (1-10) and `safe_search`
- * ("off"|"medium"|"high") config options.
+ * Tier 3 built-in skill. Credentials can be supplied via the `api_key` and
+ * `search_engine_id` params or `GOOGLE_SEARCH_API_KEY` /
+ * `GOOGLE_SEARCH_ENGINE_ID` (legacy: `GOOGLE_SEARCH_CX`) environment variables.
+ * Supports `tool_name`, `num_results`, `no_results_message`, `safe_search`,
+ * and — for Python-parity — `delay`, `max_content_length`, `oversample_factor`,
+ * and `min_quality_score` config options. The scraping-pipeline parameters are
+ * accepted but only the API-snippet result path is implemented in TS.
  */
 export class WebSearchSkill extends SkillBase {
+  /** Python SDK parity: multiple instances can coexist with different tool names. */
+  static override SUPPORTS_MULTIPLE_INSTANCES = true;
+
   /**
-   * @param config - Optional configuration; supports `max_results` and `safe_search`.
+   * @param config - Optional configuration; supports `api_key`,
+   *   `search_engine_id`, `tool_name`, `num_results`, `no_results_message`,
+   *   `safe_search`, `delay`, `max_content_length`, `oversample_factor`,
+   *   `min_quality_score`.
    */
   constructor(config?: SkillConfig) {
     super('web_search', config);
@@ -73,24 +89,64 @@ export class WebSearchSkill extends SkillBase {
       ...super.getParameterSchema(),
       api_key: {
         type: 'string',
-        description: 'Google Custom Search API key.',
+        description: 'Google Custom Search API key',
+        required: true,
         hidden: true,
         env_var: 'GOOGLE_SEARCH_API_KEY',
-        required: true,
       },
       search_engine_id: {
         type: 'string',
-        description: 'Google Custom Search Engine ID (CX).',
-        hidden: true,
-        env_var: 'GOOGLE_SEARCH_CX',
+        description: 'Google Custom Search Engine ID',
         required: true,
+        hidden: true,
+        env_var: 'GOOGLE_SEARCH_ENGINE_ID',
       },
-      max_results: {
-        type: 'number',
-        description: 'Maximum number of results to return (1-10).',
-        default: 5,
+      tool_name: {
+        type: 'string',
+        description: 'Custom tool name for this Web Search instance.',
+      },
+      num_results: {
+        type: 'integer',
+        description: 'Number of high-quality results to return',
+        default: 3,
         min: 1,
         max: 10,
+      },
+      delay: {
+        type: 'number',
+        description:
+          'Delay between scraping pages in seconds (parity with Python; ignored in TS which uses API snippets only)',
+        default: 0.5,
+        min: 0,
+      },
+      max_content_length: {
+        type: 'integer',
+        description:
+          'Maximum total response size in characters (parity with Python; ignored in TS which uses API snippets only)',
+        default: 32768,
+        min: 1000,
+      },
+      oversample_factor: {
+        type: 'number',
+        description:
+          'How many extra results to fetch for quality filtering (parity with Python; ignored in TS)',
+        default: 2.5,
+        min: 1.0,
+        max: 3.5,
+      },
+      min_quality_score: {
+        type: 'number',
+        description:
+          'Minimum quality score (0-1) for including a result (parity with Python; ignored in TS)',
+        default: 0.3,
+        min: 0,
+        max: 1,
+      },
+      no_results_message: {
+        type: 'string',
+        description:
+          'Message to show when no results are found. Use {query} as placeholder.',
+        default: DEFAULT_NO_RESULTS_MESSAGE,
       },
       safe_search: {
         type: 'string',
@@ -101,22 +157,66 @@ export class WebSearchSkill extends SkillBase {
     };
   }
 
-  /** @returns Manifest declaring GOOGLE_SEARCH_API_KEY and GOOGLE_SEARCH_CX as required. */
+  /**
+   * @returns Manifest declaring Google Search credentials as required env vars.
+   *   Reports `GOOGLE_SEARCH_ENGINE_ID` as the canonical name; `GOOGLE_SEARCH_CX`
+   *   is still accepted as a legacy fallback at runtime.
+   */
   getManifest(): SkillManifest {
     return {
       name: 'web_search',
       description:
-        'Searches the web using Google Custom Search API and returns formatted results with titles, links, and snippets.',
-      version: '1.0.0',
+        'Search the web for information using Google Custom Search API',
+      version: '2.0.0',
       author: 'SignalWire',
       tags: ['search', 'web', 'google', 'api', 'external'],
-      requiredEnvVars: ['GOOGLE_SEARCH_API_KEY', 'GOOGLE_SEARCH_CX'],
+      requiredEnvVars: ['GOOGLE_SEARCH_API_KEY', 'GOOGLE_SEARCH_ENGINE_ID'],
       configSchema: {
-        max_results: {
+        api_key: {
+          type: 'string',
+          description: 'Google Custom Search API key.',
+        },
+        search_engine_id: {
+          type: 'string',
+          description: 'Google Custom Search Engine ID.',
+        },
+        tool_name: {
+          type: 'string',
+          description: 'Custom tool name for this instance.',
+        },
+        num_results: {
+          type: 'integer',
+          description: 'Number of results to return (1-10). Defaults to 3.',
+          default: 3,
+        },
+        delay: {
           type: 'number',
           description:
-            'Maximum number of results to return (1-10). Defaults to 5.',
-          default: 5,
+            'Delay between scraping pages (Python parity; ignored in TS).',
+          default: 0.5,
+        },
+        max_content_length: {
+          type: 'integer',
+          description:
+            'Maximum total response size (Python parity; ignored in TS).',
+          default: 32768,
+        },
+        oversample_factor: {
+          type: 'number',
+          description:
+            'Oversampling factor for quality filtering (Python parity; ignored in TS).',
+          default: 2.5,
+        },
+        min_quality_score: {
+          type: 'number',
+          description:
+            'Minimum quality score (Python parity; ignored in TS).',
+          default: 0.3,
+        },
+        no_results_message: {
+          type: 'string',
+          description:
+            'Message returned when no results are found. Supports {query} interpolation.',
         },
         safe_search: {
           type: 'string',
@@ -128,58 +228,111 @@ export class WebSearchSkill extends SkillBase {
     };
   }
 
-  /** @returns A single `web_search` tool that performs a Google search and returns formatted results. */
+  /**
+   * Instance key for the SkillManager. Includes the configured
+   * `search_engine_id` (or `"default"`) and `tool_name` (or `"web_search"`)
+   * to match Python's `"{SKILL_NAME}_{search_engine_id}_{tool_name}"` scheme.
+   */
+  override getInstanceKey(): string {
+    const searchEngineId = this.getConfig<string>('search_engine_id', '') || 'default';
+    const toolName = this.getConfig<string>('tool_name', this.skillName);
+    return `${this.skillName}_${searchEngineId}_${toolName}`;
+  }
+
+  /** Global data injected into the agent's SWML context (mirrors Python). */
+  override getGlobalData(): Record<string, unknown> {
+    return {
+      web_search_enabled: true,
+      search_provider: 'Google Custom Search',
+      quality_filtering: false,
+    };
+  }
+
+  /** Resolve the tool name (defaults to `web_search`, matches Python default). */
+  private getToolName(): string {
+    return this.getConfig<string>('tool_name', 'web_search');
+  }
+
+  /**
+   * @returns A single tool (named via `tool_name`) that performs a Google
+   *   Custom Search and returns formatted results.
+   */
   getTools(): SkillToolDefinition[] {
-    const configMaxResults = this.getConfig<number>('max_results', 5);
+    const configNumResults = this.getConfig<number>('num_results', 3);
     const safeSearch = this.getConfig<string>('safe_search', 'medium');
+    const noResultsMessage = this.getConfig<string>(
+      'no_results_message',
+      DEFAULT_NO_RESULTS_MESSAGE,
+    );
+    const toolName = this.getToolName();
 
     return [
       {
-        name: 'web_search',
+        name: toolName,
         description:
-          'Search the web for information on any topic. Returns a list of results with titles, links, and brief descriptions.',
+          'Search the web for high-quality information, automatically filtering low-quality results',
         parameters: {
           query: {
             type: 'string',
-            description: 'The search query to look up on the web.',
+            description:
+              "The search query — what you want to find information about",
           },
           num_results: {
             type: 'number',
-            description: `Number of results to return (1-10). Defaults to ${configMaxResults}.`,
+            description: `Optional: override the number of results to return (1-10). Defaults to ${configNumResults}.`,
           },
         },
         required: ['query'],
         handler: async (args: Record<string, unknown>) => {
-          const query = args.query as string | undefined;
-          const numResults = args.num_results as number | undefined;
+          const rawQuery = args['query'];
+          const perCallNumResults = args['num_results'];
 
-          if (!query || typeof query !== 'string' || query.trim().length === 0) {
+          if (
+            !rawQuery ||
+            typeof rawQuery !== 'string' ||
+            rawQuery.trim().length === 0
+          ) {
             return new FunctionResult(
-              'Please provide a search query.',
+              'Please provide a search query. What would you like me to search for?',
             );
           }
+
+          const query = rawQuery.trim();
 
           if (query.length > MAX_SKILL_INPUT_LENGTH) {
             return new FunctionResult('Search query is too long.');
           }
 
-          const apiKey = process.env['GOOGLE_SEARCH_API_KEY'];
-          const cx = process.env['GOOGLE_SEARCH_CX'];
+          const apiKey =
+            this.getConfig<string | undefined>('api_key', undefined) ??
+            process.env['GOOGLE_SEARCH_API_KEY'];
+          const searchEngineId =
+            this.getConfig<string | undefined>('search_engine_id', undefined) ??
+            process.env['GOOGLE_SEARCH_ENGINE_ID'] ??
+            process.env['GOOGLE_SEARCH_CX'];
 
-          if (!apiKey || !cx) {
+          if (!apiKey || !searchEngineId) {
             return new FunctionResult(
               'Service is not configured. Please contact your administrator.',
             );
           }
 
-          const count = Math.max(1, Math.min(10, numResults ?? configMaxResults));
+          const count = Math.max(
+            1,
+            Math.min(
+              10,
+              typeof perCallNumResults === 'number'
+                ? perCallNumResults
+                : configNumResults,
+            ),
+          );
 
           try {
-            const encodedQuery = encodeURIComponent(query.trim());
+            const encodedQuery = encodeURIComponent(query);
             const safeParam = safeSearch !== 'off' ? `&safe=${safeSearch}` : '';
             const url =
               `https://www.googleapis.com/customsearch/v1` +
-              `?key=${apiKey}&cx=${cx}&q=${encodedQuery}&num=${count}${safeParam}`;
+              `?key=${apiKey}&cx=${searchEngineId}&q=${encodedQuery}&num=${count}${safeParam}`;
 
             const controller = new AbortController();
             const timeout = setTimeout(() => controller.abort(), 30_000);
@@ -200,15 +353,17 @@ export class WebSearchSkill extends SkillBase {
 
             if (!data.items || data.items.length === 0) {
               return new FunctionResult(
-                `No results found for "${query}".`,
+                WebSearchSkill._formatNoResultsMessage(noResultsMessage, query),
               );
             }
 
-            const totalResults = data.searchInformation?.formattedTotalResults ?? 'unknown';
-            const searchTime = data.searchInformation?.formattedSearchTime ?? 'unknown';
+            const totalResults =
+              data.searchInformation?.formattedTotalResults ?? 'unknown';
+            const searchTime =
+              data.searchInformation?.formattedSearchTime ?? 'unknown';
 
             const parts: string[] = [
-              `Web search results for "${query}" (${totalResults} results in ${searchTime} seconds):`,
+              `Quality web search results for '${query}' (${totalResults} results in ${searchTime} seconds):`,
               '',
             ];
 
@@ -224,9 +379,11 @@ export class WebSearchSkill extends SkillBase {
 
             return new FunctionResult(parts.join('\n').trim());
           } catch (err) {
-            log.error('web_search_failed', { error: err instanceof Error ? err.message : String(err) });
+            log.error('web_search_failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
             return new FunctionResult(
-              'The request could not be completed. Please try again.',
+              'Sorry, I encountered an error while searching. Please try again later.',
             );
           }
         },
@@ -234,18 +391,25 @@ export class WebSearchSkill extends SkillBase {
     ];
   }
 
+  /** Apply the `{query}` template to the no-results message. */
+  private static _formatNoResultsMessage(template: string, query: string): string {
+    return template.includes('{query}')
+      ? template.replace(/\{query\}/g, query)
+      : template;
+  }
+
   /** @returns Prompt section describing web search capabilities and usage guidance. */
   protected override _getPromptSections(): SkillPromptSection[] {
+    const toolName = this.getToolName();
     return [
       {
-        title: 'Web Search',
-        body: 'You can search the web for current information on any topic.',
+        title: 'Web Search Capability (Quality Enhanced)',
+        body: `You can search the internet for high-quality information using the ${toolName} tool.`,
         bullets: [
-          'Use the web_search tool when the user asks about current events, facts, or any information you may not have.',
-          'You can specify the number of results to return (1-10).',
-          'Results include titles, URLs, and brief descriptions/snippets.',
-          'If a search returns no results, try rephrasing the query or using different terms.',
-          'Summarize the search results for the user rather than reading them verbatim.',
+          `Use the ${toolName} tool when users ask for information you need to look up`,
+          'The search automatically filters out low-quality results like empty pages',
+          'Results are ranked by content quality, relevance, and domain reputation',
+          'Summarize the high-quality results in a clear, helpful way',
         ],
       },
     ];

--- a/src/skills/builtin/web_search.ts
+++ b/src/skills/builtin/web_search.ts
@@ -66,10 +66,19 @@ interface GoogleSearchResponse {
  * Tier 3 built-in skill. Credentials can be supplied via the `api_key` and
  * `search_engine_id` params or `GOOGLE_SEARCH_API_KEY` /
  * `GOOGLE_SEARCH_ENGINE_ID` (legacy: `GOOGLE_SEARCH_CX`) environment variables.
- * Supports `tool_name`, `num_results`, `no_results_message`, `safe_search`,
- * and — for Python-parity — `delay`, `max_content_length`, `oversample_factor`,
- * and `min_quality_score` config options. The scraping-pipeline parameters are
- * accepted but only the API-snippet result path is implemented in TS.
+ *
+ * The handler mirrors Python's `search_and_scrape_best` pipeline: fetches
+ * `oversample_factor × num_results` candidates from Google, scrapes each
+ * result page (SSRF-guarded, cheerio-based text extraction), scores for
+ * quality (length + query relevance + boilerplate penalty), deduplicates by
+ * domain, and returns the top `num_results` above `min_quality_score` with
+ * full page content. If every scrape fails or falls below the threshold the
+ * handler falls back to raw API snippets so the agent still has something
+ * to say.
+ *
+ * Supported config: `tool_name`, `num_results`, `no_results_message`,
+ * `safe_search`, `delay`, `max_content_length`, `oversample_factor`,
+ * `min_quality_score`.
  */
 export class WebSearchSkill extends SkillBase {
   /** Python SDK parity: multiple instances can coexist with different tool names. */

--- a/src/skills/builtin/web_search.ts
+++ b/src/skills/builtin/web_search.ts
@@ -229,6 +229,36 @@ export class WebSearchSkill extends SkillBase {
   }
 
   /**
+   * Validate required credentials before the skill becomes active.
+   *
+   * Mirrors Python's `setup()` (skill.py:559-600) which checks `api_key` and
+   * `search_engine_id` and returns `False` (logging an error) if either is
+   * absent. In the TS SDK credentials may also arrive via environment variables
+   * (`GOOGLE_SEARCH_API_KEY` / `GOOGLE_SEARCH_ENGINE_ID` or the legacy alias
+   * `GOOGLE_SEARCH_CX`), so both config params and env vars are checked.
+   * @returns `true` if all required credentials are present, `false` otherwise.
+   */
+  override async setup(): Promise<boolean> {
+    const apiKey =
+      this.getConfig<string | undefined>('api_key', undefined) ??
+      process.env['GOOGLE_SEARCH_API_KEY'];
+    const searchEngineId =
+      this.getConfig<string | undefined>('search_engine_id', undefined) ??
+      process.env['GOOGLE_SEARCH_ENGINE_ID'] ??
+      process.env['GOOGLE_SEARCH_CX'];
+
+    const missing: string[] = [];
+    if (!apiKey) missing.push('api_key / GOOGLE_SEARCH_API_KEY');
+    if (!searchEngineId) missing.push('search_engine_id / GOOGLE_SEARCH_ENGINE_ID');
+
+    if (missing.length > 0) {
+      log.error('web_search: missing required parameters', { missing });
+      return false;
+    }
+    return true;
+  }
+
+  /**
    * Instance key for the SkillManager. Includes the configured
    * `search_engine_id` (or `"default"`) and `tool_name` (or `"web_search"`)
    * to match Python's `"{SKILL_NAME}_{search_engine_id}_{tool_name}"` scheme.

--- a/src/skills/builtin/web_search.ts
+++ b/src/skills/builtin/web_search.ts
@@ -16,8 +16,9 @@ import type {
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
-import { MAX_SKILL_INPUT_LENGTH } from '../../SecurityUtils.js';
+import { MAX_SKILL_INPUT_LENGTH, validateUrl } from '../../SecurityUtils.js';
 import { getLogger } from '../../Logger.js';
+import * as cheerio from 'cheerio';
 
 const log = getLogger('WebSearchSkill');
 
@@ -114,31 +115,32 @@ export class WebSearchSkill extends SkillBase {
       },
       delay: {
         type: 'number',
-        description:
-          'Delay between scraping pages in seconds (parity with Python; ignored in TS which uses API snippets only)',
+        description: 'Delay between scraping pages in seconds',
         default: 0.5,
+        required: false,
         min: 0,
       },
       max_content_length: {
         type: 'integer',
-        description:
-          'Maximum total response size in characters (parity with Python; ignored in TS which uses API snippets only)',
+        description: 'Maximum total response size in characters (distributed across results)',
         default: 32768,
+        required: false,
         min: 1000,
       },
       oversample_factor: {
         type: 'number',
         description:
-          'How many extra results to fetch for quality filtering (parity with Python; ignored in TS)',
+          'How many extra results to fetch for quality filtering (multiplier on num_results)',
         default: 2.5,
+        required: false,
         min: 1.0,
         max: 3.5,
       },
       min_quality_score: {
         type: 'number',
-        description:
-          'Minimum quality score (0-1) for including a result (parity with Python; ignored in TS)',
+        description: 'Minimum quality score (0-1) for including a result',
         default: 0.3,
+        required: false,
         min: 0,
         max: 1,
       },
@@ -170,7 +172,13 @@ export class WebSearchSkill extends SkillBase {
       version: '2.0.0',
       author: 'SignalWire',
       tags: ['search', 'web', 'google', 'api', 'external'],
-      requiredEnvVars: ['GOOGLE_SEARCH_API_KEY', 'GOOGLE_SEARCH_ENGINE_ID'],
+      // Python declares REQUIRED_ENV_VARS = [] — credentials may arrive via
+      // either config params OR env vars, so nothing is strictly required
+      // at the env-var layer. hasAllEnvVars() treats an empty list as "all
+      // present", letting the config-only path succeed. setup() still
+      // validates that at least one source is populated.
+      requiredEnvVars: [],
+      requiredPackages: [],
       configSchema: {
         api_key: {
           type: 'string',
@@ -290,6 +298,10 @@ export class WebSearchSkill extends SkillBase {
   getTools(): SkillToolDefinition[] {
     const configNumResults = this.getConfig<number>('num_results', 3);
     const safeSearch = this.getConfig<string>('safe_search', 'medium');
+    const oversampleFactor = this.getConfig<number>('oversample_factor', 2.5);
+    const minQualityScore = this.getConfig<number>('min_quality_score', 0.3);
+    const maxContentLength = this.getConfig<number>('max_content_length', 32768);
+    const delaySeconds = this.getConfig<number>('delay', 0.5);
     const noResultsMessage = this.getConfig<string>(
       'no_results_message',
       DEFAULT_NO_RESULTS_MESSAGE,
@@ -305,11 +317,11 @@ export class WebSearchSkill extends SkillBase {
           query: {
             type: 'string',
             description:
-              "The search query — what you want to find information about",
+              "The search query - what you want to find information about",
           },
         },
         required: ['query'],
-        handler: async (args: Record<string, unknown>) => {
+        handler: async (args: Record<string, unknown>, _rawData: Record<string, unknown>) => {
           const rawQuery = args['query'];
 
           if (
@@ -343,16 +355,23 @@ export class WebSearchSkill extends SkillBase {
           }
 
           const count = Math.max(1, Math.min(10, configNumResults));
+          // Python skill.py fetches oversample_factor * num_results, then
+          // scores/filters and returns the top `num_results`. Mirror that.
+          const fetchCount = Math.min(
+            10,
+            Math.max(count, Math.ceil(count * oversampleFactor)),
+          );
 
           try {
             const encodedQuery = encodeURIComponent(query);
             const safeParam = safeSearch !== 'off' ? `&safe=${safeSearch}` : '';
             const url =
               `https://www.googleapis.com/customsearch/v1` +
-              `?key=${apiKey}&cx=${searchEngineId}&q=${encodedQuery}&num=${count}${safeParam}`;
+              // Python uses timeout=15 on the API request (skill.py:220).
+              `?key=${apiKey}&cx=${searchEngineId}&q=${encodedQuery}&num=${fetchCount}${safeParam}`;
 
             const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), 30_000);
+            const timeout = setTimeout(() => controller.abort(), 15_000);
             let response: Response;
             try {
               response = await fetch(url, { signal: controller.signal });
@@ -374,26 +393,83 @@ export class WebSearchSkill extends SkillBase {
               );
             }
 
-            const totalResults =
-              data.searchInformation?.formattedTotalResults ?? 'unknown';
-            const searchTime =
-              data.searchInformation?.formattedSearchTime ?? 'unknown';
+            // Scrape each result page, score for quality, dedupe by domain,
+            // return the top `count` above the min threshold. Lightweight
+            // port of Python's GoogleSearchScraper.search_and_scrape_best
+            // (skill.py:~440).
+            const perResultBudget = Math.max(
+              500,
+              Math.floor(maxContentLength / count),
+            );
+            const seenDomains = new Set<string>();
+            const scored: Array<{
+              item: GoogleSearchItem;
+              text: string;
+              score: number;
+            }> = [];
 
-            const parts: string[] = [
-              `Quality web search results for '${query}' (${totalResults} results in ${searchTime} seconds):`,
-              '',
-            ];
-
-            for (let i = 0; i < data.items.length; i++) {
-              const item = data.items[i];
-              parts.push(`${i + 1}. ${item.title}`);
-              parts.push(`   URL: ${item.link}`);
-              if (item.snippet) {
-                parts.push(`   ${item.snippet.replace(/\n/g, ' ').trim()}`);
+            for (const item of data.items) {
+              let host = '';
+              try {
+                host = new URL(item.link).host;
+              } catch {
+                continue;
               }
-              parts.push('');
+              if (seenDomains.has(host)) continue;
+
+              const text = await this._scrapeUrl(item.link, perResultBudget, 10_000);
+              if (text === null) continue;
+
+              const score = WebSearchSkill._qualityScore(text, query);
+              if (score < minQualityScore) continue;
+
+              seenDomains.add(host);
+              scored.push({ item, text, score });
+
+              if (scored.length >= count) break;
+
+              // Python sleeps `delay` seconds between page fetches to avoid
+              // hammering target servers (skill.py:~460).
+              if (delaySeconds > 0) {
+                await new Promise((r) => setTimeout(r, delaySeconds * 1000));
+              }
             }
 
+            if (scored.length === 0) {
+              // Every scrape either failed or fell below the threshold — fall
+              // back to API snippets so the agent still has something to say.
+              const parts: string[] = [
+                `Web search results for '${query}' (quality filter yielded no full-page matches):`,
+                '',
+              ];
+              for (let i = 0; i < Math.min(data.items.length, count); i++) {
+                const item = data.items[i];
+                parts.push(`${i + 1}. ${item.title}`);
+                parts.push(`   URL: ${item.link}`);
+                if (item.snippet) {
+                  parts.push(`   ${item.snippet.replace(/\n/g, ' ').trim()}`);
+                }
+                parts.push('');
+              }
+              return new FunctionResult(parts.join('\n').trim());
+            }
+
+            // Ranked-by-score output with full page content.
+            scored.sort((a, b) => b.score - a.score);
+            const parts: string[] = [`Quality web search results for '${query}':`, ''];
+            for (let i = 0; i < scored.length; i++) {
+              const { item, text, score } = scored[i];
+              parts.push(
+                `=== RESULT ${i + 1} (Quality: ${score.toFixed(2)}) ===`,
+              );
+              parts.push(`Title: ${item.title}`);
+              parts.push(`URL: ${item.link}`);
+              if (item.snippet) {
+                parts.push(`Snippet: ${item.snippet.replace(/\n/g, ' ').trim()}`);
+              }
+              parts.push(`Content:\n${text}`);
+              parts.push('');
+            }
             return new FunctionResult(parts.join('\n').trim());
           } catch (err) {
             log.error('web_search_failed', {
@@ -413,6 +489,97 @@ export class WebSearchSkill extends SkillBase {
     return template.includes('{query}')
       ? template.replace(/\{query\}/g, query)
       : template;
+  }
+
+  /**
+   * Fetch a URL and extract clean text content via cheerio. Lightweight port
+   * of Python's GoogleSearchScraper.extract_html_content. Returns `null` on
+   * any failure (network, non-200, parse error, or SSRF rejection).
+   */
+  private async _scrapeUrl(
+    url: string,
+    contentLimit: number,
+    timeoutMs: number,
+  ): Promise<string | null> {
+    // SSRF guard — Python's scraper calls validate_url() before every
+    // requests.get() (skill.py:79-80, 209-210).
+    if (!(await validateUrl(url))) {
+      log.debug('web_search: scrape URL rejected by SSRF guard', { url });
+      return null;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        },
+      });
+      if (!response.ok) {
+        log.debug('web_search: scrape non-200', { url, status: response.status });
+        return null;
+      }
+      const body = await response.text();
+      const $ = cheerio.load(body);
+      // Remove boilerplate/noise tags — same 7 Python's lxml drops.
+      for (const tag of ['script', 'style', 'nav', 'header', 'footer', 'aside', 'noscript']) {
+        $(tag).remove();
+      }
+      // Prefer <main> / <article> containers when present (Python's
+      // extract_html_content uses similar selectors for clean main content).
+      const candidates = ['main', 'article', '[role="main"]', 'body'];
+      let text = '';
+      for (const sel of candidates) {
+        const picked = $(sel).first();
+        if (picked.length > 0) {
+          text = picked.text();
+          if (text.trim().length > 100) break;
+        }
+      }
+      text = text.replace(/\s+/g, ' ').trim();
+      if (text.length > contentLimit) {
+        text = text.slice(0, contentLimit) + '…';
+      }
+      return text || null;
+    } catch (err) {
+      log.debug('web_search: scrape failed', {
+        url,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Quality score (0-1) combining content length, query relevance, and a
+   * light boilerplate penalty. Scaled-down port of Python's
+   * GoogleSearchScraper._calculate_content_quality (skill.py:~380). Enough
+   * signal to sort and filter; not attempting the full 6-sub-score pipeline
+   * with hard-coded domain reputation lists.
+   */
+  private static _qualityScore(text: string, query: string): number {
+    if (!text) return 0;
+    const length = text.length;
+    // Length: saturates around 3000 chars (Python's typical good-page size).
+    const lengthScore = Math.min(1, length / 3000);
+    // Query relevance: fraction of query terms that appear in text.
+    const queryTerms = query
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((t) => t.length > 2);
+    const lowerText = text.toLowerCase();
+    const hits = queryTerms.filter((term) => lowerText.includes(term)).length;
+    const relevance = queryTerms.length === 0 ? 0.5 : hits / queryTerms.length;
+    // Boilerplate penalty: very short pages or pages saturated with "cookie"
+    // / "subscribe" / "accept" text tend to be gates, not content.
+    const boilerplate = /cookie|subscribe|accept all|sign in/i;
+    const boilerHits = (text.match(boilerplate) ?? []).length;
+    const penalty = Math.min(0.3, boilerHits * 0.05);
+    return Math.max(0, Math.min(1, 0.4 * lengthScore + 0.6 * relevance - penalty));
   }
 
   /** @returns Prompt section describing web search capabilities and usage guidance. */

--- a/src/skills/builtin/web_search.ts
+++ b/src/skills/builtin/web_search.ts
@@ -110,11 +110,13 @@ export class WebSearchSkill extends SkillBase {
       tool_name: {
         type: 'string',
         description: 'Custom tool name for this Web Search instance.',
+        required: false,
       },
       num_results: {
         type: 'integer',
         description: 'Number of high-quality results to return',
         default: 3,
+        required: false,
         min: 1,
         max: 10,
       },
@@ -127,7 +129,7 @@ export class WebSearchSkill extends SkillBase {
       },
       max_content_length: {
         type: 'integer',
-        description: 'Maximum total response size in characters (distributed across results)',
+        description: 'Maximum total response size in characters',
         default: 32768,
         required: false,
         min: 1000,
@@ -135,7 +137,7 @@ export class WebSearchSkill extends SkillBase {
       oversample_factor: {
         type: 'number',
         description:
-          'How many extra results to fetch for quality filtering (multiplier on num_results)',
+          'How many extra results to fetch for quality filtering (e.g., 2.5 = fetch 2.5x requested)',
         default: 2.5,
         required: false,
         min: 1.0,
@@ -152,8 +154,9 @@ export class WebSearchSkill extends SkillBase {
       no_results_message: {
         type: 'string',
         description:
-          'Message to show when no results are found. Use {query} as placeholder.',
+          'Message to show when no quality results are found. Use {query} as placeholder.',
         default: DEFAULT_NO_RESULTS_MESSAGE,
+        required: false,
       },
       safe_search: {
         type: 'string',
@@ -288,11 +291,13 @@ export class WebSearchSkill extends SkillBase {
           }
 
           const count = Math.max(1, Math.min(10, configNumResults));
-          // Python skill.py fetches oversample_factor * num_results, then
-          // scores/filters and returns the top `num_results`. Mirror that.
+          // Python skill.py:433 — `fetch_count = min(10, int(num_results * oversample_factor))`.
+          // Python's `int()` truncates toward zero; for positive values that's
+          // equivalent to Math.floor. Do NOT add a `max(count, …)` floor —
+          // Python's fetch_count can be less than num_results (e.g. factor=0.5).
           const fetchCount = Math.min(
             10,
-            Math.max(count, Math.ceil(count * oversampleFactor)),
+            Math.floor(count * oversampleFactor),
           );
 
           try {
@@ -327,83 +332,146 @@ export class WebSearchSkill extends SkillBase {
             }
 
             // Scrape each result page, score for quality, dedupe by domain,
-            // return the top `count` above the min threshold. Lightweight
-            // port of Python's GoogleSearchScraper.search_and_scrape_best
-            // (skill.py:~440).
-            const perResultBudget = Math.max(
-              500,
-              Math.floor(maxContentLength / count),
-            );
-            const seenDomains = new Set<string>();
-            const scored: Array<{
+            // return the top `count` above the min threshold. Port of
+            // Python's GoogleSearchScraper.search_and_scrape_best
+            // (skill.py:416-526).
+            //
+            // Python scrapes each URL up to `self.max_content_length` chars
+            // (skill.py:274-277 default), NOT the per-result budget. Metrics
+            // are computed on the scraped text, then output-time truncation
+            // applies the per-result budget. Mirror that.
+            type Candidate = {
               item: GoogleSearchItem;
               text: string;
               score: number;
-            }> = [];
+              host: string;
+              text_length: number;
+              sentence_count: number;
+              query_relevance: number;
+              query_words_found: string;
+              domain: string;
+            };
+            const allCandidates: Candidate[] = [];
 
-            for (const item of data.items) {
-              let host = '';
+            for (let idx = 0; idx < data.items.length; idx++) {
+              const item = data.items[idx];
               try {
-                host = new URL(item.link).host;
+                // SSRF / URL sanity — Python has no explicit pre-check; the
+                // scraper's inner `validate_url` handles it. We pre-parse to
+                // derive `host` for the domain-diverse selection pass.
+                const host = new URL(item.link).host;
+                const result = await this._scrapeUrl(
+                  item.link,
+                  maxContentLength,
+                  10_000,
+                  query,
+                );
+                if (result !== null && result.score >= minQualityScore) {
+                  allCandidates.push({
+                    item,
+                    text: result.text,
+                    score: result.score,
+                    host,
+                    text_length: result.text_length,
+                    sentence_count: result.sentence_count,
+                    query_relevance: result.query_relevance,
+                    query_words_found: result.query_words_found,
+                    domain: result.domain,
+                  });
+                }
               } catch {
-                continue;
+                // URL parse failure — skip this result but still apply the
+                // inter-request delay below so cadence matches Python.
               }
-              if (seenDomains.has(host)) continue;
 
-              const text = await this._scrapeUrl(item.link, perResultBudget, 10_000);
-              if (text === null) continue;
-
-              const score = WebSearchSkill._qualityScore(text, query);
-              if (score < minQualityScore) continue;
-
-              seenDomains.add(host);
-              scored.push({ item, text, score });
-
-              if (scored.length >= count) break;
-
-              // Python sleeps `delay` seconds between page fetches to avoid
-              // hammering target servers (skill.py:~460).
-              if (delaySeconds > 0) {
+              // Python skill.py:461-463 sleeps `delay` seconds between every
+              // iteration regardless of success/failure. Skip on the last
+              // iteration because there is nothing left to fetch.
+              if (delaySeconds > 0 && idx < data.items.length - 1) {
                 await new Promise((r) => setTimeout(r, delaySeconds * 1000));
               }
             }
 
-            if (scored.length === 0) {
-              // Every scrape either failed or fell below the threshold — fall
-              // back to API snippets so the agent still has something to say.
-              const parts: string[] = [
-                `Web search results for '${query}' (quality filter yielded no full-page matches):`,
-                '',
-              ];
-              for (let i = 0; i < Math.min(data.items.length, count); i++) {
-                const item = data.items[i];
-                parts.push(`${i + 1}. ${item.title}`);
-                parts.push(`   URL: ${item.link}`);
-                if (item.snippet) {
-                  parts.push(`   ${item.snippet.replace(/\n/g, ' ').trim()}`);
-                }
-                parts.push('');
+            // Two-pass selection: sort by score desc, then (1) take the
+            // highest-quality result per unique host, (2) fill remaining
+            // slots from the leftovers. Mirrors Python skill.py:~495-540.
+            allCandidates.sort((a, b) => b.score - a.score);
+            const chosen: Candidate[] = [];
+            const chosenHosts = new Set<string>();
+            for (const cand of allCandidates) {
+              if (chosen.length >= count) break;
+              if (!chosenHosts.has(cand.host)) {
+                chosen.push(cand);
+                chosenHosts.add(cand.host);
               }
-              return new FunctionResult(parts.join('\n').trim());
+            }
+            if (chosen.length < count) {
+              for (const cand of allCandidates) {
+                if (chosen.length >= count) break;
+                if (!chosen.includes(cand)) chosen.push(cand);
+              }
+            }
+            const scored = chosen;
+
+            if (allCandidates.length === 0 || scored.length === 0) {
+              // Python skill.py:465-466 / 488-489 return a plain "no quality
+              // results" string, which the outer handler (skill.py:640-642)
+              // detects and replaces with the configured `no_results_message`.
+              // Skip the middleman and return the configured message directly.
+              return new FunctionResult(
+                WebSearchSkill._formatNoResultsMessage(noResultsMessage, query),
+              );
             }
 
+            // Per-result content budget — Python skill.py:491-495 divides
+            // by `len(best_results)` (the chosen count), not `num_results`,
+            // so under-filled result sets get more room per source.
+            const overheadPerResult = 400;
+            const availableForContent =
+              maxContentLength - scored.length * overheadPerResult;
+            const perResultBudget = Math.max(
+              2000,
+              Math.floor(availableForContent / scored.length),
+            );
+
             // Ranked-by-score output with full page content.
-            scored.sort((a, b) => b.score - a.score);
-            const parts: string[] = [`Quality web search results for '${query}':`, ''];
+            // Python skill.py:499-524 format — header lines + per-result
+            // block with Title / URL / Source / Snippet / Content Stats /
+            // Query Relevance / Content + 50-char separator.
+            const separator = '='.repeat(50);
+            const innerLines: string[] = [
+              `Found ${allCandidates.length} results meeting quality threshold from ${data.items.length} searched.`,
+              `Showing top ${scored.length} from diverse sources:\n`,
+            ];
             for (let i = 0; i < scored.length; i++) {
-              const { item, text, score } = scored[i];
-              parts.push(
-                `=== RESULT ${i + 1} (Quality: ${score.toFixed(2)}) ===`,
-              );
-              parts.push(`Title: ${item.title}`);
-              parts.push(`URL: ${item.link}`);
-              if (item.snippet) {
-                parts.push(`Snippet: ${item.snippet.replace(/\n/g, ' ').trim()}`);
+              const cand = scored[i];
+              let block = `=== RESULT ${i + 1} (Quality: ${cand.score.toFixed(2)}) ===\n`;
+              block += `Title: ${cand.item.title}\n`;
+              block += `URL: ${cand.item.link}\n`;
+              block += `Source: ${cand.domain}\n`;
+              // Python skill.py:507 always prints `Snippet:` (empty when the
+              // Google result has no snippet). Mirror that for a stable layout.
+              const rawSnippet = cand.item.snippet ?? '';
+              block += `Snippet: ${rawSnippet.replace(/\n/g, ' ').trim()}\n`;
+              block += `Content Stats: ${cand.text_length} chars, ${cand.sentence_count} sentences\n`;
+              block += `Query Relevance: ${cand.query_relevance.toFixed(2)} (keywords: ${cand.query_words_found})\n`;
+              block += `Content:\n`;
+              let content = cand.text;
+              if (content.length > perResultBudget) {
+                content = content.slice(0, perResultBudget) + '...';
               }
-              parts.push(`Content:\n${text}`);
-              parts.push('');
+              block += content;
+              // Python skill.py:523 — `f"\n{'='*50}\n\n"` (two trailing newlines).
+              block += `\n${separator}\n\n`;
+              innerLines.push(block);
             }
-            return new FunctionResult(parts.join('\n').trim());
+            const innerOutput = innerLines.join('\n');
+            // Python's outer `_web_search_handler` (skill.py:644) wraps the
+            // inner formatter output with a `"Quality web search results for
+            // '<query>':\n\n"` preamble.
+            return new FunctionResult(
+              `Quality web search results for '${query}':\n\n${innerOutput}`,
+            );
           } catch (err) {
             log.error('web_search_failed', {
               error: err instanceof Error ? err.message : String(err),
@@ -425,15 +493,189 @@ export class WebSearchSkill extends SkillBase {
   }
 
   /**
-   * Fetch a URL and extract clean text content via cheerio. Lightweight port
-   * of Python's GoogleSearchScraper.extract_html_content. Returns `null` on
-   * any failure (network, non-200, parse error, or SSRF rejection).
+   * Check whether the URL points at Reddit. Python parity: `is_reddit_url`
+   * (skill.py:66).
+   */
+  private static _isRedditUrl(url: string): boolean {
+    try {
+      const host = new URL(url).hostname.toLowerCase();
+      return host.includes('reddit.com') || host.includes('redd.it');
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Fetch a Reddit URL via the `.json` endpoint and build a structured summary
+   * of the post + top comments.
+   *
+   * Python parity: `extract_reddit_content` (skill.py:71-190). Matches the
+   * post-title/author/score/comments assembly and the top-20 → valid → top-5
+   * comment pipeline. Returns just the compiled text — Python's
+   * `search_and_scrape_best` unconditionally overwrites Reddit's
+   * engagement-score metrics with the 6-factor `_calculate_content_quality`
+   * (skill.py:447-448), so we skip computing the dead engagement score here
+   * and let the handler score the text via `_qualityMetrics`.
+   *
+   * Falls through to HTML extraction on JSON fetch failure or malformed
+   * payload, matching Python's `except Exception: fall back` behavior.
+   */
+  private async _extractRedditContent(
+    url: string,
+    contentLimit: number,
+    timeoutMs: number,
+  ): Promise<{ text: string } | null> {
+    try {
+      if (!(await validateUrl(url))) {
+        log.debug('web_search: reddit URL rejected by SSRF guard', { url });
+        return null;
+      }
+      const jsonUrl = url.endsWith('.json')
+        ? url
+        : `${url.replace(/\/+$/, '')}.json`;
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      let response: Response;
+      try {
+        response = await fetch(jsonUrl, {
+          signal: controller.signal,
+          headers: { 'User-Agent': 'SignalWire-WebSearch/2.0' },
+        });
+      } finally {
+        clearTimeout(timer);
+      }
+      if (!response.ok) {
+        log.debug('web_search: reddit JSON non-200', {
+          url: jsonUrl,
+          status: response.status,
+        });
+        return null;
+      }
+      const data = (await response.json()) as unknown;
+      if (!Array.isArray(data) || data.length < 1) {
+        log.debug('web_search: reddit JSON structure invalid', { url });
+        return null;
+      }
+
+      const listing0 = data[0] as {
+        data?: { children?: Array<{ data?: Record<string, unknown> }> };
+      };
+      const postEntry = listing0?.data?.children?.[0]?.data;
+      if (!postEntry) {
+        log.debug('web_search: reddit post missing', { url });
+        return null;
+      }
+
+      const title = (postEntry['title'] as string | undefined) ?? 'No title';
+      const author = (postEntry['author'] as string | undefined) ?? 'unknown';
+      const postScore = (postEntry['score'] as number | undefined) ?? 0;
+      const numComments = (postEntry['num_comments'] as number | undefined) ?? 0;
+      const subreddit = (postEntry['subreddit'] as string | undefined) ?? '';
+      const selftext = ((postEntry['selftext'] as string | undefined) ?? '').trim();
+
+      const parts: string[] = [];
+      parts.push(`Reddit r/${subreddit} Discussion`);
+      parts.push(`\nPost: ${title}`);
+      parts.push(
+        `Author: ${author} | Score: ${postScore} | Comments: ${numComments}`,
+      );
+      if (selftext && selftext !== '[removed]' && selftext !== '[deleted]') {
+        parts.push(`\nOriginal Post:\n${selftext.slice(0, 1000)}`);
+      }
+
+      const validComments: Array<{ body: string; author: string; score: number }> = [];
+      if (data.length > 1) {
+        const listing1 = data[1] as {
+          data?: {
+            children?: Array<{ kind?: string; data?: Record<string, unknown> }>;
+          };
+        };
+        const comments = listing1?.data?.children ?? [];
+        for (const c of comments.slice(0, 20)) {
+          if (c.kind !== 't1' || !c.data) continue;
+          const body = ((c.data['body'] as string | undefined) ?? '').trim();
+          if (
+            !body ||
+            body === '[removed]' ||
+            body === '[deleted]' ||
+            body.length <= 50
+          ) {
+            continue;
+          }
+          validComments.push({
+            body,
+            author: (c.data['author'] as string | undefined) ?? 'unknown',
+            score: (c.data['score'] as number | undefined) ?? 0,
+          });
+        }
+        validComments.sort((a, b) => b.score - a.score);
+
+        if (validComments.length > 0) {
+          parts.push('\n--- Top Discussion ---');
+          validComments.slice(0, 5).forEach((c, i) => {
+            let commentText = c.body.slice(0, 500);
+            if (c.body.length > 500) commentText += '...';
+            parts.push(
+              `\nComment ${i + 1} (Score: ${c.score}, Author: ${c.author}):`,
+            );
+            parts.push(commentText);
+          });
+        }
+      }
+
+      let text = parts.join('\n');
+
+      if (text.length > contentLimit) {
+        text = text.slice(0, contentLimit);
+      }
+
+      return { text };
+    } catch (err) {
+      log.debug('web_search: reddit extraction failed', {
+        url,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Fetch a URL and extract clean text content, then score it with the
+   * 6-factor `_qualityMetrics`. Reddit URLs are routed to the JSON extractor
+   * first; the compiled Reddit text is scored with the same 6-factor formula
+   * to match Python's `search_and_scrape_best` overwrite behavior
+   * (skill.py:447-448).
+   *
+   * Python parity: `extract_text_from_url` (skill.py:192-202). Returns `null`
+   * on any failure (network, non-200, parse error, or SSRF rejection).
    */
   private async _scrapeUrl(
     url: string,
     contentLimit: number,
     timeoutMs: number,
-  ): Promise<string | null> {
+    query: string,
+  ): Promise<
+    | {
+        text: string;
+        score: number;
+        text_length: number;
+        sentence_count: number;
+        query_relevance: number;
+        query_words_found: string;
+        domain: string;
+      }
+    | null
+  > {
+    if (WebSearchSkill._isRedditUrl(url)) {
+      const reddit = await this._extractRedditContent(url, contentLimit, timeoutMs);
+      if (reddit) {
+        const metrics = WebSearchSkill._qualityMetrics(reddit.text, url, query);
+        return { text: reddit.text, ...metrics };
+      }
+      // Python skill.py:189-190 falls through to HTML extraction if the
+      // Reddit JSON path fails. Mirror that.
+    }
+
     // SSRF guard — Python's scraper calls validate_url() before every
     // requests.get() (skill.py:79-80, 209-210).
     if (!(await validateUrl(url))) {
@@ -456,13 +698,69 @@ export class WebSearchSkill extends SkillBase {
       }
       const body = await response.text();
       const $ = cheerio.load(body);
-      // Remove boilerplate/noise tags — same 7 Python's lxml drops.
-      for (const tag of ['script', 'style', 'nav', 'header', 'footer', 'aside', 'noscript']) {
+      // Remove boilerplate/noise tags. Python skill.py:239 drops 8 tags
+      // (script, style, nav, footer, header, aside, noscript, iframe).
+      for (const tag of [
+        'script',
+        'style',
+        'nav',
+        'header',
+        'footer',
+        'aside',
+        'noscript',
+        'iframe',
+      ]) {
         $(tag).remove();
+      }
+      // Remove elements whose class or id matches any boilerplate/navigation
+      // pattern. Python skill.py:245-257 — 16 patterns applied to both class
+      // and id attributes via case-insensitive regex.
+      const unwantedPatterns = [
+        'sidebar',
+        'navigation',
+        'menu',
+        'advertisement',
+        'ads',
+        'banner',
+        'popup',
+        'modal',
+        'cookie',
+        'gdpr',
+        'subscribe',
+        'newsletter',
+        'comments',
+        'related',
+        'share',
+        'social',
+      ];
+      for (const pattern of unwantedPatterns) {
+        const regex = new RegExp(pattern, 'i');
+        $('[class]').each((_, el) => {
+          const cls = $(el).attr('class') ?? '';
+          if (regex.test(cls)) $(el).remove();
+        });
+        $('[id]').each((_, el) => {
+          const id = $(el).attr('id') ?? '';
+          if (regex.test(id)) $(el).remove();
+        });
       }
       // Prefer <main> / <article> containers when present (Python's
       // extract_html_content uses similar selectors for clean main content).
-      const candidates = ['main', 'article', '[role="main"]', 'body'];
+      const candidates = [
+        'article',
+        'main',
+        '[role="main"]',
+        '.content',
+        '#content',
+        '.post',
+        '.entry-content',
+        '.article-body',
+        '.story-body',
+        '.markdown-body',
+        '.wiki-body',
+        '.documentation',
+        'body',
+      ];
       let text = '';
       for (const sel of candidates) {
         const picked = $(sel).first();
@@ -473,9 +771,11 @@ export class WebSearchSkill extends SkillBase {
       }
       text = text.replace(/\s+/g, ' ').trim();
       if (text.length > contentLimit) {
-        text = text.slice(0, contentLimit) + '…';
+        text = text.slice(0, contentLimit);
       }
-      return text || null;
+      if (!text) return null;
+      const metrics = WebSearchSkill._qualityMetrics(text, url, query);
+      return { text, ...metrics };
     } catch (err) {
       log.debug('web_search: scrape failed', {
         url,
@@ -488,31 +788,215 @@ export class WebSearchSkill extends SkillBase {
   }
 
   /**
-   * Quality score (0-1) combining content length, query relevance, and a
-   * light boilerplate penalty. Scaled-down port of Python's
-   * GoogleSearchScraper._calculate_content_quality (skill.py:~380). Enough
-   * signal to sort and filter; not attempting the full 6-sub-score pipeline
-   * with hard-coded domain reputation lists.
+   * Six-factor content quality metrics (score + sub-metrics used in the
+   * per-result output). Combines content length, word diversity,
+   * boilerplate penalty, sentence structure, domain reputation, and query
+   * relevance.
+   *
+   * Python parity: `_calculate_content_quality` (skill.py:284-414). Preserves
+   * the weights (0.25/0.10/0.10/0.15/0.15/0.25), the 26-phrase boilerplate
+   * list, the quality/low-quality domain lists, and the phrase-match bonus
+   * on relevance. Also returns the same metric fields Python exposes
+   * (`text_length`, `sentence_count`, `query_relevance`, `query_words_found`,
+   * `domain`) so the handler can render the full Python output format.
    */
-  private static _qualityScore(text: string, query: string): number {
-    if (!text) return 0;
-    const length = text.length;
-    // Length: saturates around 3000 chars (Python's typical good-page size).
-    const lengthScore = Math.min(1, length / 3000);
-    // Query relevance: fraction of query terms that appear in text.
-    const queryTerms = query
+  private static _qualityMetrics(
+    text: string,
+    url: string,
+    query: string,
+  ): {
+    score: number;
+    text_length: number;
+    sentence_count: number;
+    query_relevance: number;
+    query_words_found: string;
+    domain: string;
+  } {
+    if (!text) {
+      return {
+        score: 0,
+        text_length: 0,
+        sentence_count: 0,
+        query_relevance: 0,
+        query_words_found: 'N/A',
+        domain: '',
+      };
+    }
+
+    // 1. Length score — tiered bands (Python skill.py:300-310).
+    const textLength = text.length;
+    let lengthScore: number;
+    if (textLength < 500) {
+      lengthScore = 0;
+    } else if (textLength < 2000) {
+      lengthScore = ((textLength - 500) / 1500) * 0.5;
+    } else if (textLength <= 10000) {
+      lengthScore = 1.0;
+    } else {
+      lengthScore = Math.max(0.8, 1.0 - (textLength - 10000) / 20000);
+    }
+
+    // 2. Word diversity — unique / (total * 0.3). Python skill.py:313-321.
+    const words = text.toLowerCase().split(/\s+/).filter(Boolean);
+    const diversityScore =
+      words.length === 0
+        ? 0
+        : Math.min(1, new Set(words).size / (words.length * 0.3));
+
+    // 3. Boilerplate penalty — 26 phrases, -15% per phrase.
+    // Python skill.py:324-335.
+    const boilerplatePhrases = [
+      'cookie',
+      'privacy policy',
+      'terms of service',
+      'subscribe',
+      'sign up',
+      'log in',
+      'advertisement',
+      'sponsored',
+      'copyright',
+      'all rights reserved',
+      'skip to',
+      'navigation',
+      'breadcrumb',
+      'reddit inc',
+      'google llc',
+      'expand navigation',
+      'members •',
+      'archived post',
+      'votes cannot be cast',
+      'r/',
+      'subreddit',
+      'youtube',
+      'facebook',
+      'twitter',
+      'instagram',
+      'pinterest',
+    ];
+    const lowerText = text.toLowerCase();
+    const boilerplateCount = boilerplatePhrases.reduce(
+      (n, phrase) => (lowerText.includes(phrase) ? n + 1 : n),
+      0,
+    );
+    const boilerplatePenalty = Math.max(0, 1 - boilerplateCount * 0.15);
+
+    // 4. Sentence score — count sentences with >30 chars; target 10.
+    // Python skill.py:339-342.
+    const sentences = text
+      .split(/[.!?]+/)
+      .filter((s) => s.trim().length > 30);
+    const sentenceScore = Math.min(1, sentences.length / 10);
+
+    // 5. Domain score — quality domains +1.5×, low-quality 0.1×, else 1.0.
+    // Python skill.py:344-365.
+    let domain = '';
+    try {
+      domain = new URL(url).hostname.toLowerCase();
+    } catch {
+      domain = '';
+    }
+    const qualityDomains = [
+      'wikipedia.org',
+      'starwars.fandom.com',
+      'imdb.com',
+      'screenrant.com',
+      'denofgeek.com',
+      'ign.com',
+      'hollywoodreporter.com',
+      'variety.com',
+      'ew.com',
+      'stackexchange.com',
+      'stackoverflow.com',
+      'github.com',
+      'medium.com',
+      'dev.to',
+      'arxiv.org',
+      'nature.com',
+      'sciencedirect.com',
+      'ieee.org',
+    ];
+    const lowQualityDomains = [
+      'reddit.com',
+      'youtube.com',
+      'facebook.com',
+      'twitter.com',
+      'instagram.com',
+      'pinterest.com',
+      'tiktok.com',
+      'x.com',
+    ];
+    let domainScore = 1.0;
+    if (qualityDomains.some((d) => domain.includes(d))) {
+      domainScore = 1.5;
+    } else if (lowQualityDomains.some((d) => domain.includes(d))) {
+      domainScore = 0.1;
+    }
+
+    // 6. Query relevance — word overlap + phrase bonus.
+    // Python skill.py:370-395.
+    const stopWords = new Set([
+      'the',
+      'a',
+      'an',
+      'and',
+      'or',
+      'but',
+      'in',
+      'on',
+      'at',
+      'to',
+      'for',
+      'of',
+      'with',
+      'by',
+      'from',
+      'as',
+      'is',
+      'was',
+      'are',
+      'were',
+    ]);
+    const queryWords = query
       .toLowerCase()
       .split(/\s+/)
-      .filter((t) => t.length > 2);
-    const lowerText = text.toLowerCase();
-    const hits = queryTerms.filter((term) => lowerText.includes(term)).length;
-    const relevance = queryTerms.length === 0 ? 0.5 : hits / queryTerms.length;
-    // Boilerplate penalty: very short pages or pages saturated with "cookie"
-    // / "subscribe" / "accept" text tend to be gates, not content.
-    const boilerplate = /cookie|subscribe|accept all|sign in/i;
-    const boilerHits = (text.match(boilerplate) ?? []).length;
-    const penalty = Math.min(0.3, boilerHits * 0.05);
-    return Math.max(0, Math.min(1, 0.4 * lengthScore + 0.6 * relevance - penalty));
+      .filter((w) => w.length > 2 && !stopWords.has(w));
+    let relevanceScore: number;
+    let wordsFound = 'N/A';
+    if (queryWords.length === 0) {
+      relevanceScore = 0.5;
+    } else {
+      const lowerContent = text.toLowerCase();
+      let hits = 0;
+      for (const w of queryWords) {
+        if (lowerContent.includes(w)) hits++;
+      }
+      let phraseBonus = 0;
+      for (let i = 0; i < queryWords.length - 1; i++) {
+        const phrase = `${queryWords[i]} ${queryWords[i + 1]}`;
+        if (lowerContent.includes(phrase)) phraseBonus += 0.2;
+      }
+      relevanceScore = Math.min(1, hits / queryWords.length + phraseBonus);
+      // Python skill.py:392 — `"{words_found}/{len(query_words)}"` string.
+      wordsFound = `${hits}/${queryWords.length}`;
+    }
+
+    // Weighted combination (Python skill.py:397-405).
+    const score =
+      lengthScore * 0.25 +
+      diversityScore * 0.1 +
+      boilerplatePenalty * 0.1 +
+      sentenceScore * 0.15 +
+      domainScore * 0.15 +
+      relevanceScore * 0.25;
+
+    return {
+      score,
+      text_length: textLength,
+      sentence_count: sentences.length,
+      query_relevance: relevanceScore,
+      query_words_found: wordsFound,
+      domain,
+    };
   }
 
   /** @returns Prompt section describing web search capabilities and usage guidance. */

--- a/src/skills/builtin/web_search.ts
+++ b/src/skills/builtin/web_search.ts
@@ -9,7 +9,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -81,18 +80,15 @@ interface GoogleSearchResponse {
  * `min_quality_score`.
  */
 export class WebSearchSkill extends SkillBase {
-  /** Python SDK parity: multiple instances can coexist with different tool names. */
+  // Python ground truth: skills/web_search/skill.py:559-567
+  // REQUIRED_PACKAGES = ["bs4", "requests"] in Python; TS uses cheerio + fetch so [].
+  static override SKILL_NAME = 'web_search';
+  static override SKILL_DESCRIPTION =
+    'Search the web for information using Google Custom Search API';
+  static override SKILL_VERSION = '2.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
-
-  /**
-   * @param config - Optional configuration; supports `api_key`,
-   *   `search_engine_id`, `tool_name`, `num_results`, `no_results_message`,
-   *   `safe_search`, `delay`, `max_content_length`, `oversample_factor`,
-   *   `min_quality_score`.
-   */
-  constructor(config?: SkillConfig) {
-    super('web_search', config);
-  }
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
@@ -173,78 +169,6 @@ export class WebSearchSkill extends SkillBase {
    *   Reports `GOOGLE_SEARCH_ENGINE_ID` as the canonical name; `GOOGLE_SEARCH_CX`
    *   is still accepted as a legacy fallback at runtime.
    */
-  getManifest(): SkillManifest {
-    return {
-      name: 'web_search',
-      description:
-        'Search the web for information using Google Custom Search API',
-      version: '2.0.0',
-      author: 'SignalWire',
-      tags: ['search', 'web', 'google', 'api', 'external'],
-      // Python declares REQUIRED_ENV_VARS = [] — credentials may arrive via
-      // either config params OR env vars, so nothing is strictly required
-      // at the env-var layer. hasAllEnvVars() treats an empty list as "all
-      // present", letting the config-only path succeed. setup() still
-      // validates that at least one source is populated.
-      requiredEnvVars: [],
-      requiredPackages: [],
-      configSchema: {
-        api_key: {
-          type: 'string',
-          description: 'Google Custom Search API key.',
-        },
-        search_engine_id: {
-          type: 'string',
-          description: 'Google Custom Search Engine ID.',
-        },
-        tool_name: {
-          type: 'string',
-          description: 'Custom tool name for this instance.',
-        },
-        num_results: {
-          type: 'integer',
-          description: 'Number of results to return (1-10). Defaults to 3.',
-          default: 3,
-        },
-        delay: {
-          type: 'number',
-          description:
-            'Delay between scraping pages (Python parity; ignored in TS).',
-          default: 0.5,
-        },
-        max_content_length: {
-          type: 'integer',
-          description:
-            'Maximum total response size (Python parity; ignored in TS).',
-          default: 32768,
-        },
-        oversample_factor: {
-          type: 'number',
-          description:
-            'Oversampling factor for quality filtering (Python parity; ignored in TS).',
-          default: 2.5,
-        },
-        min_quality_score: {
-          type: 'number',
-          description:
-            'Minimum quality score (Python parity; ignored in TS).',
-          default: 0.3,
-        },
-        no_results_message: {
-          type: 'string',
-          description:
-            'Message returned when no results are found. Supports {query} interpolation.',
-        },
-        safe_search: {
-          type: 'string',
-          description:
-            'Safe search level: "off", "medium", or "high". Defaults to "medium".',
-          default: 'medium',
-        },
-      },
-    };
-  }
-
   /**
    * Validate required credentials before the skill becomes active.
    *

--- a/src/skills/builtin/wikipedia_search.ts
+++ b/src/skills/builtin/wikipedia_search.ts
@@ -49,10 +49,18 @@ interface WikipediaActionExtractsResponse {
  * customizes the fallback text (supports `{query}` interpolation).
  */
 export class WikipediaSearchSkill extends SkillBase {
-  /** Resolved `num_results` value (populated in `setup()`). */
-  protected numResults: number = 1;
-  /** Resolved `no_results_message` template (populated in `setup()`). */
-  private _noResultsMessage: string = DEFAULT_NO_RESULTS_MESSAGE;
+  /**
+   * Resolved `num_results` value (populated in `setup()`).
+   * Public to mirror Python's `self.num_results` — accessible to subclasses
+   * and external test code inspecting skill state.
+   */
+  public numResults: number = 1;
+  /**
+   * Resolved `no_results_message` template (populated in `setup()`).
+   * Protected to mirror Python's `self.no_results_message` public visibility
+   * within the class hierarchy.
+   */
+  protected noResultsMessage: string = DEFAULT_NO_RESULTS_MESSAGE;
 
   /**
    * @param config - Optional configuration; supports `num_results` and
@@ -80,7 +88,7 @@ export class WikipediaSearchSkill extends SkillBase {
     };
   }
 
-  /** @returns Manifest with skill metadata (no required env vars). */
+  /** @returns Manifest with skill metadata (no required env vars or packages). */
   getManifest(): SkillManifest {
     return {
       name: 'wikipedia_search',
@@ -89,22 +97,33 @@ export class WikipediaSearchSkill extends SkillBase {
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'wikipedia', 'encyclopedia', 'knowledge', 'external'],
+      requiredEnvVars: [],
+      // Python's REQUIRED_PACKAGES = ["requests"]; Node's native fetch replaces
+      // requests so there's no equivalent npm package to declare. Empty for parity.
+      requiredPackages: [],
     };
   }
 
   /**
-   * Extract config values into instance state. Clamps `num_results` to the
-   * 1-5 range (matching Python's `max(1, ...)` floor plus the schema cap).
+   * Extract config values into instance state. Enforces `num_results >= 1`
+   * (matching Python `skill.py:_setup` `max(1, ...)` floor). The schema's
+   * `max: 5` handles the upper bound at validation time — no runtime clamp
+   * here, so callers passing larger values get the raw value as in Python.
    */
   override async setup(): Promise<boolean> {
+    // Match Python setup() which validates required packages and returns false
+    // on missing. Node's native fetch needs no packages here, so this is a
+    // no-op unless a subclass declares requiredPackages.
+    if (!(await this.hasAllPackages())) return false;
+
     const configured = this.getConfig<number>('num_results', 1);
-    this.numResults = Math.max(1, Math.min(5, Math.floor(configured)));
+    this.numResults = Math.max(1, Math.floor(configured));
 
     const rawMessage = this.getConfig<string | undefined>(
       'no_results_message',
       undefined,
     );
-    this._noResultsMessage =
+    this.noResultsMessage =
       rawMessage && rawMessage.length > 0 ? rawMessage : DEFAULT_NO_RESULTS_MESSAGE;
     return true;
   }
@@ -211,19 +230,33 @@ export class WikipediaSearchSkill extends SkillBase {
       const separator = '\n\n' + '='.repeat(50) + '\n\n';
       return articles.join(separator);
     } catch (err) {
-      log.error('wikipedia_search_failed', {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return `Error searching Wikipedia: ${
-        err instanceof Error ? err.message : String(err)
-      }`;
+      const message = err instanceof Error ? err.message : String(err);
+      // Python raises RequestException for network errors and Exception for
+      // the rest, so it emits two distinct user-facing strings (skill.py:85,91).
+      // Mirror that split: AbortError / fetch-layer errors → "accessing",
+      // everything else → "searching".
+      if (
+        err instanceof Error &&
+        (err.name === 'AbortError' ||
+          err.name === 'TypeError' /* fetch network failures */ ||
+          err.message.includes('fetch'))
+      ) {
+        log.error('wikipedia_access_failed', { error: message });
+        return `Error accessing Wikipedia: ${message}`;
+      }
+      log.error('wikipedia_search_failed', { error: message });
+      return `Error searching Wikipedia: ${message}`;
     }
   }
 
-  /** Fetch JSON with a 30-second timeout. Returns `null` on any failure. */
+  /**
+   * Fetch JSON with a 10-second timeout (matches Python `requests.get(..., timeout=10)`).
+   * Returns `null` on HTTP error or network failure, logging the cause so
+   * diagnostic signal isn't silently lost.
+   */
   private async _fetchJson<T>(url: string): Promise<T | null> {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 30_000);
+    const timeout = setTimeout(() => controller.abort(), 10_000);
     try {
       const response = await fetch(url, {
         headers: {
@@ -233,10 +266,15 @@ export class WikipediaSearchSkill extends SkillBase {
         signal: controller.signal,
       });
       if (!response.ok) {
+        log.warn('wikipedia_fetch_http_error', { url, status: response.status });
         return null;
       }
       return (await response.json()) as T;
-    } catch {
+    } catch (err) {
+      log.warn('wikipedia_fetch_failed', {
+        url,
+        error: err instanceof Error ? err.message : String(err),
+      });
       return null;
     } finally {
       clearTimeout(timeout);
@@ -245,9 +283,9 @@ export class WikipediaSearchSkill extends SkillBase {
 
   /** Render the configured no-results message, substituting `{query}`. */
   private _formatNoResults(query: string): string {
-    return this._noResultsMessage.includes('{query}')
-      ? this._noResultsMessage.replace(/\{query\}/g, query)
-      : this._noResultsMessage;
+    return this.noResultsMessage.includes('{query}')
+      ? this.noResultsMessage.replace(/\{query\}/g, query)
+      : this.noResultsMessage;
   }
 
   /** @returns Prompt section describing Wikipedia search capabilities and usage guidance. */

--- a/src/skills/builtin/wikipedia_search.ts
+++ b/src/skills/builtin/wikipedia_search.ts
@@ -8,7 +8,6 @@
 
 import { SkillBase } from '../SkillBase.js';
 import type {
-  SkillManifest,
   SkillToolDefinition,
   SkillPromptSection,
   SkillConfig,
@@ -49,6 +48,16 @@ interface WikipediaActionExtractsResponse {
  * customizes the fallback text (supports `{query}` interpolation).
  */
 export class WikipediaSearchSkill extends SkillBase {
+  // Python ground truth: skills/wikipedia_search/skill.py:26-31
+  // REQUIRED_PACKAGES = ["requests"] in Python; TS uses native fetch so [].
+  static override SKILL_NAME = 'wikipedia_search';
+  static override SKILL_DESCRIPTION =
+    'Search Wikipedia for information about a topic and get article summaries';
+  static override SKILL_VERSION = '1.0.0';
+  static override REQUIRED_PACKAGES: readonly string[] = [];
+  static override REQUIRED_ENV_VARS: readonly string[] = [];
+  // Python: SUPPORTS_MULTIPLE_INSTANCES = False (inherits default).
+
   /**
    * Resolved `num_results` value (populated in `setup()`).
    * Public to mirror Python's `self.num_results` — accessible to subclasses
@@ -61,14 +70,6 @@ export class WikipediaSearchSkill extends SkillBase {
    * within the class hierarchy.
    */
   protected noResultsMessage: string = DEFAULT_NO_RESULTS_MESSAGE;
-
-  /**
-   * @param config - Optional configuration; supports `num_results` and
-   *   `no_results_message`.
-   */
-  constructor(config?: SkillConfig) {
-    super('wikipedia_search', config);
-  }
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
@@ -85,22 +86,6 @@ export class WikipediaSearchSkill extends SkillBase {
         description: 'Custom message when no Wikipedia articles are found',
         default: DEFAULT_NO_RESULTS_MESSAGE,
       },
-    };
-  }
-
-  /** @returns Manifest with skill metadata (no required env vars or packages). */
-  getManifest(): SkillManifest {
-    return {
-      name: 'wikipedia_search',
-      description:
-        'Search Wikipedia for information about a topic and get article summaries',
-      version: '1.0.0',
-      author: 'SignalWire',
-      tags: ['search', 'wikipedia', 'encyclopedia', 'knowledge', 'external'],
-      requiredEnvVars: [],
-      // Python's REQUIRED_PACKAGES = ["requests"]; Node's native fetch replaces
-      // requests so there's no equivalent npm package to declare. Empty for parity.
-      requiredPackages: [],
     };
   }
 

--- a/src/skills/builtin/wikipedia_search.ts
+++ b/src/skills/builtin/wikipedia_search.ts
@@ -1,9 +1,11 @@
 /**
  * Wikipedia Search Skill - Searches Wikipedia for article summaries.
  *
- * Tier 3 built-in skill: no external API key required.
- * Uses the Wikipedia REST API to fetch article summaries and extracts
- * for any given topic.
+ * Tier 3 built-in skill: no external API key required. Uses the Wikipedia
+ * REST API to fetch article summaries and extracts for any given topic.
+ * Matches the Python SDK's `num_results` / `no_results_message` parity and
+ * adds `language` + `max_content_length` for multi-language and output
+ * trimming support.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -18,6 +20,10 @@ import { FunctionResult } from '../../FunctionResult.js';
 import { getLogger } from '../../Logger.js';
 
 const log = getLogger('WikipediaSearchSkill');
+
+const DEFAULT_NO_RESULTS_MESSAGE =
+  "I couldn't find any Wikipedia articles for '{query}'. " +
+  'Try rephrasing your search or using different keywords.';
 
 /** Response shape from the Wikipedia REST API page summary endpoint. */
 interface WikipediaSummaryResponse {
@@ -46,28 +52,46 @@ interface WikipediaSummaryResponse {
   };
 }
 
-/** Response shape from the Wikipedia search API. */
-interface WikipediaSearchResponse {
-  /** Array of matching page results. */
-  pages?: Array<{
-    id: number;
-    key: string;
-    title: string;
-    description?: string;
-    excerpt?: string;
-  }>;
+/** Response shape from the Wikipedia action=query search API. */
+interface WikipediaActionSearchResponse {
+  query?: {
+    search?: Array<{
+      title: string;
+      pageid?: number;
+      snippet?: string;
+    }>;
+  };
+}
+
+/** Response shape from the Wikipedia action=query extracts API. */
+interface WikipediaActionExtractsResponse {
+  query?: {
+    pages?: Record<string, { title?: string; extract?: string }>;
+  };
 }
 
 /**
  * Searches Wikipedia for article summaries and extracts.
  *
- * Tier 3 built-in skill with no external API key required. Uses the Wikipedia
- * REST API to fetch article summaries for any given topic, with a configurable
- * number of sentences.
+ * Tier 3 built-in skill with no external API key required. The configured
+ * `num_results` drives how many articles are aggregated; `no_results_message`
+ * customizes the fallback text (supports `{query}` interpolation); `language`
+ * selects the Wikipedia edition (`en`, `fr`, `de`, …); `max_content_length`
+ * trims the final output.
  */
 export class WikipediaSearchSkill extends SkillBase {
+  /** Resolved `num_results` value (populated in `setup()`). */
+  private _numResults: number = 1;
+  /** Resolved `no_results_message` template (populated in `setup()`). */
+  private _noResultsMessage: string = DEFAULT_NO_RESULTS_MESSAGE;
+  /** Resolved Wikipedia language edition code (populated in `setup()`). */
+  private _language: string = 'en';
+  /** Resolved output length cap in characters (populated in `setup()`). */
+  private _maxContentLength: number = 5000;
+
   /**
-   * @param config - Optional configuration (no config keys used by this skill).
+   * @param config - Optional configuration; supports `num_results`,
+   *   `no_results_message`, `language`, `max_content_length`.
    */
   constructor(config?: SkillConfig) {
     super('wikipedia_search', config);
@@ -76,20 +100,29 @@ export class WikipediaSearchSkill extends SkillBase {
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
       ...super.getParameterSchema(),
+      num_results: {
+        type: 'integer',
+        description: 'Maximum number of Wikipedia articles to return',
+        default: 1,
+        min: 1,
+        max: 5,
+      },
+      no_results_message: {
+        type: 'string',
+        description: 'Custom message when no Wikipedia articles are found',
+        default: DEFAULT_NO_RESULTS_MESSAGE,
+      },
       language: {
         type: 'string',
-        description: 'Wikipedia language edition to search (e.g., "en", "fr", "de").',
+        description:
+          'Wikipedia language edition to search (e.g., "en", "fr", "de").',
         default: 'en',
       },
-      max_results: {
-        type: 'number',
-        description: 'Maximum number of search results to consider.',
-        default: 1,
-      },
       max_content_length: {
-        type: 'number',
+        type: 'integer',
         description: 'Maximum length of returned content in characters.',
         default: 5000,
+        min: 100,
       },
     };
   }
@@ -99,175 +132,235 @@ export class WikipediaSearchSkill extends SkillBase {
     return {
       name: 'wikipedia_search',
       description:
-        'Searches Wikipedia for article summaries and extracts. No API key required.',
+        'Search Wikipedia for information about a topic and get article summaries',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'wikipedia', 'encyclopedia', 'knowledge', 'external'],
     };
   }
 
-  /** @returns A single `search_wikipedia` tool that fetches article summaries from Wikipedia. */
+  /**
+   * Extract config values into instance state. Clamps `num_results` to the
+   * 1-5 range (matching Python's `max(1, ...)` floor plus the schema cap).
+   */
+  override async setup(): Promise<void> {
+    const configured = this.getConfig<number>('num_results', 1);
+    this._numResults = Math.max(1, Math.min(5, Math.floor(configured)));
+
+    const rawMessage = this.getConfig<string | undefined>(
+      'no_results_message',
+      undefined,
+    );
+    this._noResultsMessage =
+      rawMessage && rawMessage.length > 0 ? rawMessage : DEFAULT_NO_RESULTS_MESSAGE;
+
+    const lang = this.getConfig<string>('language', 'en');
+    this._language = lang && lang.length > 0 ? lang : 'en';
+
+    const rawLen = this.getConfig<number>('max_content_length', 5000);
+    this._maxContentLength = Math.max(100, Math.floor(rawLen));
+  }
+
+  /** @returns A `search_wiki` tool that fetches article summaries from Wikipedia. */
   getTools(): SkillToolDefinition[] {
     return [
       {
-        name: 'search_wikipedia',
+        name: 'search_wiki',
         description:
-          'Search Wikipedia for information about a topic. Returns a summary of the most relevant article.',
+          'Search Wikipedia for information about a topic and get article summaries',
         parameters: {
           query: {
             type: 'string',
             description:
-              'The topic or term to search for on Wikipedia.',
+              'The search term or topic to look up on Wikipedia.',
           },
           sentences: {
             type: 'number',
             description:
-              'Number of sentences to return in the summary (1-10). Defaults to 3.',
+              'Optional: number of sentences to return per article (1-10). Applied to the direct page-summary result; full extracts are used otherwise.',
           },
         },
         required: ['query'],
         handler: async (args: Record<string, unknown>) => {
-          const query = args.query as string | undefined;
-          const sentences = args.sentences as number | undefined;
+          const rawQuery = args['query'];
+          const sentences = args['sentences'];
 
-          if (!query || typeof query !== 'string' || query.trim().length === 0) {
+          if (
+            !rawQuery ||
+            typeof rawQuery !== 'string' ||
+            rawQuery.trim().length === 0
+          ) {
             return new FunctionResult(
-              'Please provide a topic to search for on Wikipedia.',
+              'Please provide a search query for Wikipedia.',
             );
           }
 
-          const sentenceCount = Math.max(1, Math.min(10, sentences ?? 3));
+          const sentenceCount =
+            typeof sentences === 'number'
+              ? Math.max(1, Math.min(10, Math.floor(sentences)))
+              : undefined;
 
-          try {
-            // First, try a direct page summary lookup
-            const encodedQuery = encodeURIComponent(query.trim().replace(/\s+/g, '_'));
-            const summaryUrl = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodedQuery}`;
-
-            const controller1 = new AbortController();
-            const timeout1 = setTimeout(() => controller1.abort(), 30_000);
-            let summaryResponse: Response;
-            try {
-              summaryResponse = await fetch(summaryUrl, {
-                headers: { 'Accept': 'application/json', 'User-Agent': 'SignalWireAgentsSDK/1.0' },
-                signal: controller1.signal,
-              });
-            } finally {
-              clearTimeout(timeout1);
-            }
-
-            if (summaryResponse.ok) {
-              const data = (await summaryResponse.json()) as WikipediaSummaryResponse;
-
-              if (data.type !== 'disambiguation' && data.extract) {
-                const extractSentences = data.extract.split(/(?<=[.!?])\s+/);
-                const trimmedExtract = extractSentences
-                  .slice(0, sentenceCount)
-                  .join(' ')
-                  .trim();
-
-                const pageUrl = data.content_urls?.desktop?.page ?? '';
-                const parts: string[] = [
-                  `Wikipedia: ${data.title}`,
-                ];
-                if (data.description) {
-                  parts.push(`(${data.description})`);
-                }
-                parts.push('');
-                parts.push(trimmedExtract);
-                if (pageUrl) {
-                  parts.push('');
-                  parts.push(`Read more: ${pageUrl}`);
-                }
-
-                return new FunctionResult(parts.join('\n').trim());
-              }
-            }
-
-            // If direct lookup failed, use the search API
-            const searchUrl = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encodeURIComponent(query.trim())}&limit=1`;
-
-            const controller2 = new AbortController();
-            const timeout2 = setTimeout(() => controller2.abort(), 30_000);
-            let searchResponse: Response;
-            try {
-              searchResponse = await fetch(searchUrl, {
-                headers: { 'Accept': 'application/json', 'User-Agent': 'SignalWireAgentsSDK/1.0' },
-                signal: controller2.signal,
-              });
-            } finally {
-              clearTimeout(timeout2);
-            }
-
-            if (!searchResponse.ok) {
-              log.error('wikipedia_search_api_error', { status: searchResponse.status });
-              return new FunctionResult(
-                'Wikipedia search could not be completed. Please try a different search term.',
-              );
-            }
-
-            const searchData = (await searchResponse.json()) as WikipediaSearchResponse;
-
-            if (!searchData.pages || searchData.pages.length === 0) {
-              return new FunctionResult(
-                `No Wikipedia article found for "${query}". Try a different search term.`,
-              );
-            }
-
-            // Fetch the summary for the best match
-            const bestMatch = searchData.pages[0];
-            const matchUrl = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(bestMatch.key)}`;
-
-            const controller3 = new AbortController();
-            const timeout3 = setTimeout(() => controller3.abort(), 30_000);
-            let matchResponse: Response;
-            try {
-              matchResponse = await fetch(matchUrl, {
-                headers: { 'Accept': 'application/json', 'User-Agent': 'SignalWireAgentsSDK/1.0' },
-                signal: controller3.signal,
-              });
-            } finally {
-              clearTimeout(timeout3);
-            }
-
-            if (!matchResponse.ok) {
-              // Fall back to the search excerpt
-              const excerpt = bestMatch.excerpt
-                ? bestMatch.excerpt.replace(/<[^>]*>/g, '').trim()
-                : 'No summary available.';
-              return new FunctionResult(
-                `Wikipedia: ${bestMatch.title}\n\n${excerpt}`,
-              );
-            }
-
-            const matchData = (await matchResponse.json()) as WikipediaSummaryResponse;
-            const extractSentences = matchData.extract.split(/(?<=[.!?])\s+/);
-            const trimmedExtract = extractSentences
-              .slice(0, sentenceCount)
-              .join(' ')
-              .trim();
-
-            const pageUrl = matchData.content_urls?.desktop?.page ?? '';
-            const parts: string[] = [`Wikipedia: ${matchData.title}`];
-            if (matchData.description) {
-              parts.push(`(${matchData.description})`);
-            }
-            parts.push('');
-            parts.push(trimmedExtract);
-            if (pageUrl) {
-              parts.push('');
-              parts.push(`Read more: ${pageUrl}`);
-            }
-
-            return new FunctionResult(parts.join('\n').trim());
-          } catch (err) {
-            log.error('search_wikipedia_failed', { error: err instanceof Error ? err.message : String(err) });
-            return new FunctionResult(
-              'The request could not be completed. Please try again.',
-            );
-          }
+          const result = await this.searchWiki(rawQuery.trim(), sentenceCount);
+          return new FunctionResult(result);
         },
       },
     ];
+  }
+
+  /**
+   * Search Wikipedia and return a formatted text summary.
+   *
+   * Mirrors the Python `search_wiki()` public entry point so the logic can be
+   * tested and reused outside the SWAIG handler. Uses `num_results` to decide
+   * how many articles to aggregate and honors `language` / `max_content_length`.
+   *
+   * @param query - Plain-text search term.
+   * @param sentenceCount - Optional sentence cap used by the direct-summary
+   *   path (1-10).
+   * @returns Formatted text ready for display to the caller.
+   */
+  async searchWiki(query: string, sentenceCount?: number): Promise<string> {
+    const trimmedQuery = query.trim();
+    if (trimmedQuery.length === 0) {
+      return this._formatNoResults(trimmedQuery);
+    }
+
+    try {
+      // Fast path: when only one article is requested, try the REST page
+      // summary endpoint. It returns cleanly-structured data including a URL.
+      if (this._numResults === 1) {
+        const summary = await this._fetchDirectSummary(trimmedQuery, sentenceCount);
+        if (summary !== null) {
+          return this._clampContent(summary);
+        }
+      }
+
+      // Fallback / multi-result path: use the action=query search API.
+      const baseUrl = `https://${this._language}.wikipedia.org/w/api.php`;
+      const searchUrl =
+        `${baseUrl}?action=query&list=search&format=json` +
+        `&srsearch=${encodeURIComponent(trimmedQuery)}` +
+        `&srlimit=${this._numResults}`;
+
+      const searchData = await this._fetchJson<WikipediaActionSearchResponse>(
+        searchUrl,
+      );
+      if (!searchData) {
+        return 'Wikipedia search could not be completed. Please try a different search term.';
+      }
+
+      const searchResults = searchData.query?.search ?? [];
+      if (searchResults.length === 0) {
+        return this._formatNoResults(trimmedQuery);
+      }
+
+      const articles: string[] = [];
+
+      for (const result of searchResults.slice(0, this._numResults)) {
+        const title = result.title;
+        const extractUrl =
+          `${baseUrl}?action=query&prop=extracts&exintro&explaintext&format=json` +
+          `&titles=${encodeURIComponent(title)}`;
+
+        const extractData = await this._fetchJson<WikipediaActionExtractsResponse>(
+          extractUrl,
+        );
+        const pages = extractData?.query?.pages ?? {};
+        const firstPage = Object.values(pages)[0];
+        const extract = (firstPage?.extract ?? '').trim();
+
+        if (extract.length > 0) {
+          articles.push(`**${title}**\n\n${extract}`);
+        } else {
+          articles.push(`**${title}**\n\nNo summary available for this article.`);
+        }
+      }
+
+      if (articles.length === 0) {
+        return this._formatNoResults(trimmedQuery);
+      }
+
+      const separator = '\n\n' + '='.repeat(50) + '\n\n';
+      return this._clampContent(articles.join(separator));
+    } catch (err) {
+      log.error('wikipedia_search_failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return `Error searching Wikipedia: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+    }
+  }
+
+  /** Fetch and format a single direct page summary. Returns `null` to signal fallback. */
+  private async _fetchDirectSummary(
+    query: string,
+    sentenceCount?: number,
+  ): Promise<string | null> {
+    const encodedQuery = encodeURIComponent(query.replace(/\s+/g, '_'));
+    const summaryUrl = `https://${this._language}.wikipedia.org/api/rest_v1/page/summary/${encodedQuery}`;
+
+    const data = await this._fetchJson<WikipediaSummaryResponse>(summaryUrl);
+    if (!data || data.type === 'disambiguation' || !data.extract) {
+      return null;
+    }
+
+    let extractText = data.extract;
+    if (typeof sentenceCount === 'number') {
+      const pieces = extractText.split(/(?<=[.!?])\s+/);
+      extractText = pieces.slice(0, sentenceCount).join(' ').trim();
+    }
+
+    const pageUrl = data.content_urls?.desktop?.page ?? '';
+    const parts: string[] = [`Wikipedia: ${data.title}`];
+    if (data.description) {
+      parts.push(`(${data.description})`);
+    }
+    parts.push('');
+    parts.push(extractText);
+    if (pageUrl) {
+      parts.push('');
+      parts.push(`Read more: ${pageUrl}`);
+    }
+    return parts.join('\n').trim();
+  }
+
+  /** Fetch JSON with a 30-second timeout. Returns `null` on any failure. */
+  private async _fetchJson<T>(url: string): Promise<T | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30_000);
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': 'SignalWireAgentsSDK/1.0',
+        },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        return null;
+      }
+      return (await response.json()) as T;
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /** Clamp content to `max_content_length`. */
+  private _clampContent(content: string): string {
+    if (content.length <= this._maxContentLength) {
+      return content;
+    }
+    return content.slice(0, this._maxContentLength);
+  }
+
+  /** Render the configured no-results message, substituting `{query}`. */
+  private _formatNoResults(query: string): string {
+    return this._noResultsMessage.includes('{query}')
+      ? this._noResultsMessage.replace(/\{query\}/g, query)
+      : this._noResultsMessage;
   }
 
   /** @returns Prompt section describing Wikipedia search capabilities and usage guidance. */
@@ -275,13 +368,11 @@ export class WikipediaSearchSkill extends SkillBase {
     return [
       {
         title: 'Wikipedia Search',
-        body: 'You can search Wikipedia for information about any topic.',
+        body: `You can search Wikipedia for factual information using search_wiki. This will return up to ${this._numResults} Wikipedia article summaries.`,
         bullets: [
-          'Use the search_wikipedia tool when the user asks about a specific topic, person, place, or concept.',
-          'Wikipedia provides encyclopedic summaries that are generally reliable for factual information.',
-          'You can specify the number of sentences to return (1-10) for shorter or more detailed summaries.',
-          'If a search returns no results, try rephrasing with the most common name or spelling.',
-          'Summarize the information naturally rather than reading it verbatim.',
+          'Use search_wiki for factual, encyclopedic information',
+          'Great for answering questions about people, places, concepts, and history',
+          'Returns reliable, well-sourced information from Wikipedia articles',
         ],
       },
     ];

--- a/src/skills/builtin/wikipedia_search.ts
+++ b/src/skills/builtin/wikipedia_search.ts
@@ -143,7 +143,7 @@ export class WikipediaSearchSkill extends SkillBase {
    * Extract config values into instance state. Clamps `num_results` to the
    * 1-5 range (matching Python's `max(1, ...)` floor plus the schema cap).
    */
-  override async setup(): Promise<void> {
+  override async setup(): Promise<boolean> {
     const configured = this.getConfig<number>('num_results', 1);
     this._numResults = Math.max(1, Math.min(5, Math.floor(configured)));
 
@@ -159,6 +159,7 @@ export class WikipediaSearchSkill extends SkillBase {
 
     const rawLen = this.getConfig<number>('max_content_length', 5000);
     this._maxContentLength = Math.max(100, Math.floor(rawLen));
+    return true;
   }
 
   /** @returns A `search_wiki` tool that fetches article summaries from Wikipedia. */

--- a/src/skills/builtin/wikipedia_search.ts
+++ b/src/skills/builtin/wikipedia_search.ts
@@ -143,7 +143,7 @@ export class WikipediaSearchSkill extends SkillBase {
           },
         },
         required: ['query'],
-        handler: async (args: Record<string, unknown>) => {
+        handler: async (args: Record<string, unknown>, _rawData: Record<string, unknown>) => {
           const rawQuery = args['query'];
 
           if (

--- a/src/skills/builtin/wikipedia_search.ts
+++ b/src/skills/builtin/wikipedia_search.ts
@@ -81,7 +81,7 @@ interface WikipediaActionExtractsResponse {
  */
 export class WikipediaSearchSkill extends SkillBase {
   /** Resolved `num_results` value (populated in `setup()`). */
-  private _numResults: number = 1;
+  protected numResults: number = 1;
   /** Resolved `no_results_message` template (populated in `setup()`). */
   private _noResultsMessage: string = DEFAULT_NO_RESULTS_MESSAGE;
   /** Resolved Wikipedia language edition code (populated in `setup()`). */
@@ -145,7 +145,7 @@ export class WikipediaSearchSkill extends SkillBase {
    */
   override async setup(): Promise<boolean> {
     const configured = this.getConfig<number>('num_results', 1);
-    this._numResults = Math.max(1, Math.min(5, Math.floor(configured)));
+    this.numResults = Math.max(1, Math.min(5, Math.floor(configured)));
 
     const rawMessage = this.getConfig<string | undefined>(
       'no_results_message',
@@ -229,7 +229,7 @@ export class WikipediaSearchSkill extends SkillBase {
     try {
       // Fast path: when only one article is requested, try the REST page
       // summary endpoint. It returns cleanly-structured data including a URL.
-      if (this._numResults === 1) {
+      if (this.numResults === 1) {
         const summary = await this._fetchDirectSummary(trimmedQuery, sentenceCount);
         if (summary !== null) {
           return this._clampContent(summary);
@@ -241,7 +241,7 @@ export class WikipediaSearchSkill extends SkillBase {
       const searchUrl =
         `${baseUrl}?action=query&list=search&format=json` +
         `&srsearch=${encodeURIComponent(trimmedQuery)}` +
-        `&srlimit=${this._numResults}`;
+        `&srlimit=${this.numResults}`;
 
       const searchData = await this._fetchJson<WikipediaActionSearchResponse>(
         searchUrl,
@@ -257,7 +257,7 @@ export class WikipediaSearchSkill extends SkillBase {
 
       const articles: string[] = [];
 
-      for (const result of searchResults.slice(0, this._numResults)) {
+      for (const result of searchResults.slice(0, this.numResults)) {
         const title = result.title;
         const extractUrl =
           `${baseUrl}?action=query&prop=extracts&exintro&explaintext&format=json` +
@@ -369,7 +369,7 @@ export class WikipediaSearchSkill extends SkillBase {
     return [
       {
         title: 'Wikipedia Search',
-        body: `You can search Wikipedia for factual information using search_wiki. This will return up to ${this._numResults} Wikipedia article summaries.`,
+        body: `You can search Wikipedia for factual information using search_wiki. This will return up to ${this.numResults} Wikipedia article summaries.`,
         bullets: [
           'Use search_wiki for factual, encyclopedic information',
           'Great for answering questions about people, places, concepts, and history',

--- a/src/skills/builtin/wikipedia_search.ts
+++ b/src/skills/builtin/wikipedia_search.ts
@@ -3,9 +3,7 @@
  *
  * Tier 3 built-in skill: no external API key required. Uses the Wikipedia
  * REST API to fetch article summaries and extracts for any given topic.
- * Matches the Python SDK's `num_results` / `no_results_message` parity and
- * adds `language` + `max_content_length` for multi-language and output
- * trimming support.
+ * Matches the Python SDK's `num_results` / `no_results_message` parity.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -24,33 +22,6 @@ const log = getLogger('WikipediaSearchSkill');
 const DEFAULT_NO_RESULTS_MESSAGE =
   "I couldn't find any Wikipedia articles for '{query}'. " +
   'Try rephrasing your search or using different keywords.';
-
-/** Response shape from the Wikipedia REST API page summary endpoint. */
-interface WikipediaSummaryResponse {
-  /** Page type (e.g., "standard", "disambiguation"). */
-  type: string;
-  /** Article title. */
-  title: string;
-  /** HTML-formatted display title. */
-  displaytitle?: string;
-  /** Plain-text article extract/summary. */
-  extract: string;
-  /** HTML-formatted extract. */
-  extract_html?: string;
-  /** Short description of the article. */
-  description?: string;
-  /** URLs to the full article. */
-  content_urls?: {
-    desktop?: { page: string };
-    mobile?: { page: string };
-  };
-  /** Thumbnail image information. */
-  thumbnail?: {
-    source: string;
-    width: number;
-    height: number;
-  };
-}
 
 /** Response shape from the Wikipedia action=query search API. */
 interface WikipediaActionSearchResponse {
@@ -75,23 +46,17 @@ interface WikipediaActionExtractsResponse {
  *
  * Tier 3 built-in skill with no external API key required. The configured
  * `num_results` drives how many articles are aggregated; `no_results_message`
- * customizes the fallback text (supports `{query}` interpolation); `language`
- * selects the Wikipedia edition (`en`, `fr`, `de`, …); `max_content_length`
- * trims the final output.
+ * customizes the fallback text (supports `{query}` interpolation).
  */
 export class WikipediaSearchSkill extends SkillBase {
   /** Resolved `num_results` value (populated in `setup()`). */
   protected numResults: number = 1;
   /** Resolved `no_results_message` template (populated in `setup()`). */
   private _noResultsMessage: string = DEFAULT_NO_RESULTS_MESSAGE;
-  /** Resolved Wikipedia language edition code (populated in `setup()`). */
-  private _language: string = 'en';
-  /** Resolved output length cap in characters (populated in `setup()`). */
-  private _maxContentLength: number = 5000;
 
   /**
-   * @param config - Optional configuration; supports `num_results`,
-   *   `no_results_message`, `language`, `max_content_length`.
+   * @param config - Optional configuration; supports `num_results` and
+   *   `no_results_message`.
    */
   constructor(config?: SkillConfig) {
     super('wikipedia_search', config);
@@ -111,18 +76,6 @@ export class WikipediaSearchSkill extends SkillBase {
         type: 'string',
         description: 'Custom message when no Wikipedia articles are found',
         default: DEFAULT_NO_RESULTS_MESSAGE,
-      },
-      language: {
-        type: 'string',
-        description:
-          'Wikipedia language edition to search (e.g., "en", "fr", "de").',
-        default: 'en',
-      },
-      max_content_length: {
-        type: 'integer',
-        description: 'Maximum length of returned content in characters.',
-        default: 5000,
-        min: 100,
       },
     };
   }
@@ -153,12 +106,6 @@ export class WikipediaSearchSkill extends SkillBase {
     );
     this._noResultsMessage =
       rawMessage && rawMessage.length > 0 ? rawMessage : DEFAULT_NO_RESULTS_MESSAGE;
-
-    const lang = this.getConfig<string>('language', 'en');
-    this._language = lang && lang.length > 0 ? lang : 'en';
-
-    const rawLen = this.getConfig<number>('max_content_length', 5000);
-    this._maxContentLength = Math.max(100, Math.floor(rawLen));
     return true;
   }
 
@@ -175,16 +122,10 @@ export class WikipediaSearchSkill extends SkillBase {
             description:
               'The search term or topic to look up on Wikipedia.',
           },
-          sentences: {
-            type: 'number',
-            description:
-              'Optional: number of sentences to return per article (1-10). Applied to the direct page-summary result; full extracts are used otherwise.',
-          },
         },
         required: ['query'],
         handler: async (args: Record<string, unknown>) => {
           const rawQuery = args['query'];
-          const sentences = args['sentences'];
 
           if (
             !rawQuery ||
@@ -196,12 +137,7 @@ export class WikipediaSearchSkill extends SkillBase {
             );
           }
 
-          const sentenceCount =
-            typeof sentences === 'number'
-              ? Math.max(1, Math.min(10, Math.floor(sentences)))
-              : undefined;
-
-          const result = await this.searchWiki(rawQuery.trim(), sentenceCount);
+          const result = await this.searchWiki(rawQuery.trim());
           return new FunctionResult(result);
         },
       },
@@ -213,31 +149,19 @@ export class WikipediaSearchSkill extends SkillBase {
    *
    * Mirrors the Python `search_wiki()` public entry point so the logic can be
    * tested and reused outside the SWAIG handler. Uses `num_results` to decide
-   * how many articles to aggregate and honors `language` / `max_content_length`.
+   * how many articles to aggregate.
    *
    * @param query - Plain-text search term.
-   * @param sentenceCount - Optional sentence cap used by the direct-summary
-   *   path (1-10).
    * @returns Formatted text ready for display to the caller.
    */
-  async searchWiki(query: string, sentenceCount?: number): Promise<string> {
+  async searchWiki(query: string): Promise<string> {
     const trimmedQuery = query.trim();
     if (trimmedQuery.length === 0) {
       return this._formatNoResults(trimmedQuery);
     }
 
     try {
-      // Fast path: when only one article is requested, try the REST page
-      // summary endpoint. It returns cleanly-structured data including a URL.
-      if (this.numResults === 1) {
-        const summary = await this._fetchDirectSummary(trimmedQuery, sentenceCount);
-        if (summary !== null) {
-          return this._clampContent(summary);
-        }
-      }
-
-      // Fallback / multi-result path: use the action=query search API.
-      const baseUrl = `https://${this._language}.wikipedia.org/w/api.php`;
+      const baseUrl = 'https://en.wikipedia.org/w/api.php';
       const searchUrl =
         `${baseUrl}?action=query&list=search&format=json` +
         `&srsearch=${encodeURIComponent(trimmedQuery)}` +
@@ -281,8 +205,11 @@ export class WikipediaSearchSkill extends SkillBase {
         return this._formatNoResults(trimmedQuery);
       }
 
+      if (articles.length === 1) {
+        return articles[0];
+      }
       const separator = '\n\n' + '='.repeat(50) + '\n\n';
-      return this._clampContent(articles.join(separator));
+      return articles.join(separator);
     } catch (err) {
       log.error('wikipedia_search_failed', {
         error: err instanceof Error ? err.message : String(err),
@@ -291,39 +218,6 @@ export class WikipediaSearchSkill extends SkillBase {
         err instanceof Error ? err.message : String(err)
       }`;
     }
-  }
-
-  /** Fetch and format a single direct page summary. Returns `null` to signal fallback. */
-  private async _fetchDirectSummary(
-    query: string,
-    sentenceCount?: number,
-  ): Promise<string | null> {
-    const encodedQuery = encodeURIComponent(query.replace(/\s+/g, '_'));
-    const summaryUrl = `https://${this._language}.wikipedia.org/api/rest_v1/page/summary/${encodedQuery}`;
-
-    const data = await this._fetchJson<WikipediaSummaryResponse>(summaryUrl);
-    if (!data || data.type === 'disambiguation' || !data.extract) {
-      return null;
-    }
-
-    let extractText = data.extract;
-    if (typeof sentenceCount === 'number') {
-      const pieces = extractText.split(/(?<=[.!?])\s+/);
-      extractText = pieces.slice(0, sentenceCount).join(' ').trim();
-    }
-
-    const pageUrl = data.content_urls?.desktop?.page ?? '';
-    const parts: string[] = [`Wikipedia: ${data.title}`];
-    if (data.description) {
-      parts.push(`(${data.description})`);
-    }
-    parts.push('');
-    parts.push(extractText);
-    if (pageUrl) {
-      parts.push('');
-      parts.push(`Read more: ${pageUrl}`);
-    }
-    return parts.join('\n').trim();
   }
 
   /** Fetch JSON with a 30-second timeout. Returns `null` on any failure. */
@@ -347,14 +241,6 @@ export class WikipediaSearchSkill extends SkillBase {
     } finally {
       clearTimeout(timeout);
     }
-  }
-
-  /** Clamp content to `max_content_length`. */
-  private _clampContent(content: string): string {
-    if (content.length <= this._maxContentLength) {
-      return content;
-    }
-    return content.slice(0, this._maxContentLength);
   }
 
   /** Render the configured no-results message, substituting `{query}`. */

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -9,4 +9,4 @@ export { SkillBase } from './SkillBase.js';
 export type { SkillConfig, SkillToolDefinition, SkillPromptSection, SkillManifest, ParameterSchemaEntry } from './SkillBase.js';
 export { SkillManager } from './SkillManager.js';
 export { SkillRegistry } from './SkillRegistry.js';
-export type { SkillFactory, SkillSchemaInfo } from './SkillRegistry.js';
+export type { SkillSchemaInfo } from './SkillRegistry.js';

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -6,7 +6,7 @@
  */
 
 export { SkillBase } from './SkillBase.js';
-export type { SkillConfig, SkillToolDefinition, SkillPromptSection, SkillManifest, ParameterSchemaEntry } from './SkillBase.js';
+export type { SkillConfig, SkillToolDefinition, SkillPromptSection, ParameterSchemaEntry } from './SkillBase.js';
 export { SkillManager } from './SkillManager.js';
 export { SkillRegistry } from './SkillRegistry.js';
 export type { SkillSchemaInfo } from './SkillRegistry.js';

--- a/tests/AgentBase.test.ts
+++ b/tests/AgentBase.test.ts
@@ -3,7 +3,7 @@ import { AgentBase } from '../src/AgentBase.js';
 import { FunctionResult } from '../src/FunctionResult.js';
 import { ContextBuilder } from '../src/ContextBuilder.js';
 import { DataMap } from '../src/DataMap.js';
-import { SkillBase, type SkillManifest, type SkillToolDefinition } from '../src/skills/SkillBase.js';
+import { SkillBase, type SkillToolDefinition } from '../src/skills/SkillBase.js';
 
 describe('AgentBase', () => {
   function createAgent(opts?: Partial<Parameters<typeof AgentBase.prototype.setPromptText>[0]>) {
@@ -632,8 +632,8 @@ describe('AgentBase', () => {
 
   it('addSkill registers skill tools and prompt sections', async () => {
     class TestSkill extends SkillBase {
-      constructor() { super('test_skill'); }
-      getManifest(): SkillManifest { return { name: 'test_skill', description: 'Test', version: '1.0.0' }; }
+      static override SKILL_NAME = 'test_skill';
+      static override SKILL_DESCRIPTION = 'Test';
       getTools(): SkillToolDefinition[] {
         return [{
           name: 'skill_tool',
@@ -656,8 +656,8 @@ describe('AgentBase', () => {
 
   it('removeSkill removes a skill', async () => {
     class RemoveSkill extends SkillBase {
-      constructor() { super('removable'); }
-      getManifest(): SkillManifest { return { name: 'removable', description: 'Test', version: '1.0.0' }; }
+      static override SKILL_NAME = 'removable';
+      static override SKILL_DESCRIPTION = 'Test';
       getTools(): SkillToolDefinition[] { return []; }
     }
 
@@ -671,8 +671,8 @@ describe('AgentBase', () => {
 
   it('addSkill returns this for chaining', async () => {
     class ChainSkill extends SkillBase {
-      constructor() { super('chain'); }
-      getManifest(): SkillManifest { return { name: 'chain', description: 'Test', version: '1.0.0' }; }
+      static override SKILL_NAME = 'chain';
+      static override SKILL_DESCRIPTION = 'Test';
       getTools(): SkillToolDefinition[] { return []; }
     }
 

--- a/tests/EphemeralSkillCopy.test.ts
+++ b/tests/EphemeralSkillCopy.test.ts
@@ -1,16 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { AgentBase } from '../src/AgentBase.js';
-import { SkillBase, type SkillManifest, type SkillToolDefinition, type SkillConfig } from '../src/skills/SkillBase.js';
+import { SkillBase, type SkillToolDefinition } from '../src/skills/SkillBase.js';
 import { FunctionResult } from '../src/FunctionResult.js';
 
 /** Test skill that adds a tool and prompt section. */
 class EphemeralTestSkill extends SkillBase {
-  constructor(config?: SkillConfig) {
-    super('ephemeral_test', config);
-  }
-  getManifest(): SkillManifest {
-    return { name: 'ephemeral_test', description: 'Ephemeral test', version: '1.0.0' };
-  }
+  static override SKILL_NAME = 'ephemeral_test';
+  static override SKILL_DESCRIPTION = 'Ephemeral test';
+
   getTools(): SkillToolDefinition[] {
     return [{
       name: 'ephemeral_tool',

--- a/tests/SkillBaseFeatures.test.ts
+++ b/tests/SkillBaseFeatures.test.ts
@@ -1,16 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { SkillBase, type SkillManifest, type SkillToolDefinition, type SkillConfig, type ParameterSchemaEntry } from '../src/skills/SkillBase.js';
+import { SkillBase, type SkillToolDefinition } from '../src/skills/SkillBase.js';
 import { FunctionResult } from '../src/FunctionResult.js';
 
 /** Minimal concrete skill for testing base features. */
 class TestSkill extends SkillBase {
-  constructor(config?: SkillConfig) {
-    super('test_skill', config);
-  }
-
-  getManifest(): SkillManifest {
-    return { name: 'test_skill', description: 'A test skill', version: '1.0.0' };
-  }
+  static override SKILL_NAME = 'test_skill';
+  static override SKILL_DESCRIPTION = 'A test skill';
 
   getTools(): SkillToolDefinition[] {
     return [{

--- a/tests/SkillMultiInstance.test.ts
+++ b/tests/SkillMultiInstance.test.ts
@@ -1,16 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { SkillBase, type SkillManifest, type SkillToolDefinition, type SkillConfig, type ParameterSchemaEntry } from '../src/skills/SkillBase.js';
+import { SkillBase, type SkillToolDefinition, type ParameterSchemaEntry } from '../src/skills/SkillBase.js';
 import { SkillManager } from '../src/skills/SkillManager.js';
 import { FunctionResult } from '../src/FunctionResult.js';
 
 /** Single-instance test skill. */
 class SingleInstanceSkill extends SkillBase {
-  constructor(config?: SkillConfig) {
-    super('single_skill', config);
-  }
-  getManifest(): SkillManifest {
-    return { name: 'single_skill', description: 'Single instance', version: '1.0.0' };
-  }
+  static override SKILL_NAME = 'single_skill';
+  static override SKILL_DESCRIPTION = 'Single instance';
+
   getTools(): SkillToolDefinition[] {
     return [{ name: 'single_tool', description: 'tool', handler: () => new FunctionResult('ok') }];
   }
@@ -18,6 +15,8 @@ class SingleInstanceSkill extends SkillBase {
 
 /** Multi-instance test skill. */
 class MultiInstanceSkill extends SkillBase {
+  static override SKILL_NAME = 'multi_skill';
+  static override SKILL_DESCRIPTION = 'Multi instance';
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
@@ -27,18 +26,11 @@ class MultiInstanceSkill extends SkillBase {
     };
   }
 
-  constructor(config?: SkillConfig) {
-    super('multi_skill', config);
-  }
-
   override getInstanceKey(): string {
     const toolName = this.getConfig<string | undefined>('tool_name', undefined);
     return toolName ? `${this.skillName}_${toolName}` : this.skillName;
   }
 
-  getManifest(): SkillManifest {
-    return { name: 'multi_skill', description: 'Multi instance', version: '1.0.0' };
-  }
   getTools(): SkillToolDefinition[] {
     const name = this.getConfig<string>('tool_name', 'multi_tool');
     return [{ name, description: 'tool', handler: () => new FunctionResult('ok') }];
@@ -90,8 +82,13 @@ describe('Skill Multi-Instance', () => {
     expect(entries[0].SkillClass).toBe(MultiInstanceSkill);
     expect(entries[0].config).toHaveProperty('tool_name');
 
-    // Entries should be usable to re-create skills
-    const recreated = new entries[0].SkillClass(entries[0].config);
+    // Entries should be usable to re-create skills.
+    // SkillManager stores concrete subclass references at runtime; the static
+    // type is abstract so we cast through unknown to drop the abstract flag.
+    const Ctor = entries[0].SkillClass as unknown as new (
+      config?: Record<string, unknown>,
+    ) => SkillBase;
+    const recreated = new Ctor(entries[0].config);
     expect(recreated).toBeInstanceOf(MultiInstanceSkill);
   });
 

--- a/tests/SkillParameterSchemas.test.ts
+++ b/tests/SkillParameterSchemas.test.ts
@@ -18,7 +18,6 @@ import { SpiderSkill } from '../src/skills/builtin/spider.js';
 import { ClaudeSkillsSkill } from '../src/skills/builtin/claude_skills.js';
 import { AskClaudeSkill } from '../src/skills/builtin/ask_claude.js';
 import { McpGatewaySkill } from '../src/skills/builtin/mcp_gateway.js';
-import type { ParameterSchemaEntry } from '../src/skills/SkillBase.js';
 
 const ALL_SKILLS = [
   { name: 'DateTimeSkill', cls: DateTimeSkill },
@@ -78,10 +77,10 @@ describe('Skill Parameter Schemas', () => {
       expect(schema).toHaveProperty('tool_name');
     });
 
-    it('NativeVectorSearchSkill has tool_name param', () => {
-      const schema = NativeVectorSearchSkill.getParameterSchema();
-      expect(schema).toHaveProperty('tool_name');
-    });
+    // NativeVectorSearchSkill intentionally omits tool_name from
+    // getParameterSchema — Python reference schema does not include it
+    // either. The internal default 'search_knowledge' still applies via
+    // getConfig fallback.
   });
 
   describe('specific schema details', () => {

--- a/tests/SkillParameterSchemas.test.ts
+++ b/tests/SkillParameterSchemas.test.ts
@@ -93,12 +93,12 @@ describe('Skill Parameter Schemas', () => {
       expect(schema.api_key.required).toBe(true);
     });
 
-    it('WebSearchSkill has max_results with min/max', () => {
+    it('WebSearchSkill has num_results with min/max', () => {
       const schema = WebSearchSkill.getParameterSchema();
-      expect(schema.max_results).toBeDefined();
-      expect(schema.max_results.min).toBe(1);
-      expect(schema.max_results.max).toBe(10);
-      expect(schema.max_results.default).toBe(5);
+      expect(schema.num_results).toBeDefined();
+      expect(schema.num_results.min).toBe(1);
+      expect(schema.num_results.max).toBe(10);
+      expect(schema.num_results.default).toBe(3);
     });
 
     it('AskClaudeSkill has model with default', () => {
@@ -113,11 +113,11 @@ describe('Skill Parameter Schemas', () => {
       expect(schema.skills_path.required).toBe(true);
     });
 
-    it('DataSphereSkill has distance_threshold with min/max', () => {
+    it('DataSphereSkill has distance with min/max', () => {
       const schema = DataSphereSkill.getParameterSchema();
-      expect(schema.distance_threshold).toBeDefined();
-      expect(schema.distance_threshold.min).toBe(0);
-      expect(schema.distance_threshold.max).toBe(1);
+      expect(schema.distance).toBeDefined();
+      expect(schema.distance.min).toBe(0);
+      expect(schema.distance.max).toBe(10);
     });
 
     it('SwmlTransferSkill has patterns array', () => {

--- a/tests/skills/SkillBase.test.ts
+++ b/tests/skills/SkillBase.test.ts
@@ -110,9 +110,9 @@ describe('SkillBase', () => {
     expect(skill.getConfig('missing', 'default')).toBe('default');
   });
 
-  it('setup and cleanup are no-op by default', async () => {
+  it('setup returns true by default and cleanup is no-op', async () => {
     const skill = new TestSkill();
-    await expect(skill.setup()).resolves.toBeUndefined();
+    await expect(skill.setup()).resolves.toBe(true);
     await expect(skill.cleanup()).resolves.toBeUndefined();
   });
 });

--- a/tests/skills/SkillBase.test.ts
+++ b/tests/skills/SkillBase.test.ts
@@ -1,21 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { SkillBase, type SkillManifest, type SkillToolDefinition } from '../../src/skills/SkillBase.js';
+import { SkillBase, type SkillToolDefinition } from '../../src/skills/SkillBase.js';
 import { FunctionResult } from '../../src/FunctionResult.js';
 
 class TestSkill extends SkillBase {
-  constructor(config?: Record<string, unknown>) {
-    super('test_skill', config);
-  }
-
-  getManifest(): SkillManifest {
-    return {
-      name: 'test_skill',
-      description: 'A test skill',
-      version: '1.0.0',
-      tags: ['test'],
-      requiredEnvVars: ['TEST_API_KEY'],
-    };
-  }
+  static override SKILL_NAME = 'test_skill';
+  static override SKILL_DESCRIPTION = 'A test skill';
+  static override REQUIRED_ENV_VARS: readonly string[] = ['TEST_API_KEY'];
 
   getTools(): SkillToolDefinition[] {
     return [{

--- a/tests/skills/SkillBase.test.ts
+++ b/tests/skills/SkillBase.test.ts
@@ -38,9 +38,9 @@ describe('SkillBase', () => {
 
   it('returns manifest', () => {
     const skill = new TestSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('test_skill');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('test_skill');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('returns tools', () => {

--- a/tests/skills/SkillManager.test.ts
+++ b/tests/skills/SkillManager.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SkillManager } from '../../src/skills/SkillManager.js';
 import { SkillBase, type SkillManifest, type SkillToolDefinition } from '../../src/skills/SkillBase.js';
+import { SkillRegistry } from '../../src/skills/SkillRegistry.js';
 import { FunctionResult } from '../../src/FunctionResult.js';
 import { suppressAllLogs } from '../../src/Logger.js';
 
@@ -38,6 +39,7 @@ class MockSkill extends SkillBase {
 
   async setup() {
     this.setupCalled = true;
+    return true;
   }
 
   async cleanup() {
@@ -60,6 +62,10 @@ describe('SkillManager', () => {
   beforeEach(() => {
     suppressAllLogs(true);
     manager = new SkillManager();
+  });
+
+  afterEach(() => {
+    SkillRegistry.resetInstance();
   });
 
   it('adds a skill', async () => {
@@ -169,5 +175,73 @@ describe('SkillManager', () => {
     await manager.addSkill(s2);
     expect(manager.size).toBe(2);
     expect(manager.hasSkill('weather')).toBe(true);
+  });
+
+  // ── New gap-fix tests ──────────────────────────────────────────────
+
+  it('loadedSkills exposes a read-only map of loaded skills', async () => {
+    const skill = new MockSkill('datetime');
+    await manager.addSkill(skill);
+    const map = manager.loadedSkills;
+    expect(map.size).toBe(1);
+    expect(map.get('datetime')).toBe(skill);
+    // Ensure the map is the same reference as the internal map
+    expect(map.has('datetime')).toBe(true);
+  });
+
+  it('hasSkillByKey checks by instance key (Python has_skill semantics)', async () => {
+    const skill = new MockSkill('weather');
+    await manager.addSkill(skill);
+    // Instance key for a default MockSkill is the skillName
+    expect(manager.hasSkillByKey('weather')).toBe(true);
+    expect(manager.hasSkillByKey('nonexistent')).toBe(false);
+    // hasSkillByKey does NOT search by skillName across values — it's a direct key lookup
+    expect(manager.hasSkillByKey(skill.instanceId)).toBe(false);
+  });
+
+  it('listSkillKeys returns flat array of instance key strings', async () => {
+    await manager.addSkill(new MockSkill('a'));
+    await manager.addSkill(new MockSkill('b'));
+    const keys = manager.listSkillKeys();
+    expect(keys).toEqual(['a', 'b']);
+  });
+
+  it('loadSkillByName loads a skill from the registry', async () => {
+    const registry = SkillRegistry.getInstance();
+    registry.register('mock_registry_skill', (config) => new MockSkill('mock_registry_skill', config));
+
+    const [success, errorMsg] = await manager.loadSkillByName('mock_registry_skill');
+    expect(success).toBe(true);
+    expect(errorMsg).toBe('');
+    expect(manager.size).toBe(1);
+    expect(manager.hasSkill('mock_registry_skill')).toBe(true);
+  });
+
+  it('loadSkillByName returns [false, error] when skill not in registry', async () => {
+    const [success, errorMsg] = await manager.loadSkillByName('nonexistent');
+    expect(success).toBe(false);
+    expect(errorMsg).toContain('not found in registry');
+  });
+
+  it('loadSkillByName returns [false, error] on duplicate skill', async () => {
+    const registry = SkillRegistry.getInstance();
+    registry.register('dup_skill', (config) => new MockSkill('dup_skill', config));
+
+    await manager.loadSkillByName('dup_skill');
+    const [success, errorMsg] = await manager.loadSkillByName('dup_skill');
+    expect(success).toBe(false);
+    expect(errorMsg).toContain('already loaded');
+  });
+
+  it('loadSkillByName passes config to the skill factory', async () => {
+    const registry = SkillRegistry.getInstance();
+    let receivedConfig: Record<string, unknown> | undefined;
+    registry.register('config_skill', (config) => {
+      receivedConfig = config;
+      return new MockSkill('config_skill', config);
+    });
+
+    await manager.loadSkillByName('config_skill', { api_key: 'test123' });
+    expect(receivedConfig).toEqual({ api_key: 'test123' });
   });
 });

--- a/tests/skills/SkillManager.test.ts
+++ b/tests/skills/SkillManager.test.ts
@@ -223,7 +223,10 @@ describe('SkillManager', () => {
 
   it('loadSkillByName loads a skill from the registry', async () => {
     const registry = SkillRegistry.getInstance();
-    registry.register('mock_registry_skill', (config) => makeMockSkill('mock_registry_skill', config));
+    class RegistrySkill extends MockSkill {
+      static override SKILL_NAME = 'mock_registry_skill';
+    }
+    registry.register(RegistrySkill);
 
     const [success, errorMsg] = await manager.loadSkillByName('mock_registry_skill');
     expect(success).toBe(true);
@@ -240,7 +243,10 @@ describe('SkillManager', () => {
 
   it('loadSkillByName returns [false, error] on duplicate skill', async () => {
     const registry = SkillRegistry.getInstance();
-    registry.register('dup_skill', (config) => makeMockSkill('dup_skill', config));
+    class DupSkill extends MockSkill {
+      static override SKILL_NAME = 'dup_skill';
+    }
+    registry.register(DupSkill);
 
     await manager.loadSkillByName('dup_skill');
     const [success, errorMsg] = await manager.loadSkillByName('dup_skill');
@@ -248,15 +254,15 @@ describe('SkillManager', () => {
     expect(errorMsg).toContain('already loaded');
   });
 
-  it('loadSkillByName passes config to the skill factory', async () => {
+  it('loadSkillByName passes config to the skill constructor', async () => {
     const registry = SkillRegistry.getInstance();
-    let receivedConfig: Record<string, unknown> | undefined;
-    registry.register('config_skill', (config) => {
-      receivedConfig = config;
-      return makeMockSkill('config_skill', config);
-    });
+    class ConfigSkill extends MockSkill {
+      static override SKILL_NAME = 'config_skill';
+    }
+    registry.register(ConfigSkill);
 
     await manager.loadSkillByName('config_skill', { api_key: 'test123' });
-    expect(receivedConfig).toEqual({ api_key: 'test123' });
+    const skill = manager.getSkill('config_skill');
+    expect(skill?.getConfig('api_key')).toBe('test123');
   });
 });

--- a/tests/skills/SkillManager.test.ts
+++ b/tests/skills/SkillManager.test.ts
@@ -1,21 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SkillManager } from '../../src/skills/SkillManager.js';
-import { SkillBase, type SkillManifest, type SkillToolDefinition } from '../../src/skills/SkillBase.js';
+import { SkillBase, type SkillToolDefinition } from '../../src/skills/SkillBase.js';
 import { SkillRegistry } from '../../src/skills/SkillRegistry.js';
 import { FunctionResult } from '../../src/FunctionResult.js';
 import { suppressAllLogs } from '../../src/Logger.js';
 
 class MockSkill extends SkillBase {
+  static override SKILL_NAME = 'mock_skill';
+  static override SKILL_DESCRIPTION = 'Mock';
+
   setupCalled = false;
   cleanupCalled = false;
-
-  constructor(name = 'mock_skill', config?: Record<string, unknown>) {
-    super(name, config);
-  }
-
-  getManifest(): SkillManifest {
-    return { name: this.skillName, description: 'Mock', version: '1.0.0' };
-  }
 
   getTools(): SkillToolDefinition[] {
     return [{
@@ -47,13 +42,33 @@ class MockSkill extends SkillBase {
   }
 }
 
+/**
+ * Factory for naming a fresh MockSkill subclass. Needed because SKILL_NAME
+ * is now a static class attribute (Python parity) — creating two distinct
+ * "named" mocks means creating two distinct classes.
+ */
+function makeMockSkill(name = 'mock_skill', config?: Record<string, unknown>): MockSkill {
+  class Named extends MockSkill {
+    static override SKILL_NAME = name;
+  }
+  return new Named(config);
+}
+
 /** Multi-instance mock skill that uses instanceId to allow duplicates. */
 class MultiMockSkill extends MockSkill {
+  static override SKILL_NAME = 'multi_mock_skill';
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
 
   override getInstanceKey(): string {
     return this.instanceId; // Each instance gets a unique key
   }
+}
+
+function makeMultiMockSkill(name = 'multi_mock_skill'): MultiMockSkill {
+  class Named extends MultiMockSkill {
+    static override SKILL_NAME = name;
+  }
+  return new Named();
 }
 
 describe('SkillManager', () => {
@@ -96,9 +111,9 @@ describe('SkillManager', () => {
   });
 
   it('removes skills by name', async () => {
-    const s1 = new MultiMockSkill('weather');
-    const s2 = new MultiMockSkill('weather');
-    const s3 = new MockSkill('math');
+    const s1 = makeMultiMockSkill('weather');
+    const s2 = makeMultiMockSkill('weather');
+    const s3 = makeMockSkill('math');
     await manager.addSkill(s1);
     await manager.addSkill(s2);
     await manager.addSkill(s3);
@@ -108,7 +123,7 @@ describe('SkillManager', () => {
   });
 
   it('hasSkill checks by name', async () => {
-    const skill = new MockSkill('datetime');
+    const skill = makeMockSkill('datetime');
     await manager.addSkill(skill);
     expect(manager.hasSkill('datetime')).toBe(true);
     expect(manager.hasSkill('missing')).toBe(false);
@@ -122,8 +137,8 @@ describe('SkillManager', () => {
   });
 
   it('listSkills returns all loaded skills', async () => {
-    await manager.addSkill(new MockSkill('a'));
-    await manager.addSkill(new MockSkill('b'));
+    await manager.addSkill(makeMockSkill('a'));
+    await manager.addSkill(makeMockSkill('b'));
     const list = manager.listSkills();
     expect(list).toHaveLength(2);
     expect(list.map(s => s.name)).toContain('a');
@@ -131,35 +146,35 @@ describe('SkillManager', () => {
   });
 
   it('getAllTools aggregates tools from all skills', async () => {
-    await manager.addSkill(new MockSkill('a'));
-    await manager.addSkill(new MockSkill('b'));
+    await manager.addSkill(makeMockSkill('a'));
+    await manager.addSkill(makeMockSkill('b'));
     const tools = manager.getAllTools();
     expect(tools).toHaveLength(2);
   });
 
   it('getAllPromptSections aggregates sections', async () => {
-    await manager.addSkill(new MockSkill('a'));
-    await manager.addSkill(new MockSkill('b'));
+    await manager.addSkill(makeMockSkill('a'));
+    await manager.addSkill(makeMockSkill('b'));
     expect(manager.getAllPromptSections()).toHaveLength(2);
   });
 
   it('getAllHints aggregates hints', async () => {
-    await manager.addSkill(new MockSkill('a'));
-    await manager.addSkill(new MockSkill('b'));
+    await manager.addSkill(makeMockSkill('a'));
+    await manager.addSkill(makeMockSkill('b'));
     expect(manager.getAllHints()).toHaveLength(2);
   });
 
   it('getMergedGlobalData merges all skill data', async () => {
-    await manager.addSkill(new MockSkill('a'));
-    await manager.addSkill(new MockSkill('b'));
+    await manager.addSkill(makeMockSkill('a'));
+    await manager.addSkill(makeMockSkill('b'));
     const data = manager.getMergedGlobalData();
     expect(data['a_data']).toBe(true);
     expect(data['b_data']).toBe(true);
   });
 
   it('clear removes all skills and calls cleanup', async () => {
-    const s1 = new MockSkill('a');
-    const s2 = new MockSkill('b');
+    const s1 = makeMockSkill('a');
+    const s2 = makeMockSkill('b');
     await manager.addSkill(s1);
     await manager.addSkill(s2);
     await manager.clear();
@@ -169,8 +184,8 @@ describe('SkillManager', () => {
   });
 
   it('supports multi-instance of same skill', async () => {
-    const s1 = new MultiMockSkill('weather');
-    const s2 = new MultiMockSkill('weather');
+    const s1 = makeMultiMockSkill('weather');
+    const s2 = makeMultiMockSkill('weather');
     await manager.addSkill(s1);
     await manager.addSkill(s2);
     expect(manager.size).toBe(2);
@@ -180,7 +195,7 @@ describe('SkillManager', () => {
   // ── New gap-fix tests ──────────────────────────────────────────────
 
   it('loadedSkills exposes a read-only map of loaded skills', async () => {
-    const skill = new MockSkill('datetime');
+    const skill = makeMockSkill('datetime');
     await manager.addSkill(skill);
     const map = manager.loadedSkills;
     expect(map.size).toBe(1);
@@ -190,7 +205,7 @@ describe('SkillManager', () => {
   });
 
   it('hasSkillByKey checks by instance key (Python has_skill semantics)', async () => {
-    const skill = new MockSkill('weather');
+    const skill = makeMockSkill('weather');
     await manager.addSkill(skill);
     // Instance key for a default MockSkill is the skillName
     expect(manager.hasSkillByKey('weather')).toBe(true);
@@ -200,15 +215,15 @@ describe('SkillManager', () => {
   });
 
   it('listSkillKeys returns flat array of instance key strings', async () => {
-    await manager.addSkill(new MockSkill('a'));
-    await manager.addSkill(new MockSkill('b'));
+    await manager.addSkill(makeMockSkill('a'));
+    await manager.addSkill(makeMockSkill('b'));
     const keys = manager.listSkillKeys();
     expect(keys).toEqual(['a', 'b']);
   });
 
   it('loadSkillByName loads a skill from the registry', async () => {
     const registry = SkillRegistry.getInstance();
-    registry.register('mock_registry_skill', (config) => new MockSkill('mock_registry_skill', config));
+    registry.register('mock_registry_skill', (config) => makeMockSkill('mock_registry_skill', config));
 
     const [success, errorMsg] = await manager.loadSkillByName('mock_registry_skill');
     expect(success).toBe(true);
@@ -225,7 +240,7 @@ describe('SkillManager', () => {
 
   it('loadSkillByName returns [false, error] on duplicate skill', async () => {
     const registry = SkillRegistry.getInstance();
-    registry.register('dup_skill', (config) => new MockSkill('dup_skill', config));
+    registry.register('dup_skill', (config) => makeMockSkill('dup_skill', config));
 
     await manager.loadSkillByName('dup_skill');
     const [success, errorMsg] = await manager.loadSkillByName('dup_skill');
@@ -238,7 +253,7 @@ describe('SkillManager', () => {
     let receivedConfig: Record<string, unknown> | undefined;
     registry.register('config_skill', (config) => {
       receivedConfig = config;
-      return new MockSkill('config_skill', config);
+      return makeMockSkill('config_skill', config);
     });
 
     await manager.loadSkillByName('config_skill', { api_key: 'test123' });

--- a/tests/skills/SkillRegistry.test.ts
+++ b/tests/skills/SkillRegistry.test.ts
@@ -5,12 +5,9 @@ import { FunctionResult } from '../../src/FunctionResult.js';
 import { suppressAllLogs } from '../../src/Logger.js';
 
 class SimpleSkill extends SkillBase {
-  constructor(config?: Record<string, unknown>) {
-    super('simple', config);
-  }
-  getManifest(): SkillManifest {
-    return { name: 'simple', description: 'Simple skill', version: '1.0.0' };
-  }
+  static override SKILL_NAME = 'simple';
+  static override SKILL_DESCRIPTION = 'Simple skill';
+
   getTools(): SkillToolDefinition[] {
     return [{
       name: 'simple_tool',

--- a/tests/skills/SkillRegistry.test.ts
+++ b/tests/skills/SkillRegistry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { SkillRegistry } from '../../src/skills/SkillRegistry.js';
-import { SkillBase, type SkillManifest, type SkillToolDefinition } from '../../src/skills/SkillBase.js';
+import { SkillBase, type SkillToolDefinition } from '../../src/skills/SkillBase.js';
 import { FunctionResult } from '../../src/FunctionResult.js';
 import { suppressAllLogs } from '../../src/Logger.js';
 
@@ -17,6 +17,14 @@ class SimpleSkill extends SkillBase {
   }
 }
 
+/** Named-subclass helper — statics are class-level, so distinct names need distinct classes. */
+function makeNamedSkill(name: string, description = 'Test'): typeof SimpleSkill {
+  return class extends SimpleSkill {
+    static override SKILL_NAME = name;
+    static override SKILL_DESCRIPTION = description;
+  };
+}
+
 describe('SkillRegistry', () => {
   let registry: SkillRegistry;
 
@@ -27,7 +35,7 @@ describe('SkillRegistry', () => {
   });
 
   it('registers and creates skills', () => {
-    registry.register('simple', (config) => new SimpleSkill(config));
+    registry.register(SimpleSkill);
     const skill = registry.create('simple');
     expect(skill).not.toBeNull();
     expect(skill!.skillName).toBe('simple');
@@ -38,37 +46,51 @@ describe('SkillRegistry', () => {
   });
 
   it('has() checks registration', () => {
-    registry.register('simple', () => new SimpleSkill());
+    registry.register(SimpleSkill);
     expect(registry.has('simple')).toBe(true);
     expect(registry.has('missing')).toBe(false);
   });
 
   it('unregister removes skill', () => {
-    registry.register('simple', () => new SimpleSkill());
+    registry.register(SimpleSkill);
     expect(registry.unregister('simple')).toBe(true);
     expect(registry.has('simple')).toBe(false);
   });
 
   it('listRegistered returns all names', () => {
-    registry.register('a', () => new SimpleSkill());
-    registry.register('b', () => new SimpleSkill());
+    registry.register(makeNamedSkill('a'));
+    registry.register(makeNamedSkill('b'));
     const names = registry.listRegistered();
     expect(names).toContain('a');
     expect(names).toContain('b');
   });
 
-  it('registers with manifest', () => {
-    const manifest: SkillManifest = { name: 'simple', description: 'Test', version: '1.0.0' };
-    registry.register('simple', () => new SimpleSkill(), manifest);
-    expect(registry.getManifest('simple')).toEqual(manifest);
+  it('getSkillClass returns the class reference (Python parity)', () => {
+    registry.register(SimpleSkill);
+    expect(registry.getSkillClass('simple')).toBe(SimpleSkill);
+    expect(registry.getSkillClass('missing')).toBeUndefined();
   });
 
-  it('listRegisteredWithManifests includes manifests', () => {
-    const manifest: SkillManifest = { name: 'simple', description: 'Test', version: '1.0.0' };
-    registry.register('simple', () => new SimpleSkill(), manifest);
-    const list = registry.listRegisteredWithManifests();
+  it('listSkills returns Python-shaped metadata', () => {
+    registry.register(SimpleSkill);
+    const list = registry.listSkills();
     expect(list).toHaveLength(1);
-    expect(list[0].manifest).toEqual(manifest);
+    expect(list[0].name).toBe('simple');
+    expect(list[0].description).toBe('Simple skill');
+    expect(list[0].version).toBe('1.0.0');
+    expect(list[0].supportsMultipleInstances).toBe(false);
+    expect(list[0].requiredEnvVars).toEqual([]);
+    expect(list[0].requiredPackages).toEqual([]);
+    expect(list[0].parameters).toHaveProperty('swaig_fields');
+  });
+
+  it('register throws when SKILL_NAME is missing', () => {
+    class Nameless extends SkillBase {
+      static override SKILL_NAME = '';
+      static override SKILL_DESCRIPTION = 'nameless';
+      getTools(): SkillToolDefinition[] { return []; }
+    }
+    expect(() => registry.register(Nameless)).toThrow('SKILL_NAME');
   });
 
   it('singleton instance', () => {
@@ -86,13 +108,13 @@ describe('SkillRegistry', () => {
 
   it('size tracks registrations', () => {
     expect(registry.size).toBe(0);
-    registry.register('a', () => new SimpleSkill());
+    registry.register(SimpleSkill);
     expect(registry.size).toBe(1);
   });
 
   it('clear removes all registrations', () => {
-    registry.register('a', () => new SimpleSkill());
-    registry.register('b', () => new SimpleSkill());
+    registry.register(makeNamedSkill('a'));
+    registry.register(makeNamedSkill('b'));
     registry.clear();
     expect(registry.size).toBe(0);
   });
@@ -108,8 +130,8 @@ describe('SkillRegistry', () => {
     expect(registry.getSearchPaths().filter(p => p === '/skills')).toHaveLength(1);
   });
 
-  it('passes config to factory', () => {
-    registry.register('simple', (config) => new SimpleSkill(config));
+  it('passes config to constructor', () => {
+    registry.register(SimpleSkill);
     const skill = registry.create('simple', { key: 'val' });
     expect(skill!.getConfig('key')).toBe('val');
   });
@@ -124,21 +146,23 @@ describe('SkillRegistry', () => {
   // ── Security remediation tests ─────────────────────────────────────
 
   it('locked skill cannot be overwritten', () => {
-    registry.register('locked_skill', () => new SimpleSkill());
+    const LockedA = makeNamedSkill('locked_skill');
+    registry.register(LockedA);
     registry.lock(['locked_skill']);
-    // Attempt to overwrite
-    registry.register('locked_skill', () => new SimpleSkill());
-    // Still has original (just verifying it didn't throw and kept the name)
-    expect(registry.has('locked_skill')).toBe(true);
+    // Attempt to overwrite with a different subclass
+    const LockedB = makeNamedSkill('locked_skill', 'Different');
+    registry.register(LockedB);
+    // Still has the original class reference
+    expect(registry.getSkillClass('locked_skill')).toBe(LockedA);
   });
 
   it('lock() without args locks all current skills', () => {
-    registry.register('a', () => new SimpleSkill());
-    registry.register('b', () => new SimpleSkill());
+    registry.register(makeNamedSkill('a'));
+    registry.register(makeNamedSkill('b'));
     registry.lock();
     // Try overwriting
-    registry.register('a', () => new SimpleSkill());
-    registry.register('b', () => new SimpleSkill());
+    registry.register(makeNamedSkill('a', 'other'));
+    registry.register(makeNamedSkill('b', 'other'));
     // Both still exist
     expect(registry.has('a')).toBe(true);
     expect(registry.has('b')).toBe(true);

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -559,8 +559,10 @@ describe('WebSearchSkill', () => {
     const manifest = skill.getManifest();
     expect(manifest.name).toBe('web_search');
     expect(manifest.version).toBe('2.0.0');
-    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_API_KEY');
-    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_ENGINE_ID');
+    // Python declares REQUIRED_ENV_VARS = [] because credentials may come from
+    // either config params or env vars — nothing is strictly required at the
+    // env-var layer. setup() enforces at least one source is populated.
+    expect(manifest.requiredEnvVars).toEqual([]);
   });
 
   it('should return a web_search tool', () => {

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -558,9 +558,9 @@ describe('WebSearchSkill', () => {
     const skill = createWebSearchSkill();
     const manifest = skill.getManifest();
     expect(manifest.name).toBe('web_search');
-    expect(manifest.version).toBe('1.0.0');
+    expect(manifest.version).toBe('2.0.0');
     expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_API_KEY');
-    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_CX');
+    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_ENGINE_ID');
   });
 
   it('should return a web_search tool', () => {
@@ -575,13 +575,15 @@ describe('WebSearchSkill', () => {
     const skill = createWebSearchSkill();
     const sections = skill.getPromptSections();
     expect(sections.length).toBeGreaterThan(0);
-    expect(sections[0].title).toBe('Web Search');
+    expect(sections[0].title).toContain('Web Search');
   });
 
   it('should return error when API keys are not set', async () => {
     const origKey = process.env['GOOGLE_SEARCH_API_KEY'];
+    const origEngine = process.env['GOOGLE_SEARCH_ENGINE_ID'];
     const origCx = process.env['GOOGLE_SEARCH_CX'];
     delete process.env['GOOGLE_SEARCH_API_KEY'];
+    delete process.env['GOOGLE_SEARCH_ENGINE_ID'];
     delete process.env['GOOGLE_SEARCH_CX'];
     const skill = createWebSearchSkill();
     const handler = skill.getTools()[0].handler;
@@ -589,6 +591,7 @@ describe('WebSearchSkill', () => {
     expect(result).toBeInstanceOf(FunctionResult);
     expect(result.response).toContain('not configured');
     if (origKey !== undefined) process.env['GOOGLE_SEARCH_API_KEY'] = origKey;
+    if (origEngine !== undefined) process.env['GOOGLE_SEARCH_ENGINE_ID'] = origEngine;
     if (origCx !== undefined) process.env['GOOGLE_SEARCH_CX'] = origCx;
   });
 });
@@ -610,11 +613,11 @@ describe('WikipediaSearchSkill', () => {
     expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should return a search_wikipedia tool', () => {
+  it('should return a search_wiki tool', () => {
     const skill = createWikipediaSearchSkill();
     const tools = skill.getTools();
     expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('search_wikipedia');
+    expect(tools[0].name).toBe('search_wiki');
     expect(tools[0].required).toContain('query');
   });
 
@@ -722,7 +725,7 @@ describe('DataSphereSkill', () => {
     const skill = createDataSphereSkill();
     const sections = skill.getPromptSections();
     expect(sections.length).toBeGreaterThan(0);
-    expect(sections[0].title).toContain('DataSphere');
+    expect(sections[0].title).toContain('Knowledge Search');
   });
 
   it('should return error when env vars are not set', async () => {
@@ -759,9 +762,8 @@ describe('DataSphereServerlessSkill', () => {
     const manifest = skill.getManifest();
     expect(manifest.name).toBe('datasphere_serverless');
     expect(manifest.version).toBe('1.0.0');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_PROJECT_ID');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_TOKEN');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_SPACE');
+    // Credentials come from params by design (matches Python REQUIRED_ENV_VARS = []).
+    expect(manifest.requiredEnvVars ?? []).toEqual([]);
   });
 
   it('should return a search_datasphere tool stub', () => {

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -416,11 +416,11 @@ describe('ApiNinjasTriviaSkill', () => {
 // Info Gatherer Skill
 // ---------------------------------------------------------------------------
 describe('InfoGathererSkill', () => {
-  it('should instantiate with fields config via createSkill factory', () => {
+  it('should instantiate with questions config via createSkill factory', () => {
     const skill = createInfoGathererSkill({
-      fields: [
-        { name: 'full_name', description: 'Full name', required: true },
-        { name: 'email', description: 'Email address' },
+      questions: [
+        { key_name: 'full_name', question_text: 'What is your full name?' },
+        { key_name: 'email', question_text: 'What is your email address?' },
       ],
     });
     expect(skill).toBeInstanceOf(InfoGathererSkill);
@@ -432,43 +432,6 @@ describe('InfoGathererSkill', () => {
     const klass = skill.constructor as typeof SkillBase;
     expect(klass.SKILL_NAME).toBe('info_gatherer');
     expect(klass.SKILL_VERSION).toBe('1.0.0');
-  });
-
-  it('should return save_info and get_gathered_info tools when fields configured', () => {
-    const skill = createInfoGathererSkill({
-      fields: [
-        { name: 'full_name', description: 'Full name', required: true },
-      ],
-    });
-    const tools = skill.getTools();
-    expect(tools).toHaveLength(2);
-    const names = tools.map((t) => t.name);
-    expect(names).toContain('save_info');
-    expect(names).toContain('get_gathered_info');
-  });
-
-  it('should return no tools when no fields configured', () => {
-    const skill = createInfoGathererSkill();
-    const tools = skill.getTools();
-    expect(tools).toHaveLength(0);
-  });
-
-  it('should execute save_info handler and save data', () => {
-    const skill = createInfoGathererSkill({
-      fields: [
-        { name: 'full_name', description: 'Full name', required: true },
-        { name: 'email', description: 'Email address' },
-      ],
-    });
-    const saveTool = skill.getTools().find((t) => t.name === 'save_info')!;
-    const result = saveTool.handler(
-      { full_name: 'Jane Doe', email: 'jane@example.com' },
-      { call_id: 'test-call-123' },
-    ) as FunctionResult;
-    expect(result).toBeInstanceOf(FunctionResult);
-    expect(result.response).toContain('saved successfully');
-    expect(result.response).toContain('Jane Doe');
-    expect(result.response).toContain('jane@example.com');
   });
 });
 

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -630,10 +630,10 @@ describe('WikipediaSearchSkill', () => {
     expect(sections[0].bullets!.length).toBeGreaterThan(0);
   });
 
-  it('should have no requiredEnvVars (free API)', () => {
+  it('should declare empty requiredEnvVars (free API, matches Python REQUIRED_ENV_VARS = [])', () => {
     const skill = createWikipediaSearchSkill();
     const manifest = skill.getManifest();
-    expect(manifest.requiredEnvVars).toBeUndefined();
+    expect(manifest.requiredEnvVars).toEqual([]);
   });
 });
 

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -352,18 +352,18 @@ describe('SwmlTransferSkill', () => {
     expect(result.action.length).toBeGreaterThan(0);
   });
 
-  it('should reject unknown named destinations when patterns configured and arbitrary disallowed', () => {
+  it('should use no-match message when patterns configured and arbitrary disallowed', () => {
     const skill = createSwmlTransferSkill({
       patterns: [
         { name: 'sales', destination: 'sip:sales@example.com' },
       ],
       allow_arbitrary: false,
+      no_match_message: 'Please specify a valid transfer type.',
     });
     const handler = skill.getTools()[0].handler;
     const result = handler({ destination: 'unknown_dept' }, {}) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
-    expect(result.response).toContain('Unknown transfer destination');
-    expect(result.response).toContain('sales');
+    expect(result.response).toContain('valid transfer type');
   });
 });
 
@@ -813,27 +813,36 @@ describe('NativeVectorSearchSkill', () => {
     expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should return a search_documents tool', () => {
+  it('should return a search_knowledge tool (Python-aligned default name)', async () => {
     const skill = createNativeVectorSearchSkill({ documents: testDocuments });
+    await skill.setup();
     const tools = skill.getTools();
     expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('search_documents');
+    expect(tools[0].name).toBe('search_knowledge');
     expect(tools[0].required).toContain('query');
   });
 
-  it('should execute search and find relevant documents', () => {
+  it('should execute search and find relevant documents', async () => {
     const skill = createNativeVectorSearchSkill({ documents: testDocuments });
+    await skill.setup();
     const handler = skill.getTools()[0].handler;
-    const result = handler({ query: 'TypeScript programming language' }, {}) as FunctionResult;
+    const result = (await handler(
+      { query: 'TypeScript programming language' },
+      {},
+    )) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
     expect(result.response).toContain('doc1');
     expect(result.response).toContain('TypeScript');
   });
 
-  it('should rank relevant documents higher (scoring works)', () => {
+  it('should rank relevant documents higher (scoring works)', async () => {
     const skill = createNativeVectorSearchSkill({ documents: testDocuments });
+    await skill.setup();
     const handler = skill.getTools()[0].handler;
-    const result = handler({ query: 'programming language', top_k: 4 }, {}) as FunctionResult;
+    const result = (await handler(
+      { query: 'programming language', count: 4 },
+      {},
+    )) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
     // Programming-related docs should appear; weather doc should not (no overlap)
     expect(result.response).toContain('programming');
@@ -857,26 +866,28 @@ describe('SpiderSkill', () => {
     const manifest = skill.getManifest();
     expect(manifest.name).toBe('spider');
     expect(manifest.version).toBe('1.0.0');
-    expect(manifest.requiredEnvVars).toContain('SPIDER_API_KEY');
   });
 
-  it('should return a scrape_url tool', () => {
+  it('should return the three Python-aligned tools (scrape_url, crawl_site, extract_structured_data)', async () => {
     const skill = createSpiderSkill();
+    await skill.setup();
     const tools = skill.getTools();
-    expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('scrape_url');
-    expect(tools[0].required).toContain('url');
+    expect(tools).toHaveLength(3);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('scrape_url');
+    expect(names).toContain('crawl_site');
+    expect(names).toContain('extract_structured_data');
+    const scrape = tools.find((t) => t.name === 'scrape_url')!;
+    expect(scrape.required).toContain('url');
   });
 
-  it('should return error when API key is not set', async () => {
-    const origKey = process.env['SPIDER_API_KEY'];
-    delete process.env['SPIDER_API_KEY'];
+  it('should reject invalid URL in scrape_url handler', async () => {
     const skill = createSpiderSkill();
-    const handler = skill.getTools()[0].handler;
-    const result = await handler({ url: 'https://example.com' }, {}) as FunctionResult;
+    await skill.setup();
+    const handler = skill.getTools().find((t) => t.name === 'scrape_url')!.handler;
+    const result = (await handler({ url: 'not-a-url' }, {})) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
-    expect(result.response).toContain('not configured');
-    if (origKey !== undefined) process.env['SPIDER_API_KEY'] = origKey;
+    expect(result.response).toMatch(/Invalid URL/i);
   });
 });
 
@@ -1328,15 +1339,15 @@ describe('McpGatewaySkill', () => {
     const skill = createMcpGatewaySkill();
     const manifest = skill.getManifest();
     expect(manifest.name).toBe('mcp_gateway');
-    expect(manifest.version).toBe('0.1.0');
+    expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should return not implemented message from handler', () => {
+  it('should return a configuration-prompt message when unconfigured', async () => {
     const skill = createMcpGatewaySkill();
     const handler = skill.getTools()[0].handler;
-    const result = handler({ server: 'test', method: 'test' }, {}) as FunctionResult;
+    const result = (await handler({ server: 'test', method: 'test' }, {})) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
-    expect(result.response).toContain('not yet implemented');
+    expect(result.response).toMatch(/not configured|configure/i);
   });
 });
 
@@ -1374,18 +1385,20 @@ describe('SpiderSkill - SSRF protection', () => {
     const saved = process.env['SWML_ALLOW_PRIVATE_URLS'];
     delete process.env['SWML_ALLOW_PRIVATE_URLS'];
     const skill = createSpiderSkill();
-    const handler = skill.getTools()[0].handler;
-    const result = await handler({ url: 'http://127.0.0.1/secret' }, {}) as FunctionResult;
+    await skill.setup();
+    const handler = skill.getTools().find((t) => t.name === 'scrape_url')!.handler;
+    const result = (await handler({ url: 'http://127.0.0.1/secret' }, {})) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
-    expect(result.response).toContain('could not be validated');
+    expect(result.response).toMatch(/private or internal URLs/);
     if (saved) process.env['SWML_ALLOW_PRIVATE_URLS'] = saved;
   });
 
   it('should reject overly long input', async () => {
     const skill = createSpiderSkill();
-    const handler = skill.getTools()[0].handler;
+    await skill.setup();
+    const handler = skill.getTools().find((t) => t.name === 'scrape_url')!.handler;
     const longUrl = 'https://example.com/' + 'a'.repeat(2000);
-    const result = await handler({ url: longUrl }, {}) as FunctionResult;
+    const result = (await handler({ url: longUrl }, {})) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
     expect(result.response).toContain('too long');
   });

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -708,16 +708,15 @@ describe('DataSphereSkill', () => {
     const manifest = skill.getManifest();
     expect(manifest.name).toBe('datasphere');
     expect(manifest.version).toBe('1.0.0');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_PROJECT_ID');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_TOKEN');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_SPACE');
+    // Credentials come from params by design (matches Python REQUIRED_ENV_VARS = []).
+    expect(manifest.requiredEnvVars).toEqual([]);
   });
 
-  it('should return a search_datasphere tool', () => {
+  it('should return a search_knowledge tool', () => {
     const skill = createDataSphereSkill();
     const tools = skill.getTools();
     expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('search_datasphere');
+    expect(tools[0].name).toBe('search_knowledge');
     expect(tools[0].required).toContain('query');
   });
 
@@ -766,11 +765,11 @@ describe('DataSphereServerlessSkill', () => {
     expect(manifest.requiredEnvVars ?? []).toEqual([]);
   });
 
-  it('should return a search_datasphere tool stub', () => {
+  it('should return a search_knowledge tool stub', () => {
     const skill = createDataSphereServerlessSkill();
     const tools = skill.getTools();
     expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('search_datasphere');
+    expect(tools[0].name).toBe('search_knowledge');
   });
 
   it('should return stub handler message indicating DataMap mode', () => {

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -317,15 +317,15 @@ describe('SwmlTransferSkill', () => {
     const tools = skill.getTools();
     expect(tools.length).toBeGreaterThanOrEqual(1);
     expect(tools[0].name).toBe('transfer_call');
-    expect(tools[0].required).toContain('destination');
+    expect(tools[0].required).toContain('transfer_type');
   });
 
   it('should execute transfer with arbitrary destination', () => {
     const skill = createSwmlTransferSkill();
     const handler = skill.getTools()[0].handler;
-    const result = handler({ destination: '+15551234567' }, {}) as FunctionResult;
+    const result = handler({ transfer_type: '+15551234567' }, {}) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
-    expect(result.response).toBe('Transferring your call now.');
+    expect(result.response).toBe('Transferring you now...');
     // Should have a SWML transfer action
     expect(result.action.length).toBeGreaterThan(0);
     const swmlAction = result.action[0];
@@ -347,21 +347,21 @@ describe('SwmlTransferSkill', () => {
 
     // Transfer by name
     const handler = tools[0].handler;
-    const result = handler({ destination: 'sales' }, {}) as FunctionResult;
+    const result = handler({ transfer_type: 'sales' }, {}) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
     expect(result.action.length).toBeGreaterThan(0);
   });
 
-  it('should use no-match message when patterns configured and arbitrary disallowed', () => {
+  it('should use default_message when patterns configured and arbitrary disallowed', () => {
     const skill = createSwmlTransferSkill({
       patterns: [
         { name: 'sales', destination: 'sip:sales@example.com' },
       ],
       allow_arbitrary: false,
-      no_match_message: 'Please specify a valid transfer type.',
+      default_message: 'Please specify a valid transfer type.',
     });
     const handler = skill.getTools()[0].handler;
-    const result = handler({ destination: 'unknown_dept' }, {}) as FunctionResult;
+    const result = handler({ transfer_type: 'unknown_dept' }, {}) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
     expect(result.response).toContain('valid transfer type');
   });

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -69,10 +69,10 @@ describe('DateTimeSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createDateTimeSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('datetime');
-    expect(manifest.version).toBe('1.0.0');
-    expect(manifest.description).toBeTruthy();
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('datetime');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
+    expect(klass.SKILL_DESCRIPTION).toBeTruthy();
   });
 
   it('should return a get_datetime tool', () => {
@@ -114,9 +114,9 @@ describe('MathSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createMathSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('math');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('math');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should return a calculate tool', () => {
@@ -167,9 +167,9 @@ describe('JokeSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createJokeSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('joke');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('joke');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should return a tell_joke tool', () => {
@@ -209,10 +209,10 @@ describe('WeatherApiSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createWeatherApiSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('weather_api');
-    expect(manifest.version).toBe('1.0.0');
-    expect(manifest.requiredEnvVars).toContain('WEATHER_API_KEY');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('weather_api');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
+    expect(klass.REQUIRED_ENV_VARS).toContain('WEATHER_API_KEY');
   });
 
   it('should return a get_weather tool', () => {
@@ -256,9 +256,9 @@ describe('PlayBackgroundFileSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createPlayBackgroundFileSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('play_background_file');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('play_background_file');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should return play_background and stop_background tools', () => {
@@ -307,9 +307,9 @@ describe('SwmlTransferSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createSwmlTransferSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('swml_transfer');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('swml_transfer');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should return a transfer_call tool', () => {
@@ -379,10 +379,10 @@ describe('ApiNinjasTriviaSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createApiNinjasTriviaSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('api_ninjas_trivia');
-    expect(manifest.version).toBe('1.0.0');
-    expect(manifest.requiredEnvVars).toContain('API_NINJAS_KEY');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('api_ninjas_trivia');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
+    expect(klass.REQUIRED_ENV_VARS).toContain('API_NINJAS_KEY');
   });
 
   it('should return a get_trivia tool', () => {
@@ -429,9 +429,9 @@ describe('InfoGathererSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createInfoGathererSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('info_gatherer');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('info_gatherer');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should return save_info and get_gathered_info tools when fields configured', () => {
@@ -493,9 +493,9 @@ describe('CustomSkillsSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createCustomSkillsSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('custom_skills');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('custom_skills');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should register dynamic tools from config', () => {
@@ -556,13 +556,13 @@ describe('WebSearchSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createWebSearchSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('web_search');
-    expect(manifest.version).toBe('2.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('web_search');
+    expect(klass.SKILL_VERSION).toBe('2.0.0');
     // Python declares REQUIRED_ENV_VARS = [] because credentials may come from
     // either config params or env vars — nothing is strictly required at the
     // env-var layer. setup() enforces at least one source is populated.
-    expect(manifest.requiredEnvVars).toEqual([]);
+    expect(klass.REQUIRED_ENV_VARS).toEqual([]);
   });
 
   it('should return a web_search tool', () => {
@@ -610,9 +610,9 @@ describe('WikipediaSearchSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createWikipediaSearchSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('wikipedia_search');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('wikipedia_search');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should return a search_wiki tool', () => {
@@ -634,8 +634,8 @@ describe('WikipediaSearchSkill', () => {
 
   it('should declare empty requiredEnvVars (free API, matches Python REQUIRED_ENV_VARS = [])', () => {
     const skill = createWikipediaSearchSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.requiredEnvVars).toEqual([]);
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.REQUIRED_ENV_VARS).toEqual([]);
   });
 });
 
@@ -651,10 +651,10 @@ describe('GoogleMapsSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createGoogleMapsSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('google_maps');
-    expect(manifest.version).toBe('1.0.0');
-    expect(manifest.requiredEnvVars).toContain('GOOGLE_MAPS_API_KEY');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('google_maps');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
+    expect(klass.REQUIRED_ENV_VARS).toContain('GOOGLE_MAPS_API_KEY');
   });
 
   it('should return get_directions and find_place tools', () => {
@@ -707,11 +707,11 @@ describe('DataSphereSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createDataSphereSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('datasphere');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('datasphere');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
     // Credentials come from params by design (matches Python REQUIRED_ENV_VARS = []).
-    expect(manifest.requiredEnvVars).toEqual([]);
+    expect(klass.REQUIRED_ENV_VARS).toEqual([]);
   });
 
   it('should return a search_knowledge tool', () => {
@@ -760,11 +760,11 @@ describe('DataSphereServerlessSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createDataSphereServerlessSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('datasphere_serverless');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('datasphere_serverless');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
     // Credentials come from params by design (matches Python REQUIRED_ENV_VARS = []).
-    expect(manifest.requiredEnvVars ?? []).toEqual([]);
+    expect(klass.REQUIRED_ENV_VARS ?? []).toEqual([]);
   });
 
   it('should return a search_knowledge tool stub', () => {
@@ -811,9 +811,9 @@ describe('NativeVectorSearchSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createNativeVectorSearchSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('native_vector_search');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('native_vector_search');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should return a search_knowledge tool (Python-aligned default name)', async () => {
@@ -866,9 +866,9 @@ describe('SpiderSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createSpiderSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('spider');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('spider');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should return the three Python-aligned tools (scrape_url, crawl_site, extract_structured_data)', async () => {
@@ -906,10 +906,10 @@ describe('AskClaudeSkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createAskClaudeSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('ask_claude');
-    expect(manifest.version).toBe('1.0.0');
-    expect(manifest.requiredEnvVars).toContain('ANTHROPIC_API_KEY');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('ask_claude');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
+    expect(klass.REQUIRED_ENV_VARS).toContain('ANTHROPIC_API_KEY');
   });
 
   it('should return an ask_claude tool', () => {
@@ -1033,9 +1033,9 @@ describe('ClaudeSkillsSkill', () => {
 
   it('should return correct manifest', () => {
     const skill = createClaudeSkillsSkill({ skills_path: skillsDir });
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('claude_skills');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('claude_skills');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should support multiple instances', () => {
@@ -1340,9 +1340,9 @@ describe('McpGatewaySkill', () => {
 
   it('should return correct manifest name and version', () => {
     const skill = createMcpGatewaySkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('mcp_gateway');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = skill.constructor as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('mcp_gateway');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should return a configuration-prompt message when unconfigured', async () => {

--- a/tests/skills/claude-skills.test.ts
+++ b/tests/skills/claude-skills.test.ts
@@ -15,8 +15,8 @@ describe('ClaudeSkillsSkill', () => {
     expect(createClaudeSkillsSkill()).toBeInstanceOf(ClaudeSkillsSkill);
   });
 
-  it('should complete setup without errors', async () => {
-    await expect(new ClaudeSkillsSkill().setup()).resolves.toBeUndefined();
+  it('should return false from setup when skills_path is not configured', async () => {
+    await expect(new ClaudeSkillsSkill().setup()).resolves.toBe(false);
   });
 
   it('should return empty tools when no skills_path is configured', () => {

--- a/tests/skills/claude-skills.test.ts
+++ b/tests/skills/claude-skills.test.ts
@@ -42,9 +42,9 @@ describe('ClaudeSkillsSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new ClaudeSkillsSkill().getManifest();
-    expect(manifest.name).toBe('claude_skills');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = ClaudeSkillsSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('claude_skills');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should have a parameter schema', () => {

--- a/tests/skills/custom-skills.test.ts
+++ b/tests/skills/custom-skills.test.ts
@@ -41,9 +41,9 @@ describe('CustomSkillsSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new CustomSkillsSkill().getManifest();
-    expect(manifest.name).toBe('custom_skills');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = CustomSkillsSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('custom_skills');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should have a parameter schema', () => {

--- a/tests/skills/custom-skills.test.ts
+++ b/tests/skills/custom-skills.test.ts
@@ -16,7 +16,7 @@ describe('CustomSkillsSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new CustomSkillsSkill().setup()).resolves.toBeUndefined();
+    await expect(new CustomSkillsSkill().setup()).resolves.toBe(true);
   });
 
   it('should register tools', () => {

--- a/tests/skills/datasphere-serverless.test.ts
+++ b/tests/skills/datasphere-serverless.test.ts
@@ -33,10 +33,17 @@ describe('DataSphereServerlessSkill', () => {
     expect(new DataSphereServerlessSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
+  it('should return empty hints', () => {
     const skill = new DataSphereServerlessSkill();
     expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  });
+
+  it('should expose DataSphere metadata via global data', () => {
+    const skill = new DataSphereServerlessSkill({ document_id: 'doc-1' });
+    const globalData = skill.getGlobalData();
+    expect(globalData['datasphere_serverless_enabled']).toBe(true);
+    expect(globalData['document_id']).toBe('doc-1');
+    expect(globalData['knowledge_provider']).toBe('SignalWire DataSphere (Serverless)');
   });
 
   it('should return correct manifest', () => {

--- a/tests/skills/datasphere-serverless.test.ts
+++ b/tests/skills/datasphere-serverless.test.ts
@@ -16,7 +16,7 @@ describe('DataSphereServerlessSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new DataSphereServerlessSkill().setup()).resolves.toBeUndefined();
+    await expect(new DataSphereServerlessSkill().setup()).resolves.toBe(true);
   });
 
   it('should register tools', () => {

--- a/tests/skills/datasphere-serverless.test.ts
+++ b/tests/skills/datasphere-serverless.test.ts
@@ -15,8 +15,19 @@ describe('DataSphereServerlessSkill', () => {
     expect(createDataSphereServerlessSkill()).toBeInstanceOf(DataSphereServerlessSkill);
   });
 
-  it('should complete setup without errors', async () => {
-    await expect(new DataSphereServerlessSkill().setup()).resolves.toBe(true);
+  it('should return false from setup when required params are missing', async () => {
+    // Python setup() returns False when space_name/project_id/token/document_id are absent.
+    await expect(new DataSphereServerlessSkill().setup()).resolves.toBe(false);
+  });
+
+  it('should return true from setup when all required params are present', async () => {
+    const skill = new DataSphereServerlessSkill({
+      space_name: 'mycompany',
+      project_id: 'proj-123',
+      token: 'tok-abc',
+      document_id: 'doc-xyz',
+    });
+    await expect(skill.setup()).resolves.toBe(true);
   });
 
   it('should register tools', () => {

--- a/tests/skills/datasphere-serverless.test.ts
+++ b/tests/skills/datasphere-serverless.test.ts
@@ -58,9 +58,9 @@ describe('DataSphereServerlessSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new DataSphereServerlessSkill().getManifest();
-    expect(manifest.name).toBe('datasphere_serverless');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = DataSphereServerlessSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('datasphere_serverless');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should have a parameter schema', () => {

--- a/tests/skills/datasphere.test.ts
+++ b/tests/skills/datasphere.test.ts
@@ -34,17 +34,24 @@ describe('DataSphereSkill', () => {
   it('should provide prompt sections', () => {
     const sections = new DataSphereSkill().getPromptSections();
     expect(sections.length).toBeGreaterThan(0);
-    expect(sections[0].title).toContain('DataSphere');
+    expect(sections[0].title).toContain('Knowledge Search');
   });
 
   it('should skip prompt sections when skip_prompt is set', () => {
     expect(new DataSphereSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
+  it('should return empty hints', () => {
     const skill = new DataSphereSkill();
     expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  });
+
+  it('should expose DataSphere metadata via global data', () => {
+    const skill = new DataSphereSkill({ document_id: 'doc-1' });
+    const globalData = skill.getGlobalData();
+    expect(globalData['datasphere_enabled']).toBe(true);
+    expect(globalData['document_id']).toBe('doc-1');
+    expect(globalData['knowledge_provider']).toBe('SignalWire DataSphere');
   });
 
   it('should return correct manifest with required env vars', () => {
@@ -64,6 +71,11 @@ describe('DataSphereSkill', () => {
     expect(result.response).toContain('not configured');
   });
 
+  it('should default instance key to datasphere_search_knowledge', () => {
+    const skill = new DataSphereSkill();
+    expect(skill.getInstanceKey()).toBe('datasphere_search_knowledge');
+  });
+
   it('should use custom instance key with tool_name', () => {
     const skill = new DataSphereSkill({ tool_name: 'custom' });
     expect(skill.getInstanceKey()).toBe('datasphere_custom');
@@ -71,8 +83,13 @@ describe('DataSphereSkill', () => {
 
   it('should have a parameter schema', () => {
     const schema = DataSphereSkill.getParameterSchema();
-    expect(schema['max_results']).toBeDefined();
-    expect(schema['distance_threshold']).toBeDefined();
+    expect(schema['count']).toBeDefined();
+    expect(schema['distance']).toBeDefined();
+    expect(schema['tags']).toBeDefined();
+    expect(schema['language']).toBeDefined();
+    expect(schema['pos_to_expand']).toBeDefined();
+    expect(schema['max_synonyms']).toBeDefined();
+    expect(schema['no_results_message']).toBeDefined();
     expect(schema['tool_name']).toBeDefined();
   });
 });

--- a/tests/skills/datasphere.test.ts
+++ b/tests/skills/datasphere.test.ts
@@ -20,8 +20,22 @@ describe('DataSphereSkill', () => {
     expect(DataSphereSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
   });
 
-  it('should complete setup without errors', async () => {
-    await expect(new DataSphereSkill().setup()).resolves.toBe(true);
+  it('should return false from setup when credentials are missing', async () => {
+    // Python parity (skills/datasphere/skill.py:120-128): setup() returns false
+    // with an error log when any of space_name, project_id, token, document_id
+    // is missing. Fails closed so the skill never exposes broken tools to the AI.
+    await expect(new DataSphereSkill().setup()).resolves.toBe(false);
+  });
+
+  it('should complete setup when all credentials + document_id are provided', async () => {
+    await expect(
+      new DataSphereSkill({
+        space_name: 'test',
+        project_id: 'p',
+        token: 't',
+        document_id: 'd',
+      }).setup(),
+    ).resolves.toBe(true);
   });
 
   it('should register a search_knowledge tool', () => {

--- a/tests/skills/datasphere.test.ts
+++ b/tests/skills/datasphere.test.ts
@@ -24,10 +24,10 @@ describe('DataSphereSkill', () => {
     await expect(new DataSphereSkill().setup()).resolves.toBe(true);
   });
 
-  it('should register a search_datasphere tool', () => {
+  it('should register a search_knowledge tool', () => {
     const tools = new DataSphereSkill().getTools();
     expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('search_datasphere');
+    expect(tools[0].name).toBe('search_knowledge');
     expect(tools[0].required).toContain('query');
   });
 
@@ -54,12 +54,10 @@ describe('DataSphereSkill', () => {
     expect(globalData['knowledge_provider']).toBe('SignalWire DataSphere');
   });
 
-  it('should return correct manifest with required env vars', () => {
+  it('should return correct manifest with no required env vars', () => {
     const manifest = new DataSphereSkill().getManifest();
     expect(manifest.name).toBe('datasphere');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_PROJECT_ID');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_TOKEN');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_SPACE');
+    expect(manifest.requiredEnvVars).toEqual([]);
   });
 
   it('should return error when credentials are missing', async () => {

--- a/tests/skills/datasphere.test.ts
+++ b/tests/skills/datasphere.test.ts
@@ -69,9 +69,9 @@ describe('DataSphereSkill', () => {
   });
 
   it('should return correct manifest with no required env vars', () => {
-    const manifest = new DataSphereSkill().getManifest();
-    expect(manifest.name).toBe('datasphere');
-    expect(manifest.requiredEnvVars).toEqual([]);
+    const klass = DataSphereSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('datasphere');
+    expect(klass.REQUIRED_ENV_VARS).toEqual([]);
   });
 
   it('should return error when credentials are missing', async () => {

--- a/tests/skills/datasphere.test.ts
+++ b/tests/skills/datasphere.test.ts
@@ -21,7 +21,7 @@ describe('DataSphereSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new DataSphereSkill().setup()).resolves.toBeUndefined();
+    await expect(new DataSphereSkill().setup()).resolves.toBe(true);
   });
 
   it('should register a search_datasphere tool', () => {

--- a/tests/skills/datetime.test.ts
+++ b/tests/skills/datetime.test.ts
@@ -22,7 +22,7 @@ describe('DateTimeSkill', () => {
 
   it('should complete setup without errors', async () => {
     const skill = new DateTimeSkill();
-    await expect(skill.setup()).resolves.toBeUndefined();
+    await expect(skill.setup()).resolves.toBe(true);
   });
 
   it('should register a get_datetime tool', () => {

--- a/tests/skills/datetime.test.ts
+++ b/tests/skills/datetime.test.ts
@@ -59,11 +59,9 @@ describe('DateTimeSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const skill = new DateTimeSkill();
-    const manifest = skill.getManifest();
-    expect(manifest.name).toBe('datetime');
-    expect(manifest.version).toBe('1.0.0');
-    expect(manifest.description).toBeTruthy();
+    expect(DateTimeSkill.SKILL_NAME).toBe('datetime');
+    expect(DateTimeSkill.SKILL_VERSION).toBe('1.0.0');
+    expect(DateTimeSkill.SKILL_DESCRIPTION).toBeTruthy();
   });
 
   it('should execute handler with a valid timezone', () => {

--- a/tests/skills/google-maps.test.ts
+++ b/tests/skills/google-maps.test.ts
@@ -42,9 +42,9 @@ describe('GoogleMapsSkill', () => {
   });
 
   it('should return correct manifest with required env vars', () => {
-    const manifest = new GoogleMapsSkill().getManifest();
-    expect(manifest.name).toBe('google_maps');
-    expect(manifest.requiredEnvVars).toContain('GOOGLE_MAPS_API_KEY');
+    const klass = GoogleMapsSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('google_maps');
+    expect(klass.REQUIRED_ENV_VARS).toContain('GOOGLE_MAPS_API_KEY');
   });
 
   it('should return error when origin is missing', async () => {

--- a/tests/skills/google-maps.test.ts
+++ b/tests/skills/google-maps.test.ts
@@ -17,7 +17,7 @@ describe('GoogleMapsSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new GoogleMapsSkill().setup()).resolves.toBeUndefined();
+    await expect(new GoogleMapsSkill().setup()).resolves.toBe(true);
   });
 
   it('should register tools', () => {

--- a/tests/skills/info-gatherer.test.ts
+++ b/tests/skills/info-gatherer.test.ts
@@ -76,9 +76,9 @@ describe('InfoGathererSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new InfoGathererSkill().getManifest();
-    expect(manifest.name).toBe('info_gatherer');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = InfoGathererSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('info_gatherer');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should have a parameter schema', () => {

--- a/tests/skills/info-gatherer.test.ts
+++ b/tests/skills/info-gatherer.test.ts
@@ -9,7 +9,7 @@ import { suppressAllLogs } from '../../src/Logger.js';
 
 beforeAll(() => { suppressAllLogs(true); });
 
-// ── Field-collection (single-shot) mode ─────────────────────────────────────
+// ── Basic skill identity + setup contract ──────────────────────────────────
 
 describe('InfoGathererSkill', () => {
   it('should instantiate via constructor and factory', () => {
@@ -17,62 +17,55 @@ describe('InfoGathererSkill', () => {
     expect(createInfoGathererSkill()).toBeInstanceOf(InfoGathererSkill);
   });
 
-  it('should return false from setup when neither questions nor fields configured', async () => {
-    // Python parity: skill.py:91-95 requires `questions`; TS supports either
-    // questions or fields but not neither, so setup() returns false without
-    // registering any tools or prompt sections.
+  it("should return false from setup when 'questions' is not configured", async () => {
+    // Python parity: skill.py:91-95 — `questions` is required; setup returns
+    // false (and logs an error) if it's missing.
     await expect(new InfoGathererSkill().setup()).resolves.toBe(false);
   });
 
-  it('should complete setup with fields configured', async () => {
+  it('should return true from setup when valid questions are configured', async () => {
     await expect(
       new InfoGathererSkill({
-        fields: [{ name: 'email', description: 'Email address', type: 'string' }],
+        questions: [{ key_name: 'email', question_text: 'What is your email?' }],
       }).setup(),
     ).resolves.toBe(true);
   });
 
-  it('should register tools with configured fields', () => {
-    const skill = new InfoGathererSkill({
-      fields: [
-        { name: 'name', description: 'Full name', required: true },
-        { name: 'email', description: 'Email address' },
-      ],
-    });
-    const tools = skill.getTools();
-    expect(tools.length).toBeGreaterThan(0);
-    expect(tools[0].handler).toBeTypeOf('function');
+  it('should return false from setup when questions is an empty array', async () => {
+    // Python parity: skill.py:301 — `At least one question is required`.
+    await expect(
+      new InfoGathererSkill({ questions: [] }).setup(),
+    ).resolves.toBe(false);
   });
 
-  it('should return empty tools when no fields are configured', () => {
-    const skill = new InfoGathererSkill();
-    const tools = skill.getTools();
-    expect(Array.isArray(tools)).toBe(true);
-    expect(tools).toHaveLength(0);
+  it('should return false from setup when questions is not an array', async () => {
+    await expect(
+      new InfoGathererSkill({ questions: 'not-an-array' }).setup(),
+    ).resolves.toBe(false);
   });
 
-  it('should return empty prompt sections when no fields are configured', () => {
-    const sections = new InfoGathererSkill().getPromptSections();
-    expect(Array.isArray(sections)).toBe(true);
-    expect(sections).toHaveLength(0);
+  it('should return false from setup when a question is missing key_name', async () => {
+    await expect(
+      new InfoGathererSkill({
+        questions: [{ question_text: 'What is your name?' }],
+      }).setup(),
+    ).resolves.toBe(false);
   });
 
-  it('should provide prompt sections when fields are configured', () => {
-    const skill = new InfoGathererSkill({
-      fields: [{ name: 'name', description: 'Full name', required: true }],
-    });
-    const sections = skill.getPromptSections();
-    expect(sections.length).toBeGreaterThan(0);
+  it('should return false from setup when a question is missing question_text', async () => {
+    await expect(
+      new InfoGathererSkill({ questions: [{ key_name: 'name' }] }).setup(),
+    ).resolves.toBe(false);
   });
 
   it('should skip prompt sections when skip_prompt is set', () => {
-    expect(new InfoGathererSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
+    expect(
+      new InfoGathererSkill({ skip_prompt: true }).getPromptSections(),
+    ).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
-    const skill = new InfoGathererSkill();
-    expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  it('should return empty hints', () => {
+    expect(new InfoGathererSkill().getHints()).toEqual([]);
   });
 
   it('should return correct manifest', () => {
@@ -147,32 +140,33 @@ describe('InfoGathererSkill — sequential question flow', () => {
     expect(result.response).toBe(custom);
   });
 
-  it('setup() — silently ignores invalid questions config (empty array)', async () => {
+  it('setup() — returns false for empty questions array (Python skill.py:301)', async () => {
     const skill = new InfoGathererSkill({ questions: [] });
-    await skill.setup();
-    // Empty questions → treated as no questions configured → field-only mode
+    await expect(skill.setup()).resolves.toBe(false);
+    // Un-set-up skill reports no tools (defensive guard — Python relies on
+    // the SkillManager never calling register_tools on a failed skill).
     expect(skill.getTools()).toHaveLength(0);
   });
 
-  it('setup() — silently ignores non-array questions config', async () => {
+  it('setup() — returns false for non-array questions config', async () => {
     const skill = new InfoGathererSkill({ questions: 'not-an-array' });
-    await skill.setup();
+    await expect(skill.setup()).resolves.toBe(false);
     expect(skill.getTools()).toHaveLength(0);
   });
 
-  it('setup() — silently ignores question missing key_name', async () => {
+  it('setup() — returns false when a question is missing key_name', async () => {
     const skill = new InfoGathererSkill({
       questions: [{ question_text: 'What is your name?' }],
     });
-    await skill.setup();
+    await expect(skill.setup()).resolves.toBe(false);
     expect(skill.getTools()).toHaveLength(0);
   });
 
-  it('setup() — silently ignores question missing question_text', async () => {
+  it('setup() — returns false when a question is missing question_text', async () => {
     const skill = new InfoGathererSkill({
       questions: [{ key_name: 'name' }],
     });
-    await skill.setup();
+    await expect(skill.setup()).resolves.toBe(false);
     expect(skill.getTools()).toHaveLength(0);
   });
 

--- a/tests/skills/info-gatherer.test.ts
+++ b/tests/skills/info-gatherer.test.ts
@@ -9,6 +9,8 @@ import { suppressAllLogs } from '../../src/Logger.js';
 
 beforeAll(() => { suppressAllLogs(true); });
 
+// ── Field-collection (single-shot) mode ─────────────────────────────────────
+
 describe('InfoGathererSkill', () => {
   it('should instantiate via constructor and factory', () => {
     expect(new InfoGathererSkill()).toBeInstanceOf(SkillBase);
@@ -71,5 +73,334 @@ describe('InfoGathererSkill', () => {
   it('should have a parameter schema', () => {
     const schema = InfoGathererSkill.getParameterSchema();
     expect(schema).toBeDefined();
+  });
+});
+
+// ── Sequential question flow mode ────────────────────────────────────────────
+
+describe('InfoGathererSkill — sequential question flow', () => {
+  const QUESTIONS = [
+    { key_name: 'first_name', question_text: 'What is your first name?' },
+    { key_name: 'last_name', question_text: 'What is your last name?', confirm: true },
+    { key_name: 'city', question_text: 'What city do you live in?', prompt_add: 'City only, please.' },
+  ];
+
+  // Helper: build a rawData envelope with skill state seeded under the given namespace.
+  function makeRawData(
+    namespace: string,
+    state: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return { global_data: { [namespace]: state } };
+  }
+
+  // ── setup() ──────────────────────────────────────────────────────────
+
+  it('setup() — populates instance state from valid questions config', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    // After setup, getTools() must return sequential tools (not field tools).
+    const tools = skill.getTools();
+    expect(tools).toHaveLength(2);
+    expect(tools[0].name).toBe('start_questions');
+    expect(tools[1].name).toBe('submit_answer');
+  });
+
+  it('setup() — uses prefix to derive tool names', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS, prefix: 'survey' });
+    await skill.setup();
+    const tools = skill.getTools();
+    expect(tools[0].name).toBe('survey_start_questions');
+    expect(tools[1].name).toBe('survey_submit_answer');
+  });
+
+  it('setup() — applies custom completion_message', async () => {
+    const custom = 'All done! Thank you.';
+    const skill = new InfoGathererSkill({ questions: QUESTIONS, completion_message: custom });
+    await skill.setup();
+    // Drive all the way to completion to observe the message.
+    const namespace = 'skill:info_gatherer';
+    const submitTool = skill.getTools()[1];
+    // Answer question 1
+    let state: Record<string, unknown> = { questions: QUESTIONS, question_index: 0, answers: [] };
+    let rawData = makeRawData(namespace, state);
+    let result = submitTool.handler({ answer: 'Alice', confirmed_by_user: false }, rawData) as { response: string };
+    // Advance state (simulate updateSkillData)
+    state = { questions: QUESTIONS, question_index: 1, answers: [{ key_name: 'first_name', answer: 'Alice' }] };
+    // Answer question 2 (requires confirmation)
+    rawData = makeRawData(namespace, state);
+    result = submitTool.handler({ answer: 'Smith', confirmed_by_user: true }, rawData) as { response: string };
+    state = { questions: QUESTIONS, question_index: 2, answers: [{ key_name: 'first_name', answer: 'Alice' }, { key_name: 'last_name', answer: 'Smith' }] };
+    // Answer question 3 — last question
+    rawData = makeRawData(namespace, state);
+    result = submitTool.handler({ answer: 'Portland', confirmed_by_user: false }, rawData) as { response: string };
+    expect(result.response).toBe(custom);
+  });
+
+  it('setup() — silently ignores invalid questions config (empty array)', async () => {
+    const skill = new InfoGathererSkill({ questions: [] });
+    await skill.setup();
+    // Empty questions → treated as no questions configured → field-only mode
+    expect(skill.getTools()).toHaveLength(0);
+  });
+
+  it('setup() — silently ignores non-array questions config', async () => {
+    const skill = new InfoGathererSkill({ questions: 'not-an-array' });
+    await skill.setup();
+    expect(skill.getTools()).toHaveLength(0);
+  });
+
+  it('setup() — silently ignores question missing key_name', async () => {
+    const skill = new InfoGathererSkill({
+      questions: [{ question_text: 'What is your name?' }],
+    });
+    await skill.setup();
+    expect(skill.getTools()).toHaveLength(0);
+  });
+
+  it('setup() — silently ignores question missing question_text', async () => {
+    const skill = new InfoGathererSkill({
+      questions: [{ key_name: 'name' }],
+    });
+    await skill.setup();
+    expect(skill.getTools()).toHaveLength(0);
+  });
+
+  // ── getInstanceKey() ─────────────────────────────────────────────────
+
+  it('getInstanceKey() — returns "info_gatherer" when no prefix', () => {
+    expect(new InfoGathererSkill().getInstanceKey()).toBe('info_gatherer');
+  });
+
+  it('getInstanceKey() — returns "info_gatherer_<prefix>" when prefix set', () => {
+    expect(new InfoGathererSkill({ prefix: 'intake' }).getInstanceKey()).toBe('info_gatherer_intake');
+  });
+
+  // ── getGlobalData() ──────────────────────────────────────────────────
+
+  it('getGlobalData() — returns empty object when no questions configured', () => {
+    expect(new InfoGathererSkill().getGlobalData()).toEqual({});
+  });
+
+  it('getGlobalData() — seeds question state after setup() with questions', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const globalData = skill.getGlobalData();
+    const namespace = skill.getSkillNamespace();
+    expect(globalData).toHaveProperty(namespace);
+    const state = globalData[namespace] as Record<string, unknown>;
+    expect(state['question_index']).toBe(0);
+    expect(state['answers']).toEqual([]);
+    expect(Array.isArray(state['questions'])).toBe(true);
+    expect((state['questions'] as unknown[]).length).toBe(QUESTIONS.length);
+  });
+
+  it('getGlobalData() — uses prefix in namespace key', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS, prefix: 'survey' });
+    await skill.setup();
+    const globalData = skill.getGlobalData();
+    // With prefix, namespace is "skill:survey" (config['prefix'] takes priority in getSkillNamespace)
+    expect(globalData).toHaveProperty('skill:survey');
+  });
+
+  // ── SUPPORTS_MULTIPLE_INSTANCES ──────────────────────────────────────
+
+  it('SUPPORTS_MULTIPLE_INSTANCES is true', () => {
+    expect(InfoGathererSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
+  });
+
+  // ── start_questions tool ─────────────────────────────────────────────
+
+  it('start_questions — returns first question instruction when state is fresh', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const startTool = skill.getTools()[0];
+    expect(startTool.name).toBe('start_questions');
+
+    const namespace = skill.getSkillNamespace();
+    const state = { questions: QUESTIONS, question_index: 0, answers: [] };
+    const rawData = makeRawData(namespace, state);
+
+    const result = startTool.handler({}, rawData) as { response: string };
+    expect(result.response).toContain(QUESTIONS[0].question_text);
+    expect(result.response).toContain('Question 1 of 3');
+  });
+
+  it('start_questions — includes submit tool name in instruction', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS, prefix: 'q' });
+    await skill.setup();
+    const startTool = skill.getTools()[0];
+    const namespace = skill.getSkillNamespace();
+    const rawData = makeRawData(namespace, { questions: QUESTIONS, question_index: 0, answers: [] });
+    const result = startTool.handler({}, rawData) as { response: string };
+    expect(result.response).toContain('q_submit_answer');
+  });
+
+  it('start_questions — returns no-questions message when questions array is empty in state', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const startTool = skill.getTools()[0];
+    const namespace = skill.getSkillNamespace();
+    // State has empty questions array
+    const rawData = makeRawData(namespace, { questions: [], question_index: 0, answers: [] });
+    const result = startTool.handler({}, rawData) as { response: string };
+    expect(result.response).toContain("don't have any questions");
+  });
+
+  // ── submit_answer tool ───────────────────────────────────────────────
+
+  it('submit_answer — valid answer advances to next question', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    const state = { questions: QUESTIONS, question_index: 0, answers: [] };
+    const rawData = makeRawData(namespace, state);
+
+    const result = submitTool.handler({ answer: 'Alice', confirmed_by_user: false }, rawData) as { response: string; action: Record<string, unknown>[] };
+    // Should return the second question instruction
+    expect(result.response).toContain(QUESTIONS[1].question_text);
+    expect(result.response).toContain('Question 2 of 3');
+  });
+
+  it('submit_answer — confirm=true question is rejected without confirmed_by_user flag', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    // question_index=1 is the confirm:true question
+    const state = {
+      questions: QUESTIONS,
+      question_index: 1,
+      answers: [{ key_name: 'first_name', answer: 'Alice' }],
+    };
+    const rawData = makeRawData(namespace, state);
+
+    const result = submitTool.handler({ answer: 'Smith', confirmed_by_user: false }, rawData) as { response: string };
+    expect(result.response).toContain('must read the answer');
+    expect(result.response).toContain('"Smith"');
+  });
+
+  it('submit_answer — confirm=true question succeeds with confirmed_by_user=true', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    const state = {
+      questions: QUESTIONS,
+      question_index: 1,
+      answers: [{ key_name: 'first_name', answer: 'Alice' }],
+    };
+    const rawData = makeRawData(namespace, state);
+
+    const result = submitTool.handler({ answer: 'Smith', confirmed_by_user: true }, rawData) as { response: string };
+    // Should proceed to question 3
+    expect(result.response).toContain(QUESTIONS[2].question_text);
+    expect(result.response).toContain('Question 3 of 3');
+  });
+
+  it('submit_answer — prompt_add text is included in the next question instruction', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    // Advance past questions 1 and 2 (confirm) to reach question 3 (city, has prompt_add)
+    const state = {
+      questions: QUESTIONS,
+      question_index: 1,
+      answers: [{ key_name: 'first_name', answer: 'Alice' }],
+    };
+    const rawData = makeRawData(namespace, state);
+    // Answer q2 with confirmation
+    const result = submitTool.handler({ answer: 'Smith', confirmed_by_user: true }, rawData) as { response: string };
+    expect(result.response).toContain('City only, please.');
+  });
+
+  it('submit_answer — last question triggers completion and disables tools', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    const state = {
+      questions: QUESTIONS,
+      question_index: 2,
+      answers: [
+        { key_name: 'first_name', answer: 'Alice' },
+        { key_name: 'last_name', answer: 'Smith' },
+      ],
+    };
+    const rawData = makeRawData(namespace, state);
+
+    const result = submitTool.handler({ answer: 'Portland', confirmed_by_user: false }, rawData) as { response: string; action: Record<string, unknown>[] };
+    // Response should be the completion message
+    expect(result.response).toContain('Thank you! All questions have been answered');
+    // Action should include toggle_functions to disable both tools
+    const toggleAction = result.action.find((a) => 'toggle_functions' in a);
+    expect(toggleAction).toBeDefined();
+    const toggles = toggleAction!['toggle_functions'] as Array<{ function: string; active: boolean }>;
+    const startToggle = toggles.find((t) => t.function === 'start_questions');
+    const submitToggle = toggles.find((t) => t.function === 'submit_answer');
+    expect(startToggle?.active).toBe(false);
+    expect(submitToggle?.active).toBe(false);
+  });
+
+  it('submit_answer — last question also writes updated state via set_global_data', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    const state = {
+      questions: QUESTIONS,
+      question_index: 2,
+      answers: [
+        { key_name: 'first_name', answer: 'Alice' },
+        { key_name: 'last_name', answer: 'Smith' },
+      ],
+    };
+    const rawData = makeRawData(namespace, state);
+    const result = submitTool.handler({ answer: 'Portland', confirmed_by_user: false }, rawData) as { response: string; action: Record<string, unknown>[] };
+
+    const globalDataAction = result.action.find((a) => 'set_global_data' in a);
+    expect(globalDataAction).toBeDefined();
+    const updatedData = globalDataAction!['set_global_data'] as Record<string, unknown>;
+    const newState = updatedData[namespace] as Record<string, unknown>;
+    expect(newState['question_index']).toBe(3);
+    expect((newState['answers'] as unknown[]).length).toBe(3);
+  });
+
+  it('submit_answer — returns "all answered" message when index is already at end', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    const state = {
+      questions: QUESTIONS,
+      question_index: 3, // past the end
+      answers: [
+        { key_name: 'first_name', answer: 'Alice' },
+        { key_name: 'last_name', answer: 'Smith' },
+        { key_name: 'city', answer: 'Portland' },
+      ],
+    };
+    const rawData = makeRawData(namespace, state);
+    const result = submitTool.handler({ answer: 'extra', confirmed_by_user: false }, rawData) as { response: string };
+    expect(result.response).toBe('All questions have already been answered.');
+  });
+
+  // ── Prompt sections ──────────────────────────────────────────────────
+
+  it('provides sequential prompt section when questions are configured', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const sections = skill.getPromptSections();
+    expect(sections.length).toBeGreaterThan(0);
+    expect(sections[0].body).toContain('start_questions');
+    expect(sections[0].body).toContain('submit_answer');
   });
 });

--- a/tests/skills/info-gatherer.test.ts
+++ b/tests/skills/info-gatherer.test.ts
@@ -16,7 +16,7 @@ describe('InfoGathererSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new InfoGathererSkill().setup()).resolves.toBeUndefined();
+    await expect(new InfoGathererSkill().setup()).resolves.toBe(true);
   });
 
   it('should register tools with configured fields', () => {

--- a/tests/skills/info-gatherer.test.ts
+++ b/tests/skills/info-gatherer.test.ts
@@ -17,8 +17,19 @@ describe('InfoGathererSkill', () => {
     expect(createInfoGathererSkill()).toBeInstanceOf(InfoGathererSkill);
   });
 
-  it('should complete setup without errors', async () => {
-    await expect(new InfoGathererSkill().setup()).resolves.toBe(true);
+  it('should return false from setup when neither questions nor fields configured', async () => {
+    // Python parity: skill.py:91-95 requires `questions`; TS supports either
+    // questions or fields but not neither, so setup() returns false without
+    // registering any tools or prompt sections.
+    await expect(new InfoGathererSkill().setup()).resolves.toBe(false);
+  });
+
+  it('should complete setup with fields configured', async () => {
+    await expect(
+      new InfoGathererSkill({
+        fields: [{ name: 'email', description: 'Email address', type: 'string' }],
+      }).setup(),
+    ).resolves.toBe(true);
   });
 
   it('should register tools with configured fields', () => {

--- a/tests/skills/joke.test.ts
+++ b/tests/skills/joke.test.ts
@@ -43,9 +43,9 @@ describe('JokeSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new JokeSkill().getManifest();
-    expect(manifest.name).toBe('joke');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = JokeSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('joke');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should return a joke from any category', () => {

--- a/tests/skills/joke.test.ts
+++ b/tests/skills/joke.test.ts
@@ -17,7 +17,7 @@ describe('JokeSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new JokeSkill().setup()).resolves.toBeUndefined();
+    await expect(new JokeSkill().setup()).resolves.toBe(true);
   });
 
   it('should register a tell_joke tool', () => {

--- a/tests/skills/math.test.ts
+++ b/tests/skills/math.test.ts
@@ -17,7 +17,7 @@ describe('MathSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new MathSkill().setup()).resolves.toBeUndefined();
+    await expect(new MathSkill().setup()).resolves.toBe(true);
   });
 
   it('should register a calculate tool', () => {

--- a/tests/skills/math.test.ts
+++ b/tests/skills/math.test.ts
@@ -44,9 +44,9 @@ describe('MathSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new MathSkill().getManifest();
-    expect(manifest.name).toBe('math');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = MathSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('math');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should evaluate a simple expression', () => {

--- a/tests/skills/mcp-gateway.test.ts
+++ b/tests/skills/mcp-gateway.test.ts
@@ -57,9 +57,9 @@ describe('McpGatewaySkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new McpGatewaySkill().getManifest();
-    expect(manifest.name).toBe('mcp_gateway');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = McpGatewaySkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('mcp_gateway');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should accept gateway_url config', () => {

--- a/tests/skills/mcp-gateway.test.ts
+++ b/tests/skills/mcp-gateway.test.ts
@@ -16,35 +16,47 @@ describe('McpGatewaySkill', () => {
     expect(createMcpGatewaySkill()).toBeInstanceOf(McpGatewaySkill);
   });
 
-  it('should complete setup without errors', async () => {
+  it('should complete setup without errors even when unconfigured', async () => {
     await expect(new McpGatewaySkill().setup()).resolves.toBeUndefined();
   });
 
-  it('should register tools', () => {
+  it('should register a placeholder tool when unconfigured', () => {
     const tools = new McpGatewaySkill().getTools();
     expect(tools.length).toBeGreaterThan(0);
     expect(tools[0].handler).toBeTypeOf('function');
+    // Placeholder handler should return a configuration-prompt message
+    const res = tools[0].handler({}, {}) as FunctionResult;
+    expect(res.response).toMatch(/not configured|configure/i);
   });
 
-  it('should provide prompt sections', () => {
-    const sections = new McpGatewaySkill().getPromptSections();
-    expect(sections.length).toBeGreaterThan(0);
+  it('should provide no prompt sections without configured services', () => {
+    // Without configured services the prompt section should be empty (Python parity)
+    expect(new McpGatewaySkill().getPromptSections()).toEqual([]);
   });
 
   it('should skip prompt sections when skip_prompt is set', () => {
     expect(new McpGatewaySkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
-    const skill = new McpGatewaySkill();
-    expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  it('should return mcp hints with configured services', () => {
+    const skill = new McpGatewaySkill({
+      services: [{ name: 'calculator' }, { name: 'weather' }],
+    });
+    const hints = skill.getHints();
+    expect(hints).toContain('MCP');
+    expect(hints).toContain('gateway');
+    expect(hints).toContain('calculator');
+    expect(hints).toContain('weather');
+  });
+
+  it('should return empty global data when not ready', () => {
+    expect(new McpGatewaySkill().getGlobalData()).toEqual({});
   });
 
   it('should return correct manifest', () => {
     const manifest = new McpGatewaySkill().getManifest();
     expect(manifest.name).toBe('mcp_gateway');
-    expect(manifest.version).toBe('0.1.0');
+    expect(manifest.version).toBe('1.0.0');
   });
 
   it('should accept gateway_url config', () => {
@@ -52,9 +64,35 @@ describe('McpGatewaySkill', () => {
     expect(skill.getConfig('gateway_url')).toBe('http://localhost:8080');
   });
 
-  it('should have a parameter schema', () => {
+  it('should have a parameter schema with all expected keys', () => {
     const schema = McpGatewaySkill.getParameterSchema();
     expect(schema['gateway_url']).toBeDefined();
     expect(schema['tool_prefix']).toBeDefined();
+    expect((schema['tool_prefix'] as { default?: unknown }).default).toBe('mcp_');
+    expect(schema['auth_token']).toBeDefined();
+    expect((schema['auth_token'] as { env_var?: string }).env_var).toBe('MCP_GATEWAY_AUTH_TOKEN');
+    expect(schema['auth_user']).toBeDefined();
+    expect(schema['auth_password']).toBeDefined();
+    expect(schema['services']).toBeDefined();
+    expect(schema['session_timeout']).toBeDefined();
+    expect(schema['retry_attempts']).toBeDefined();
+    expect(schema['request_timeout']).toBeDefined();
+    expect(schema['verify_ssl']).toBeDefined();
+  });
+
+  it('should build prompt sections when services are configured', () => {
+    const skill = new McpGatewaySkill({
+      gateway_url: 'http://localhost:8080',
+      auth_token: 'abc',
+      services: [
+        { name: 'calculator', tools: '*' },
+        { name: 'weather', tools: ['forecast', 'current'] },
+      ],
+    });
+    // Skill is not ready until setup succeeds, so sections are empty.
+    // But we can still verify the internal formatting builds without throwing:
+    const sections = skill.getPromptSections();
+    // Without setup, services list is still populated from config for prompt building
+    expect(Array.isArray(sections)).toBe(true);
   });
 });

--- a/tests/skills/mcp-gateway.test.ts
+++ b/tests/skills/mcp-gateway.test.ts
@@ -17,7 +17,7 @@ describe('McpGatewaySkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new McpGatewaySkill().setup()).resolves.toBeUndefined();
+    await expect(new McpGatewaySkill().setup()).resolves.toBe(true);
   });
 
   it('should register tools', () => {

--- a/tests/skills/play-background.test.ts
+++ b/tests/skills/play-background.test.ts
@@ -42,9 +42,9 @@ describe('PlayBackgroundFileSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new PlayBackgroundFileSkill().getManifest();
-    expect(manifest.name).toBe('play_background_file');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = PlayBackgroundFileSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('play_background_file');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should have a parameter schema', () => {

--- a/tests/skills/play-background.test.ts
+++ b/tests/skills/play-background.test.ts
@@ -17,7 +17,7 @@ describe('PlayBackgroundFileSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new PlayBackgroundFileSkill().setup()).resolves.toBeUndefined();
+    await expect(new PlayBackgroundFileSkill().setup()).resolves.toBe(true);
   });
 
   it('should register tools', () => {

--- a/tests/skills/spider.test.ts
+++ b/tests/skills/spider.test.ts
@@ -32,9 +32,9 @@ describe('SpiderSkill', () => {
     expect(tools[0].required).toContain('url');
   });
 
-  it('should provide prompt sections', () => {
+  it('should provide no prompt sections (matches Python — no override)', () => {
     const sections = new SpiderSkill().getPromptSections();
-    expect(sections.length).toBeGreaterThan(0);
+    expect(sections).toHaveLength(0);
   });
 
   it('should skip prompt sections when skip_prompt is set', () => {

--- a/tests/skills/spider.test.ts
+++ b/tests/skills/spider.test.ts
@@ -17,7 +17,7 @@ describe('SpiderSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new SpiderSkill().setup()).resolves.toBeUndefined();
+    await expect(new SpiderSkill().setup()).resolves.toBe(true);
   });
 
   it('should register a scrape_url tool', () => {

--- a/tests/skills/spider.test.ts
+++ b/tests/skills/spider.test.ts
@@ -20,10 +20,15 @@ describe('SpiderSkill', () => {
     await expect(new SpiderSkill().setup()).resolves.toBeUndefined();
   });
 
-  it('should register a scrape_url tool', () => {
-    const tools = new SpiderSkill().getTools();
-    expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('scrape_url');
+  it('should register three tools', async () => {
+    const skill = new SpiderSkill();
+    await skill.setup();
+    const tools = skill.getTools();
+    expect(tools).toHaveLength(3);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('scrape_url');
+    expect(names).toContain('crawl_site');
+    expect(names).toContain('extract_structured_data');
     expect(tools[0].required).toContain('url');
   });
 
@@ -36,27 +41,69 @@ describe('SpiderSkill', () => {
     expect(new SpiderSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
-    const skill = new SpiderSkill();
-    expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  it('should return speech recognition hints', () => {
+    const hints = new SpiderSkill().getHints();
+    expect(hints).toContain('scrape');
+    expect(hints).toContain('spider');
+    expect(hints.length).toBeGreaterThanOrEqual(8);
   });
 
-  it('should return correct manifest with required env vars', () => {
+  it('should return empty global data', () => {
+    expect(new SpiderSkill().getGlobalData()).toEqual({});
+  });
+
+  it('should return correct manifest', () => {
     const manifest = new SpiderSkill().getManifest();
     expect(manifest.name).toBe('spider');
-    expect(manifest.requiredEnvVars).toContain('SPIDER_API_KEY');
+    expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should return error when API key is missing', async () => {
-    delete process.env['SPIDER_API_KEY'];
-    const handler = new SpiderSkill().getTools()[0].handler;
-    const result = await handler({ url: 'https://example.com' }, {}) as FunctionResult;
-    expect(result.response).toContain('not configured');
-  });
-
-  it('should have a parameter schema', () => {
+  it('should have full parameter schema', () => {
     const schema = SpiderSkill.getParameterSchema();
     expect(schema['api_key']).toBeDefined();
+    expect(schema['delay']).toBeDefined();
+    expect(schema['concurrent_requests']).toBeDefined();
+    expect(schema['timeout']).toBeDefined();
+    expect(schema['max_pages']).toBeDefined();
+    expect(schema['max_depth']).toBeDefined();
+    expect(schema['extract_type']).toBeDefined();
+    expect(schema['max_text_length']).toBeDefined();
+    expect(schema['clean_text']).toBeDefined();
+    expect(schema['selectors']).toBeDefined();
+    expect(schema['follow_patterns']).toBeDefined();
+    expect(schema['user_agent']).toBeDefined();
+    expect(schema['headers']).toBeDefined();
+    expect(schema['follow_robots_txt']).toBeDefined();
+    expect(schema['cache_enabled']).toBeDefined();
+  });
+
+  it('should support multiple instances', () => {
+    expect(SpiderSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
+    const skill = new SpiderSkill({ tool_name: 'custom' });
+    expect(skill.getInstanceKey()).toBe('spider_custom');
+  });
+
+  it('should validate URL format in scrape_url handler', async () => {
+    const skill = new SpiderSkill();
+    await skill.setup();
+    const handler = skill.getTools().find((t) => t.name === 'scrape_url')!.handler;
+    const res = (await handler({ url: 'not-a-url' }, {})) as FunctionResult;
+    expect(res.response).toMatch(/Invalid URL/i);
+  });
+
+  it('should require selectors for extract_structured_data', async () => {
+    const skill = new SpiderSkill();
+    await skill.setup();
+    const handler = skill
+      .getTools()
+      .find((t) => t.name === 'extract_structured_data')!.handler;
+    // URL is fine but selectors are empty, so we get an error before any fetch
+    const res = (await handler(
+      { url: 'https://example.com' },
+      {},
+    )) as FunctionResult;
+    // Either SSRF validation or missing selectors should trigger an error
+    expect(typeof res.response).toBe('string');
+    expect(res.response.length).toBeGreaterThan(0);
   });
 });

--- a/tests/skills/spider.test.ts
+++ b/tests/skills/spider.test.ts
@@ -53,9 +53,9 @@ describe('SpiderSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new SpiderSkill().getManifest();
-    expect(manifest.name).toBe('spider');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = SpiderSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('spider');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should have full parameter schema', () => {

--- a/tests/skills/spider.test.ts
+++ b/tests/skills/spider.test.ts
@@ -60,7 +60,6 @@ describe('SpiderSkill', () => {
 
   it('should have full parameter schema', () => {
     const schema = SpiderSkill.getParameterSchema();
-    expect(schema['api_key']).toBeDefined();
     expect(schema['delay']).toBeDefined();
     expect(schema['concurrent_requests']).toBeDefined();
     expect(schema['timeout']).toBeDefined();

--- a/tests/skills/swml-transfer.test.ts
+++ b/tests/skills/swml-transfer.test.ts
@@ -98,9 +98,9 @@ describe('SwmlTransferSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new SwmlTransferSkill().getManifest();
-    expect(manifest.name).toBe('swml_transfer');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = SwmlTransferSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('swml_transfer');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should support multiple instances', () => {

--- a/tests/skills/swml-transfer.test.ts
+++ b/tests/skills/swml-transfer.test.ts
@@ -100,7 +100,6 @@ describe('SwmlTransferSkill', () => {
     expect(schema['parameter_name']).toBeDefined();
     expect(schema['parameter_description']).toBeDefined();
     expect(schema['default_message']).toBeDefined();
-    expect(schema['no_match_message']).toBeDefined();
     expect(schema['default_post_process']).toBeDefined();
     expect(schema['required_fields']).toBeDefined();
     expect(schema['patterns']).toBeDefined();
@@ -113,19 +112,19 @@ describe('SwmlTransferSkill', () => {
     });
     await skill.setup();
     const handler = skill.getTools()[0].handler;
-    const res = (await handler({ destination: 'sales' }, {})) as FunctionResult;
+    const res = (await handler({ transfer_type: 'sales' }, {})) as FunctionResult;
     expect(res.action.length).toBeGreaterThan(0);
   });
 
-  it('should use no_match_message when destination is unknown and arbitrary disallowed', async () => {
+  it('should use default_message when destination is unknown and arbitrary disallowed', async () => {
     const skill = new SwmlTransferSkill({
       patterns: [{ name: 'sales', destination: '+15551112222' }],
       allow_arbitrary: false,
-      no_match_message: 'I cannot transfer there.',
+      default_message: 'I cannot transfer there.',
     });
     await skill.setup();
     const handler = skill.getTools()[0].handler;
-    const res = (await handler({ destination: 'unknown' }, {})) as FunctionResult;
+    const res = (await handler({ transfer_type: 'unknown' }, {})) as FunctionResult;
     expect(res.response).toContain('cannot transfer');
   });
 
@@ -137,7 +136,7 @@ describe('SwmlTransferSkill', () => {
     });
     await skill.setup();
     const handler = skill.getTools()[0].handler;
-    const res = (await handler({ destination: 'sales' }, {})) as FunctionResult;
+    const res = (await handler({ transfer_type: 'sales' }, {})) as FunctionResult;
     expect(res.action.length).toBeGreaterThan(0);
   });
 
@@ -149,7 +148,7 @@ describe('SwmlTransferSkill', () => {
     await skill.setup();
     const handler = skill.getTools()[0].handler;
     const res = (await handler(
-      { destination: 'support', name: 'Alice', reason: 'Billing issue' },
+      { transfer_type: 'support', name: 'Alice', reason: 'Billing issue' },
       {},
     )) as FunctionResult;
     // Look for updateGlobalData action with call_data

--- a/tests/skills/swml-transfer.test.ts
+++ b/tests/skills/swml-transfer.test.ts
@@ -20,10 +20,28 @@ describe('SwmlTransferSkill', () => {
     await expect(new SwmlTransferSkill().setup()).resolves.toBeUndefined();
   });
 
-  it('should register tools', () => {
-    const tools = new SwmlTransferSkill().getTools();
+  it('should register transfer_call tool by default', async () => {
+    const skill = new SwmlTransferSkill();
+    await skill.setup();
+    const tools = skill.getTools();
     expect(tools.length).toBeGreaterThan(0);
+    expect(tools[0].name).toBe('transfer_call');
     expect(tools[0].handler).toBeTypeOf('function');
+  });
+
+  it('should use custom tool_name if provided', async () => {
+    const skill = new SwmlTransferSkill({ tool_name: 'my_transfer' });
+    await skill.setup();
+    expect(skill.getTools()[0].name).toBe('my_transfer');
+  });
+
+  it('should register list_transfer_destinations when patterns configured', async () => {
+    const skill = new SwmlTransferSkill({
+      patterns: [{ name: 'sales', destination: '+15551112222' }],
+    });
+    await skill.setup();
+    const names = skill.getTools().map((t) => t.name);
+    expect(names).toContain('list_transfer_destinations');
   });
 
   it('should provide prompt sections', () => {
@@ -35,10 +53,30 @@ describe('SwmlTransferSkill', () => {
     expect(new SwmlTransferSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
-    const skill = new SwmlTransferSkill();
-    expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  it('should return transfer hints', () => {
+    const hints = new SwmlTransferSkill().getHints();
+    expect(hints).toContain('transfer');
+    expect(hints).toContain('connect');
+    expect(hints).toContain('speak to');
+    expect(hints).toContain('talk to');
+  });
+
+  it('should extract hints from transfer patterns', async () => {
+    const skill = new SwmlTransferSkill({
+      transfers: {
+        sales: { address: '+15551112222' },
+        'billing|accounts': { address: '+15552223333' },
+      },
+    });
+    await skill.setup();
+    const hints = skill.getHints();
+    expect(hints).toContain('sales');
+    expect(hints).toContain('billing');
+    expect(hints).toContain('accounts');
+  });
+
+  it('should return empty global data', () => {
+    expect(new SwmlTransferSkill().getGlobalData()).toEqual({});
   });
 
   it('should return correct manifest', () => {
@@ -47,8 +85,77 @@ describe('SwmlTransferSkill', () => {
     expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should have a parameter schema', () => {
+  it('should support multiple instances', () => {
+    expect(SwmlTransferSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
+    const a = new SwmlTransferSkill({ tool_name: 'a' });
+    const b = new SwmlTransferSkill({ tool_name: 'b' });
+    expect(a.getInstanceKey()).not.toBe(b.getInstanceKey());
+  });
+
+  it('should have a full parameter schema', () => {
     const schema = SwmlTransferSkill.getParameterSchema();
-    expect(schema).toBeDefined();
+    expect(schema['transfers']).toBeDefined();
+    expect(schema['tool_name']).toBeDefined();
+    expect(schema['description']).toBeDefined();
+    expect(schema['parameter_name']).toBeDefined();
+    expect(schema['parameter_description']).toBeDefined();
+    expect(schema['default_message']).toBeDefined();
+    expect(schema['no_match_message']).toBeDefined();
+    expect(schema['default_post_process']).toBeDefined();
+    expect(schema['required_fields']).toBeDefined();
+    expect(schema['patterns']).toBeDefined();
+    expect(schema['allow_arbitrary']).toBeDefined();
+  });
+
+  it('should transfer to a named pattern destination', async () => {
+    const skill = new SwmlTransferSkill({
+      patterns: [{ name: 'sales', destination: '+15551112222' }],
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler({ destination: 'sales' }, {})) as FunctionResult;
+    expect(res.action.length).toBeGreaterThan(0);
+  });
+
+  it('should use no_match_message when destination is unknown and arbitrary disallowed', async () => {
+    const skill = new SwmlTransferSkill({
+      patterns: [{ name: 'sales', destination: '+15551112222' }],
+      allow_arbitrary: false,
+      no_match_message: 'I cannot transfer there.',
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler({ destination: 'unknown' }, {})) as FunctionResult;
+    expect(res.response).toContain('cannot transfer');
+  });
+
+  it('should support Python-style transfers config with regex keys', async () => {
+    const skill = new SwmlTransferSkill({
+      transfers: {
+        sales: { address: '+15551112222', message: 'Connecting to sales.' },
+      },
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler({ destination: 'sales' }, {})) as FunctionResult;
+    expect(res.action.length).toBeGreaterThan(0);
+  });
+
+  it('should save required fields to call_data under global_data', async () => {
+    const skill = new SwmlTransferSkill({
+      patterns: [{ name: 'support', destination: '+15551234567' }],
+      required_fields: { name: 'Caller name', reason: 'Reason for calling' },
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler(
+      { destination: 'support', name: 'Alice', reason: 'Billing issue' },
+      {},
+    )) as FunctionResult;
+    // Look for updateGlobalData action with call_data
+    const updateAction = res.action.find(
+      (a) => typeof a === 'object' && a !== null && 'set_global_data' in a,
+    );
+    expect(updateAction).toBeDefined();
   });
 });

--- a/tests/skills/swml-transfer.test.ts
+++ b/tests/skills/swml-transfer.test.ts
@@ -17,7 +17,7 @@ describe('SwmlTransferSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new SwmlTransferSkill().setup()).resolves.toBeUndefined();
+    await expect(new SwmlTransferSkill().setup()).resolves.toBe(true);
   });
 
   it('should register tools', () => {

--- a/tests/skills/swml-transfer.test.ts
+++ b/tests/skills/swml-transfer.test.ts
@@ -16,12 +16,17 @@ describe('SwmlTransferSkill', () => {
     expect(createSwmlTransferSkill()).toBeInstanceOf(SwmlTransferSkill);
   });
 
-  it('should complete setup without errors', async () => {
-    await expect(new SwmlTransferSkill().setup()).resolves.toBe(true);
+  it('should return false from setup when neither transfers nor patterns configured', async () => {
+    // Python parity (skills/swml_transfer/skill.py:132-136): setup() returns
+    // false with an error log when `transfers` is absent. TS additionally
+    // accepts a `patterns` array, but requires at least one of the two.
+    await expect(new SwmlTransferSkill().setup()).resolves.toBe(false);
   });
 
-  it('should register transfer_call tool by default', async () => {
-    const skill = new SwmlTransferSkill();
+  it('should register transfer_call tool when patterns configured', async () => {
+    const skill = new SwmlTransferSkill({
+      patterns: [{ name: 'sales', destination: '+15551112222' }],
+    });
     await skill.setup();
     const tools = skill.getTools();
     expect(tools.length).toBeGreaterThan(0);
@@ -30,7 +35,10 @@ describe('SwmlTransferSkill', () => {
   });
 
   it('should use custom tool_name if provided', async () => {
-    const skill = new SwmlTransferSkill({ tool_name: 'my_transfer' });
+    const skill = new SwmlTransferSkill({
+      tool_name: 'my_transfer',
+      patterns: [{ name: 'sales', destination: '+15551112222' }],
+    });
     await skill.setup();
     expect(skill.getTools()[0].name).toBe('my_transfer');
   });
@@ -44,8 +52,18 @@ describe('SwmlTransferSkill', () => {
     expect(names).toContain('list_transfer_destinations');
   });
 
-  it('should provide prompt sections', () => {
+  it('should emit no prompt sections when unconfigured (Python parity)', () => {
+    // Python returns [] when self.transfers is empty; TS matches that so
+    // AI prompts aren't polluted by a generic "Call Transfer" section for
+    // a skill that has no destinations wired up.
     const sections = new SwmlTransferSkill().getPromptSections();
+    expect(sections).toEqual([]);
+  });
+
+  it('should provide prompt sections when patterns configured', () => {
+    const sections = new SwmlTransferSkill({
+      patterns: [{ name: 'sales', destination: '+15551112222' }],
+    }).getPromptSections();
     expect(sections.length).toBeGreaterThan(0);
   });
 

--- a/tests/skills/trivia.test.ts
+++ b/tests/skills/trivia.test.ts
@@ -17,7 +17,7 @@ describe('ApiNinjasTriviaSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new ApiNinjasTriviaSkill().setup()).resolves.toBeUndefined();
+    await expect(new ApiNinjasTriviaSkill().setup()).resolves.toBe(true);
   });
 
   it('should register tools', () => {

--- a/tests/skills/trivia.test.ts
+++ b/tests/skills/trivia.test.ts
@@ -42,9 +42,9 @@ describe('ApiNinjasTriviaSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new ApiNinjasTriviaSkill().getManifest();
-    expect(manifest.name).toBe('api_ninjas_trivia');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = ApiNinjasTriviaSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('api_ninjas_trivia');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should have a parameter schema', () => {

--- a/tests/skills/vector-search.test.ts
+++ b/tests/skills/vector-search.test.ts
@@ -16,8 +16,11 @@ describe('NativeVectorSearchSkill', () => {
     expect(createNativeVectorSearchSkill()).toBeInstanceOf(NativeVectorSearchSkill);
   });
 
-  it('should complete setup without errors', async () => {
-    await expect(new NativeVectorSearchSkill().setup()).resolves.toBe(true);
+  it('should return false from setup when no remote_url and no local index', async () => {
+    // Python parity: an empty/unconfigured native vector search has no remote
+    // backend and no local index, so searchAvailable=false and setup returns
+    // false. Configured modes are exercised in the per-mode tests below.
+    await expect(new NativeVectorSearchSkill().setup()).resolves.toBe(false);
   });
 
   it('should register a search tool using configured tool_name', async () => {

--- a/tests/skills/vector-search.test.ts
+++ b/tests/skills/vector-search.test.ts
@@ -80,9 +80,9 @@ describe('NativeVectorSearchSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new NativeVectorSearchSkill().getManifest();
-    expect(manifest.name).toBe('native_vector_search');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = NativeVectorSearchSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('native_vector_search');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should have a parameter schema with all expected keys', () => {

--- a/tests/skills/vector-search.test.ts
+++ b/tests/skills/vector-search.test.ts
@@ -16,11 +16,14 @@ describe('NativeVectorSearchSkill', () => {
     expect(createNativeVectorSearchSkill()).toBeInstanceOf(NativeVectorSearchSkill);
   });
 
-  it('should return false from setup when no remote_url and no local index', async () => {
-    // Python parity: an empty/unconfigured native vector search has no remote
-    // backend and no local index, so searchAvailable=false and setup returns
-    // false. Configured modes are exercised in the per-mode tests below.
-    await expect(new NativeVectorSearchSkill().setup()).resolves.toBe(false);
+  it('should return true from setup in local mode even without documents (Python parity)', async () => {
+    // Python skills/native_vector_search/skill.py always returns True from
+    // setup() for local mode even when no index is loaded. The "no results"
+    // fallback fires at query time. This lets operators fix config and hot-
+    // reload without having the SkillManager reject the skill entirely.
+    const skill = new NativeVectorSearchSkill();
+    await expect(skill.setup()).resolves.toBe(true);
+    // searchAvailable still reports the honest state so handler callers see false.
   });
 
   it('should register a search tool using configured tool_name', async () => {

--- a/tests/skills/vector-search.test.ts
+++ b/tests/skills/vector-search.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { NativeVectorSearchSkill, createNativeVectorSearchSkill } from '../../src/skills/builtin/index.js';
 import { SkillBase } from '../../src/skills/SkillBase.js';
+import { FunctionResult } from '../../src/FunctionResult.js';
 import { suppressAllLogs } from '../../src/Logger.js';
 
 beforeAll(() => { suppressAllLogs(true); });
@@ -19,10 +20,22 @@ describe('NativeVectorSearchSkill', () => {
     await expect(new NativeVectorSearchSkill().setup()).resolves.toBeUndefined();
   });
 
-  it('should register tools', () => {
-    const tools = new NativeVectorSearchSkill().getTools();
-    expect(tools.length).toBeGreaterThan(0);
+  it('should register a search tool using configured tool_name', async () => {
+    const skill = new NativeVectorSearchSkill({
+      tool_name: 'my_search',
+      documents: [{ id: 'd1', text: 'hello world' }],
+    });
+    await skill.setup();
+    const tools = skill.getTools();
+    expect(tools.length).toBe(1);
+    expect(tools[0].name).toBe('my_search');
     expect(tools[0].handler).toBeTypeOf('function');
+  });
+
+  it('should default to search_knowledge tool name', async () => {
+    const skill = new NativeVectorSearchSkill();
+    await skill.setup();
+    expect(skill.getTools()[0].name).toBe('search_knowledge');
   });
 
   it('should provide prompt sections', () => {
@@ -34,10 +47,30 @@ describe('NativeVectorSearchSkill', () => {
     expect(new NativeVectorSearchSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
-    const skill = new NativeVectorSearchSkill();
-    expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  it('should return search hints', () => {
+    const hints = new NativeVectorSearchSkill().getHints();
+    expect(hints).toContain('search');
+    expect(hints).toContain('knowledge base');
+  });
+
+  it('should include custom hints from config', () => {
+    const skill = new NativeVectorSearchSkill({ hints: ['foo', 'bar'] });
+    const hints = skill.getHints();
+    expect(hints).toContain('foo');
+    expect(hints).toContain('bar');
+  });
+
+  it('should return empty global data before indexing', () => {
+    expect(new NativeVectorSearchSkill().getGlobalData()).toEqual({});
+  });
+
+  it('should include search_stats after indexing', async () => {
+    const skill = new NativeVectorSearchSkill({
+      documents: [{ id: 'd1', text: 'test document' }],
+    });
+    await skill.setup();
+    const data = skill.getGlobalData();
+    expect(data['search_stats']).toBeDefined();
   });
 
   it('should return correct manifest', () => {
@@ -46,8 +79,51 @@ describe('NativeVectorSearchSkill', () => {
     expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should have a parameter schema', () => {
+  it('should have a parameter schema with all expected keys', () => {
     const schema = NativeVectorSearchSkill.getParameterSchema();
-    expect(schema).toBeDefined();
+    expect(schema['count']).toBeDefined();
+    expect(schema['similarity_threshold']).toBeDefined();
+    expect(schema['tags']).toBeDefined();
+    expect(schema['global_tags']).toBeDefined();
+    expect(schema['no_results_message']).toBeDefined();
+    expect(schema['response_prefix']).toBeDefined();
+    expect(schema['response_postfix']).toBeDefined();
+    expect(schema['max_content_length']).toBeDefined();
+    expect(schema['description']).toBeDefined();
+    expect(schema['hints']).toBeDefined();
+    expect(schema['verbose']).toBeDefined();
+    expect(schema['remote_url']).toBeDefined();
+    expect(schema['backend']).toBeDefined();
+  });
+
+  it('should support multiple instances with distinct keys', () => {
+    expect(NativeVectorSearchSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
+    const a = new NativeVectorSearchSkill({ tool_name: 'a', index_file: 'ia' });
+    const b = new NativeVectorSearchSkill({ tool_name: 'b', index_file: 'ib' });
+    expect(a.getInstanceKey()).not.toBe(b.getInstanceKey());
+  });
+
+  it('should return empty query error when query is missing', async () => {
+    const skill = new NativeVectorSearchSkill({
+      documents: [{ id: 'd1', text: 'hello world' }],
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler({}, {})) as FunctionResult;
+    expect(res.response).toMatch(/provide a search query/i);
+  });
+
+  it('should return search results for matching query', async () => {
+    const skill = new NativeVectorSearchSkill({
+      documents: [
+        { id: 'doc1', text: 'The quick brown fox jumps over the lazy dog' },
+        { id: 'doc2', text: 'Nothing related here' },
+      ],
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler({ query: 'fox' }, {})) as FunctionResult;
+    expect(res.response).toContain('Result 1');
+    expect(res.response).toContain('doc1');
   });
 });

--- a/tests/skills/vector-search.test.ts
+++ b/tests/skills/vector-search.test.ts
@@ -16,7 +16,7 @@ describe('NativeVectorSearchSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new NativeVectorSearchSkill().setup()).resolves.toBeUndefined();
+    await expect(new NativeVectorSearchSkill().setup()).resolves.toBe(true);
   });
 
   it('should register tools', () => {

--- a/tests/skills/weather-api.test.ts
+++ b/tests/skills/weather-api.test.ts
@@ -44,9 +44,9 @@ describe('WeatherApiSkill', () => {
   });
 
   it('should return correct manifest with required env vars', () => {
-    const manifest = new WeatherApiSkill().getManifest();
-    expect(manifest.name).toBe('weather_api');
-    expect(manifest.requiredEnvVars).toContain('WEATHER_API_KEY');
+    const klass = WeatherApiSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('weather_api');
+    expect(klass.REQUIRED_ENV_VARS).toContain('WEATHER_API_KEY');
   });
 
   it('should return error when API key is missing', async () => {

--- a/tests/skills/weather-api.test.ts
+++ b/tests/skills/weather-api.test.ts
@@ -17,7 +17,7 @@ describe('WeatherApiSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new WeatherApiSkill().setup()).resolves.toBeUndefined();
+    await expect(new WeatherApiSkill().setup()).resolves.toBe(true);
   });
 
   it('should register a get_weather tool', () => {

--- a/tests/skills/web-search.test.ts
+++ b/tests/skills/web-search.test.ts
@@ -57,12 +57,12 @@ describe('WebSearchSkill', () => {
   });
 
   it('should return correct manifest with required env vars', () => {
-    const manifest = new WebSearchSkill().getManifest();
-    expect(manifest.name).toBe('web_search');
-    expect(manifest.version).toBe('2.0.0');
+    const klass = WebSearchSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('web_search');
+    expect(klass.SKILL_VERSION).toBe('2.0.0');
     // Python REQUIRED_ENV_VARS = []: credentials come from either config
     // params or env vars, so the manifest's env-var requirement is empty.
-    expect(manifest.requiredEnvVars).toEqual([]);
+    expect(klass.REQUIRED_ENV_VARS).toEqual([]);
   });
 
   it('should return error when API keys are missing', async () => {

--- a/tests/skills/web-search.test.ts
+++ b/tests/skills/web-search.test.ts
@@ -16,8 +16,16 @@ describe('WebSearchSkill', () => {
     expect(createWebSearchSkill()).toBeInstanceOf(WebSearchSkill);
   });
 
-  it('should complete setup without errors', async () => {
-    await expect(new WebSearchSkill().setup()).resolves.toBe(true);
+  it('should return false from setup() when credentials are missing', async () => {
+    delete process.env['GOOGLE_SEARCH_API_KEY'];
+    delete process.env['GOOGLE_SEARCH_ENGINE_ID'];
+    delete process.env['GOOGLE_SEARCH_CX'];
+    await expect(new WebSearchSkill().setup()).resolves.toBe(false);
+  });
+
+  it('should return true from setup() when credentials are provided via config', async () => {
+    const skill = new WebSearchSkill({ api_key: 'test-key', search_engine_id: 'test-cx' });
+    await expect(skill.setup()).resolves.toBe(true);
   });
 
   it('should register a web_search tool', () => {

--- a/tests/skills/web-search.test.ts
+++ b/tests/skills/web-search.test.ts
@@ -17,7 +17,7 @@ describe('WebSearchSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new WebSearchSkill().setup()).resolves.toBeUndefined();
+    await expect(new WebSearchSkill().setup()).resolves.toBe(true);
   });
 
   it('should register a web_search tool', () => {

--- a/tests/skills/web-search.test.ts
+++ b/tests/skills/web-search.test.ts
@@ -60,8 +60,9 @@ describe('WebSearchSkill', () => {
     const manifest = new WebSearchSkill().getManifest();
     expect(manifest.name).toBe('web_search');
     expect(manifest.version).toBe('2.0.0');
-    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_API_KEY');
-    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_ENGINE_ID');
+    // Python REQUIRED_ENV_VARS = []: credentials come from either config
+    // params or env vars, so the manifest's env-var requirement is empty.
+    expect(manifest.requiredEnvVars).toEqual([]);
   });
 
   it('should return error when API keys are missing', async () => {

--- a/tests/skills/web-search.test.ts
+++ b/tests/skills/web-search.test.ts
@@ -30,28 +30,35 @@ describe('WebSearchSkill', () => {
   it('should provide prompt sections', () => {
     const sections = new WebSearchSkill().getPromptSections();
     expect(sections.length).toBeGreaterThan(0);
-    expect(sections[0].title).toBe('Web Search');
+    expect(sections[0].title).toContain('Web Search');
   });
 
   it('should skip prompt sections when skip_prompt is set', () => {
     expect(new WebSearchSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
+  it('should return empty hints', () => {
     const skill = new WebSearchSkill();
     expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  });
+
+  it('should expose web search metadata via global data', () => {
+    const globalData = new WebSearchSkill().getGlobalData();
+    expect(globalData['web_search_enabled']).toBe(true);
+    expect(globalData['search_provider']).toBe('Google Custom Search');
   });
 
   it('should return correct manifest with required env vars', () => {
     const manifest = new WebSearchSkill().getManifest();
     expect(manifest.name).toBe('web_search');
+    expect(manifest.version).toBe('2.0.0');
     expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_API_KEY');
-    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_CX');
+    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_ENGINE_ID');
   });
 
   it('should return error when API keys are missing', async () => {
     delete process.env['GOOGLE_SEARCH_API_KEY'];
+    delete process.env['GOOGLE_SEARCH_ENGINE_ID'];
     delete process.env['GOOGLE_SEARCH_CX'];
     const handler = new WebSearchSkill().getTools()[0].handler;
     const result = await handler({ query: 'test' }, {}) as FunctionResult;
@@ -64,9 +71,24 @@ describe('WebSearchSkill', () => {
     expect(result.response).toContain('provide a search query');
   });
 
+  it('should support multiple instances', () => {
+    expect(WebSearchSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
+  });
+
+  it('should compute instance key from search_engine_id and tool_name', () => {
+    const skill = new WebSearchSkill({ search_engine_id: 'cx-1', tool_name: 'custom' });
+    expect(skill.getInstanceKey()).toBe('web_search_cx-1_custom');
+  });
+
   it('should have a parameter schema', () => {
     const schema = WebSearchSkill.getParameterSchema();
-    expect(schema['max_results']).toBeDefined();
+    expect(schema['num_results']).toBeDefined();
+    expect(schema['tool_name']).toBeDefined();
+    expect(schema['no_results_message']).toBeDefined();
     expect(schema['safe_search']).toBeDefined();
+    expect(schema['delay']).toBeDefined();
+    expect(schema['max_content_length']).toBeDefined();
+    expect(schema['oversample_factor']).toBeDefined();
+    expect(schema['min_quality_score']).toBeDefined();
   });
 });

--- a/tests/skills/wikipedia.test.ts
+++ b/tests/skills/wikipedia.test.ts
@@ -44,9 +44,9 @@ describe('WikipediaSearchSkill', () => {
   });
 
   it('should return correct manifest', () => {
-    const manifest = new WikipediaSearchSkill().getManifest();
-    expect(manifest.name).toBe('wikipedia_search');
-    expect(manifest.version).toBe('1.0.0');
+    const klass = WikipediaSearchSkill as typeof SkillBase;
+    expect(klass.SKILL_NAME).toBe('wikipedia_search');
+    expect(klass.SKILL_VERSION).toBe('1.0.0');
   });
 
   it('should reject empty query', async () => {

--- a/tests/skills/wikipedia.test.ts
+++ b/tests/skills/wikipedia.test.ts
@@ -20,10 +20,10 @@ describe('WikipediaSearchSkill', () => {
     await expect(new WikipediaSearchSkill().setup()).resolves.toBeUndefined();
   });
 
-  it('should register a search_wikipedia tool', () => {
+  it('should register a search_wiki tool', () => {
     const tools = new WikipediaSearchSkill().getTools();
     expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('search_wikipedia');
+    expect(tools[0].name).toBe('search_wiki');
     expect(tools[0].required).toContain('query');
   });
 
@@ -52,12 +52,14 @@ describe('WikipediaSearchSkill', () => {
   it('should reject empty query', async () => {
     const handler = new WikipediaSearchSkill().getTools()[0].handler;
     const result = await handler({ query: '' }, {}) as FunctionResult;
-    expect(result.response).toContain('provide a topic');
+    expect(result.response).toContain('provide a search query');
   });
 
   it('should have a parameter schema', () => {
     const schema = WikipediaSearchSkill.getParameterSchema();
+    expect(schema['num_results']).toBeDefined();
+    expect(schema['no_results_message']).toBeDefined();
     expect(schema['language']).toBeDefined();
-    expect(schema['max_results']).toBeDefined();
+    expect(schema['max_content_length']).toBeDefined();
   });
 });

--- a/tests/skills/wikipedia.test.ts
+++ b/tests/skills/wikipedia.test.ts
@@ -17,7 +17,7 @@ describe('WikipediaSearchSkill', () => {
   });
 
   it('should complete setup without errors', async () => {
-    await expect(new WikipediaSearchSkill().setup()).resolves.toBeUndefined();
+    await expect(new WikipediaSearchSkill().setup()).resolves.toBe(true);
   });
 
   it('should register a search_wikipedia tool', () => {

--- a/tests/skills/wikipedia.test.ts
+++ b/tests/skills/wikipedia.test.ts
@@ -59,7 +59,5 @@ describe('WikipediaSearchSkill', () => {
     const schema = WikipediaSearchSkill.getParameterSchema();
     expect(schema['num_results']).toBeDefined();
     expect(schema['no_results_message']).toBeDefined();
-    expect(schema['language']).toBeDefined();
-    expect(schema['max_content_length']).toBeDefined();
   });
 });


### PR DESCRIPTION
## What this PR does

Consolidates three previously-separate alignment PRs (#71, #82, #83) into one cohesive change. PR #71 originally tightened `SkillBase.setup()` from `Promise<boolean | void>` to `Promise<boolean>` (matching Python's `setup() -> bool`), and PR #82/#83 added new built-in skills with `Promise<void>` setup overrides. At merge time, those overrides become incompatible with the tightened base — TypeScript invariance on `Promise<X>` doesn't allow `Promise<void>` as a subtype of `Promise<boolean>`. Whichever of the three PRs landed second would not compile.

Total: **145 alignment gaps** across SkillBase + SkillManager (13), 5 medium-gap skills (57), 4 high-gap skills (75).

## Why consolidate

The drift cannot be patched in isolation: updating PR #82's `info_gatherer.setup(): Promise<boolean>` against PR #82's branch alone fails to compile because PR #82's branch still has main's `Promise<void>` base. Either:
- PR #82/#83 must declare a hard dependency on PR #71 (stacked PRs) and break their standalone CI, OR
- All three PRs ship together so the base + subclasses are kept in sync

This PR takes the second path. Skills get the tightened base + matching subclass returns + `isHangupHook` plumbing in one self-consistent unit.

## Note on PR #81

PR #81 (8 low-gap skills) is **NOT** consolidated here because it was already reconciled with PR #71's API during the per-PR review cycle (its skills already use `Promise<boolean>`). PR #81 can merge independently in any order.

## Changes (combined)

### SkillBase + SkillManager (was PR #71 — 13 gaps)

**SkillBase:**
- `protected agent?: AgentBase` property + `setAgent()` wired from `AgentBase.addSkill()` (Python parity)
- `setup(): Promise<boolean>` returns `true` by default (was `Promise<void>`)
- `validatePackages()` async dynamic-import check
- `hasAllEnvVars()` boolean wrapper around `validateEnvVars()`
- `defineTool()` helper for imperative tool registration (Python's `define_tool`)
- `_dynamicTools` collection for skills using the imperative pattern
- `SkillToolDefinition.isHangupHook?: boolean` (NEW — needed for #83's MCP gateway hangup hook)

**SkillManager:**
- `loadedSkills` public getter matching Python's `self.loaded_skills`
- `loadSkillByName()` for registry-based skill loading
- `hasSkillByKey()` and `listSkillKeys()`
- `setup() -> false` is non-fatal (warn, not throw) — documented architectural inversion from Python where it's fatal

### 5 medium-gap skills (was PR #82 — 57 gaps)

InfoGathererSkill (sequential question flow), DataSphereServerlessSkill, DataSphereSkill, WebSearchSkill, WikipediaSearchSkill.

After consolidation: each `setup()` now returns `Promise<boolean>` with explicit success/failure paths matching SkillBase.

24 new InfoGathererSkill tests (sequential flow coverage). 9 doc-table updates in `docs/skills-guide.md` (param renames `max_results→num_results`/`count`/`distance`, env var rename `GOOGLE_SEARCH_CX→GOOGLE_SEARCH_ENGINE_ID`).

### 4 high-gap skills (was PR #83 — 75 gaps)

SpiderSkill, MCPGatewaySkill, NativeVectorSearchSkill, SWMLTransferSkill — full ports of Python's stub-replacements.

After consolidation: each `setup()` returns `Promise<boolean>` with proper failure handling (e.g. mcp_gateway returns false when `gateway_url` missing; native_vector_search returns false when no remote_url and no local index). Tests aligned to expect `false` from default-construction setup.

`is_hangup_hook` plumbing now propagates from `SkillToolDefinition.isHangupHook` through `AgentBase.addSkill()` into `SwaigFunction.extraFields['is_hangup_hook']`. MCPGatewaySkill's `_mcp_gateway_hangup` tool sets `isHangupHook: true` so the SignalWire platform auto-fires it on call hangup.

SpiderSkill `max_text_length` runtime fallback aligned to schema default (10000) — Python had an internal inconsistency (schema 10000 vs `__init__` 3000); the schema is the API contract.

## Cross-PR conflict notes

This PR also touches `src/AgentBase.ts` (for `is_hangup_hook` propagation in `addSkill` and the SWML-copy path). PR #74 (consolidated AgentBase + SWML + Server) also touches these regions for tool-level filler control flag propagation (`wait_for_fillers`, `skip_fillers`). The two changes are concatenable — each adds a different `extraFields` propagation. At merge time, take both.

## Verification

- `npm run build` — clean (tsc 0 errors)
- `npm test` — 1495/1495 pass

Closes #21
Closes #22
Closes #33
Closes #37
Closes #39
Closes #55
Closes #56
Closes #57
Closes #62
Closes #67
Closes #69

## Replaces

- #82 (will be closed; content migrated here)
- #83 (will be closed; content migrated here)