### PR TITLE
Align Relay layer with Python SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "signalwire-agents",
-  "version": "0.1.0",
+  "name": "@signalwire/sdk",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "signalwire-agents",
-      "version": "0.1.0",
+      "name": "@signalwire/sdk",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.11.0",

--- a/relay/examples/relay-inbound.ts
+++ b/relay/examples/relay-inbound.ts
@@ -5,7 +5,7 @@
  *
  * Required env vars:
  *   SIGNALWIRE_PROJECT_ID - Your SignalWire project ID
- *   SIGNALWIRE_TOKEN      - Your SignalWire API token
+ *   SIGNALWIRE_API_TOKEN   - Your SignalWire API token
  *   SIGNALWIRE_SPACE      - Your SignalWire space (e.g. example.signalwire.com)
  *
  * Usage:

--- a/relay/examples/relay-messaging.ts
+++ b/relay/examples/relay-messaging.ts
@@ -5,7 +5,7 @@
  *
  * Required env vars:
  *   SIGNALWIRE_PROJECT_ID - Your SignalWire project ID
- *   SIGNALWIRE_TOKEN      - Your SignalWire API token
+ *   SIGNALWIRE_API_TOKEN   - Your SignalWire API token
  *   SIGNALWIRE_SPACE      - Your SignalWire space (e.g. example.signalwire.com)
  *   MSG_TO                - Destination number in E.164 format
  *   MSG_FROM              - Sender number in E.164 format (must be owned by your project)
@@ -41,8 +41,8 @@ async function sendAndWait() {
   // Send outbound SMS
   console.log(`Sending SMS to ${to}...`);
   const message = await client.sendMessage({
-    to,
-    from,
+    toNumber: to,
+    fromNumber: from,
     body: 'Hello from SignalWire RELAY TypeScript SDK!',
   });
   console.log(`Message queued: id=${message.messageId}`);

--- a/relay/examples/relay-outbound.ts
+++ b/relay/examples/relay-outbound.ts
@@ -5,7 +5,7 @@
  *
  * Required env vars:
  *   SIGNALWIRE_PROJECT_ID - Your SignalWire project ID
- *   SIGNALWIRE_TOKEN      - Your SignalWire API token
+ *   SIGNALWIRE_API_TOKEN   - Your SignalWire API token
  *   SIGNALWIRE_SPACE      - Your SignalWire space (e.g. example.signalwire.com)
  *   DIAL_TO               - Destination number in E.164 format
  *   DIAL_FROM             - Caller ID number in E.164 format

--- a/src/livewire/index.ts
+++ b/src/livewire/index.ts
@@ -376,18 +376,27 @@ export class JobProcess {
 }
 
 // ---------------------------------------------------------------------------
+// Room
+// ---------------------------------------------------------------------------
+
+/** Stub -- SignalWire doesn't use the LiveKit room abstraction. */
+export class Room {
+  readonly name: string = 'livewire-room';
+}
+
+// ---------------------------------------------------------------------------
 // JobContext
 // ---------------------------------------------------------------------------
 
 /** Mirrors a LiveKit JobContext -- provides room and connection info. */
 export class JobContext {
-  room: any;
+  room: Room;
   proc: JobProcess;
   /** @internal */
   _swAgent?: AgentBase;
 
   constructor() {
-    this.room = { name: 'livewire-room' };
+    this.room = new Room();
     this.proc = new JobProcess();
   }
 

--- a/src/relay/RelayClient.ts
+++ b/src/relay/RelayClient.ts
@@ -47,6 +47,10 @@ import { Message } from './Message.js';
 import { RelayError } from './RelayError.js';
 import type { CallHandler, MessageHandler, RelayClientOptions } from './types.js';
 
+// Polyfill Symbol.asyncDispose for runtimes that don't have it yet (Node <20.4)
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+(Symbol as any).asyncDispose ??= Symbol.for('Symbol.asyncDispose');
+
 const logger = getLogger('relay_client');
 
 // Any 2xx code is considered success
@@ -109,8 +113,8 @@ export class RelayClient {
 
   constructor(options: RelayClientOptions = {}) {
     this.project = options.project ?? process.env.SIGNALWIRE_PROJECT_ID ?? '';
-    this.token = options.token ?? process.env.SIGNALWIRE_TOKEN ?? '';
-    this.jwtToken = process.env.SIGNALWIRE_JWT_TOKEN ?? '';
+    this.token = options.token ?? process.env.SIGNALWIRE_API_TOKEN ?? '';
+    this.jwtToken = options.jwtToken ?? process.env.SIGNALWIRE_JWT_TOKEN ?? '';
     this.host = options.host ?? process.env.SIGNALWIRE_SPACE ?? DEFAULT_RELAY_HOST;
     this.contexts = options.contexts ?? [];
 
@@ -119,7 +123,7 @@ export class RelayClient {
     } else if (!this.project || !this.token) {
       throw new Error(
         'project and token are required (or provide jwt_token). ' +
-        'Pass them directly or set SIGNALWIRE_PROJECT_ID / SIGNALWIRE_TOKEN env vars.',
+        'Pass them directly or set SIGNALWIRE_PROJECT_ID / SIGNALWIRE_API_TOKEN env vars.',
       );
     }
 
@@ -127,22 +131,54 @@ export class RelayClient {
     if (/[@/?#\r\n ]/.test(this.host)) {
       throw new Error(`Invalid host: ${this.host}. Must be a hostname, not a URL.`);
     }
+
+    // Max concurrent calls (constructor > env var > default)
+    if (options.maxActiveCalls != null) {
+      this._maxActiveCalls = Math.max(1, options.maxActiveCalls);
+    } else {
+      const envVal = process.env.RELAY_MAX_ACTIVE_CALLS ?? '';
+      const parsed = parseInt(envVal, 10);
+      this._maxActiveCalls = envVal && !isNaN(parsed) ? Math.max(1, parsed) : DEFAULT_MAX_ACTIVE_CALLS;
+    }
   }
 
   get relayProtocol(): string {
     return this._relayProtocol;
   }
 
-  // ─── Handler Registration ──────────────────────────────────────
-
-  /** Register the inbound call handler. */
-  onCall(handler: CallHandler): void {
-    this._onCallHandler = handler;
+  /**
+   * Async disposable support — equivalent to Python's `__aexit__`.
+   *
+   * Enables usage with `await using`:
+   * ```ts
+   * await using client = new RelayClient({ ... });
+   * await client.connect();
+   * // ... automatically disconnects when scope exits
+   * ```
+   *
+   * For environments without `await using`, use try/finally:
+   * ```ts
+   * const client = new RelayClient({ ... });
+   * try { await client.connect(); ... }
+   * finally { await client.disconnect(); }
+   * ```
+   */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.disconnect();
   }
 
-  /** Register the inbound message handler. */
-  onMessage(handler: MessageHandler): void {
+  // ─── Handler Registration ──────────────────────────────────────
+
+  /** Register the inbound call handler. Returns the handler to support decorator usage. */
+  onCall(handler: CallHandler): CallHandler {
+    this._onCallHandler = handler;
+    return handler;
+  }
+
+  /** Register the inbound message handler. Returns the handler to support decorator usage. */
+  onMessage(handler: MessageHandler): MessageHandler {
     this._onMessageHandler = handler;
+    return handler;
   }
 
   // ─── Connection Lifecycle ──────────────────────────────────────
@@ -268,7 +304,7 @@ export class RelayClient {
     // Cancel queued requests
     for (const { deferred } of this._executeQueue) {
       if (!deferred.settled) {
-        deferred.reject(new RelayError('Connection closed'));
+        deferred.reject(new RelayError(-1, 'Connection closed'));
         deferred.promise.catch(() => {});
       }
     }
@@ -277,7 +313,7 @@ export class RelayClient {
     // Cancel pending dials
     for (const deferred of Array.from(this._pendingDials.values())) {
       if (!deferred.settled) {
-        deferred.reject(new RelayError('Connection closed during dial'));
+        deferred.reject(new RelayError(-1, 'Connection closed during dial'));
         deferred.promise.catch(() => {});
       }
     }
@@ -294,12 +330,20 @@ export class RelayClient {
     return this._sendRequest(method, params);
   }
 
-  /** Initiate an outbound call. Returns a Call when answered. */
+  /**
+   * Initiate an outbound call. Returns a Call when answered.
+   *
+   * @param devices - Array of device lists (serial/parallel dial).
+   * @param options.tag - Client-provided tag for event correlation. Auto-generated if not supplied.
+   * @param options.maxDuration - Optional max call duration in minutes.
+   * @param options.dialTimeout - How long (seconds) to wait for the dial to complete. Defaults to 120.
+   */
   async dial(
     devices: Record<string, unknown>[][],
     options: {
       tag?: string;
       maxDuration?: number;
+      /** Dial timeout in seconds (default 120). */
       dialTimeout?: number;
     } = {},
   ): Promise<Call> {
@@ -318,11 +362,12 @@ export class RelayClient {
     try {
       await this.execute('calling.dial', params);
 
-      const timeout = options.dialTimeout ?? 120_000;
+      const timeoutSec = options.dialTimeout ?? 120;
+      const timeoutMs = timeoutSec * 1000;
       const call = await new Promise<Call>((resolve, reject) => {
         const timer = setTimeout(() => {
-          reject(new RelayError(`Dial timed out waiting for answer (tag=${dialTag})`));
-        }, timeout);
+          reject(new RelayError(-1, `Dial timed out waiting for answer (tag=${dialTag})`));
+        }, timeoutMs);
         dialDeferred.promise.then(
           (v) => { clearTimeout(timer); resolve(v); },
           (e) => { clearTimeout(timer); reject(e); },
@@ -341,10 +386,21 @@ export class RelayClient {
     }
   }
 
-  /** Send an outbound SMS/MMS message. Returns a Message. */
+  /**
+   * Send an outbound SMS/MMS message. Returns a Message.
+   *
+   * @param options.toNumber - Destination phone number in E.164 format.
+   * @param options.fromNumber - Sender phone number in E.164 format.
+   * @param options.context - Context for receiving state events. Defaults to the relay protocol.
+   * @param options.body - Text body of the message.
+   * @param options.media - List of media URLs for MMS.
+   * @param options.tags - Optional tags for the message.
+   * @param options.region - Optional origination region.
+   * @param options.onCompleted - Optional callback fired when a terminal state is reached.
+   */
   async sendMessage(options: {
-    to: string;
-    from: string;
+    toNumber: string;
+    fromNumber: string;
     context?: string;
     body?: string;
     media?: string[];
@@ -359,8 +415,8 @@ export class RelayClient {
     const msgContext = options.context ?? this._relayProtocol ?? 'default';
     const params: Record<string, unknown> = {
       context: msgContext,
-      to_number: options.to,
-      from_number: options.from,
+      to_number: options.toNumber,
+      from_number: options.fromNumber,
     };
     if (options.body) params.body = options.body;
     if (options.media) params.media = options.media;
@@ -374,8 +430,8 @@ export class RelayClient {
       messageId,
       context: msgContext,
       direction: 'outbound',
-      fromNumber: options.from,
-      toNumber: options.to,
+      fromNumber: options.fromNumber,
+      toNumber: options.toNumber,
       body: options.body ?? '',
       media: options.media ?? [],
       tags: options.tags ?? [],
@@ -495,7 +551,7 @@ export class RelayClient {
     try {
       if (!this._ws || !this._connected) {
         if (this._executeQueue.length >= EXECUTE_QUEUE_MAX) {
-          throw new RelayError('Execute queue full — too many requests while disconnected');
+          throw new RelayError(-1, 'Execute queue full — too many requests while disconnected');
         }
         this._executeQueue.push({ message, deferred });
         logger.debug(`Request queued (not connected): ${method}`);
@@ -508,7 +564,7 @@ export class RelayClient {
       // Timeout
       return await new Promise<Record<string, unknown>>((resolve, reject) => {
         const timer = setTimeout(() => {
-          reject(new RelayError(`Request timeout for ${method}`));
+          reject(new RelayError(-1, `Request timeout for ${method}`));
           if (method !== METHOD_SIGNALWIRE_CONNECT) {
             this._forceClose();
           }
@@ -538,7 +594,7 @@ export class RelayClient {
         this._ws!.send(raw);
       } catch (err) {
         if (!deferred.settled) {
-          deferred.reject(new RelayError(`Failed to send queued request: ${err}`));
+          deferred.reject(new RelayError(-1, `Failed to send queued request: ${err}`));
           deferred.promise.catch(() => {});
         }
       }
@@ -548,7 +604,7 @@ export class RelayClient {
   private _clearPendingRequests(): void {
     for (const deferred of Array.from(this._pending.values())) {
       if (!deferred.settled) {
-        deferred.reject(new RelayError('Connection closed'));
+        deferred.reject(new RelayError(-1, 'Connection closed'));
         deferred.promise.catch(() => {});
       }
     }
@@ -557,7 +613,7 @@ export class RelayClient {
 
     for (const deferred of Array.from(this._pendingDials.values())) {
       if (!deferred.settled) {
-        deferred.reject(new RelayError('Connection closed during dial'));
+        deferred.reject(new RelayError(-1, 'Connection closed during dial'));
         deferred.promise.catch(() => {});
       }
     }
@@ -580,8 +636,8 @@ export class RelayClient {
       if (deferred && !deferred.settled) {
         const error = typeof msg.error === 'object' ? msg.error : { code: -1, message: String(msg.error) };
         deferred.reject(new RelayError(
-          String(error.message ?? 'Unknown error'),
           error.code ?? -1,
+          String(error.message ?? 'Unknown error'),
         ));
       }
       return;
@@ -608,8 +664,8 @@ export class RelayClient {
             try { intCode = parseInt(codeStr, 10); } catch { intCode = -1; }
             if (isNaN(intCode)) intCode = -1;
             deferred.reject(new RelayError(
-              String(result.message ?? 'Unknown error'),
               intCode,
+              String(result.message ?? 'Unknown error'),
             ));
           } else {
             deferred.resolve(result);
@@ -865,7 +921,7 @@ export class RelayClient {
       }
       dialDeferred.resolve(call);
     } else if (dialState === 'failed') {
-      dialDeferred.reject(new RelayError(`Dial failed (tag=${tag})`));
+      dialDeferred.reject(new RelayError(-1, `Dial failed (tag=${tag})`));
       dialDeferred.promise.catch(() => {});
     }
     // "dialing" events are progress — don't resolve

--- a/src/relay/RelayClient.ts
+++ b/src/relay/RelayClient.ts
@@ -59,6 +59,22 @@ const SUCCESS_CODE_RE = /^2\d{2}$/;
 // Safety limits
 const DEFAULT_MAX_ACTIVE_CALLS = 1000;
 
+// Max concurrent RelayClient connections per process (env: RELAY_MAX_CONNECTIONS)
+// Mirrors Python _MAX_CONNECTIONS (relay/client.py:81-88). Default 1, min 1,
+// invalid env values fall back to 1.
+function _parseMaxConnections(): number {
+  const raw = process.env.RELAY_MAX_CONNECTIONS;
+  if (raw == null || raw === '') return 1;
+  const parsed = parseInt(raw, 10);
+  if (isNaN(parsed)) return 1;
+  return Math.max(1, parsed);
+}
+const _MAX_CONNECTIONS = _parseMaxConnections();
+
+// Process-wide tracking of active RelayClient instances. Python uses id(self);
+// TS has no such helper, so we track instance refs — identity equality is fine.
+const _activeClients: Set<RelayClient> = new Set();
+
 type WsLike = {
   send(data: string): void;
   close(code?: number, reason?: string): void;
@@ -185,6 +201,23 @@ export class RelayClient {
 
   /** Connect to RELAY and authenticate. */
   async connect(): Promise<void> {
+    // Guard against connection leaks — enforce per-process limit.
+    // Don't count ourselves (allows reconnect without double-counting).
+    // Mirrors Python relay/client.py:216-228.
+    let otherCount = 0;
+    for (const c of _activeClients) {
+      if (c !== this) otherCount++;
+    }
+    if (otherCount >= _MAX_CONNECTIONS) {
+      throw new Error(
+        `RelayClient connection limit reached (${_MAX_CONNECTIONS}). ` +
+        `There are already ${otherCount} active connection(s) in this process. ` +
+        `Call disconnect() on existing clients first, or set ` +
+        `RELAY_MAX_CONNECTIONS env var to allow more.`,
+      );
+    }
+    _activeClients.add(this);
+
     const uri = `wss://${this.host}`;
     logger.info(`Connecting to ${uri}`);
 
@@ -289,6 +322,9 @@ export class RelayClient {
   async disconnect(): Promise<void> {
     this._closing = true;
     this._connected = false;
+    // Mirrors Python relay/client.py:290 — remove from per-process active set.
+    // Safe to call even if we never connected (Set.delete is idempotent).
+    _activeClients.delete(this);
     this._stopPingLoop();
     this._cancelServerPingTimeout();
 

--- a/src/relay/RelayError.ts
+++ b/src/relay/RelayError.ts
@@ -1,11 +1,13 @@
 /**
  * Custom error class for RELAY protocol errors.
+ *
+ * Mirrors the Python SDK signature: `RelayError(code, message)`.
  */
 export class RelayError extends Error {
   readonly code: number;
 
-  constructor(message: string, code = 0) {
-    super(message);
+  constructor(code: number, message: string) {
+    super(`RELAY error ${code}: ${message}`);
     this.name = 'RelayError';
     this.code = code;
   }

--- a/src/relay/RelayEvent.ts
+++ b/src/relay/RelayEvent.ts
@@ -222,10 +222,10 @@ export class CollectEvent extends RelayEvent {
     params: Record<string, any>,
     callId: string,
     timestamp: number,
-    controlId: string,
-    state: string,
-    result: Record<string, any>,
-    final_: boolean | undefined,
+    controlId: string = '',
+    state: string = '',
+    result: Record<string, any> = {},
+    final_: boolean | undefined = undefined,
   ) {
     super(eventType, params, callId, timestamp);
     this.controlId = controlId;

--- a/src/relay/RelayEvent.ts
+++ b/src/relay/RelayEvent.ts
@@ -856,9 +856,9 @@ export class MessageStateEvent extends RelayEvent {
 
 // ─── Event Class Map & Parser ────────────────────────────────────────
 
-type EventClass = { fromPayload(payload: Record<string, any>): RelayEvent };
+export type EventClass = { fromPayload(payload: Record<string, any>): RelayEvent };
 
-const EVENT_CLASS_MAP: Record<string, EventClass> = {
+export const EVENT_CLASS_MAP: Record<string, EventClass> = {
   'calling.call.state': CallStateEvent,
   'calling.call.receive': CallReceiveEvent,
   'calling.call.play': PlayEvent,

--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -55,7 +55,9 @@ export {
   MessageReceiveEvent,
   MessageStateEvent,
   parseEvent,
+  EVENT_CLASS_MAP,
 } from './RelayEvent.js';
+export type { EventClass } from './RelayEvent.js';
 
 // Deferred utility
 export { createDeferred, withTimeout } from './Deferred.js';

--- a/src/relay/types.ts
+++ b/src/relay/types.ts
@@ -10,12 +10,16 @@ import type { RelayEvent } from './RelayEvent.js';
 export interface RelayClientOptions {
   /** SignalWire project ID. Defaults to env SIGNALWIRE_PROJECT_ID. */
   project?: string;
-  /** SignalWire API token. Defaults to env SIGNALWIRE_TOKEN. */
+  /** SignalWire API token. Defaults to env SIGNALWIRE_API_TOKEN. */
   token?: string;
+  /** JWT token for authentication. Defaults to env SIGNALWIRE_JWT_TOKEN. */
+  jwtToken?: string;
   /** RELAY host. Defaults to relay.signalwire.com. */
   host?: string;
   /** Contexts (topics) to receive inbound calls/messages on. */
   contexts?: string[];
+  /** Maximum number of concurrent active calls. Defaults to env RELAY_MAX_ACTIVE_CALLS or 1000. */
+  maxActiveCalls?: number;
 }
 
 /** JSON-RPC 2.0 request. */
@@ -90,10 +94,10 @@ export interface DialOptions {
 
 /** Options for the sendMessage() method. */
 export interface SendMessageOptions {
-  /** Destination number/address. */
-  to: string;
-  /** Source number/address. */
-  from: string;
+  /** Destination phone number in E.164 format. */
+  toNumber: string;
+  /** Sender phone number in E.164 format. */
+  fromNumber: string;
   /** Message body text. */
   body?: string;
   /** Media URLs for MMS. */

--- a/tests/relay/Call.test.ts
+++ b/tests/relay/Call.test.ts
@@ -26,7 +26,7 @@ function goneClient(): RelayClientLike {
 // Mock client that throws a RelayError
 function errorClient(code: number, msg: string): RelayClientLike {
   return {
-    async execute() { throw new RelayError(msg, code); },
+    async execute() { throw new RelayError(code, msg); },
   };
 }
 

--- a/tests/relay/RelayClient.test.ts
+++ b/tests/relay/RelayClient.test.ts
@@ -614,4 +614,166 @@ describe('RelayClient', () => {
       await client.disconnect();
     });
   });
+
+  describe('jwtToken env precedence', () => {
+    let origJwt: string | undefined;
+
+    beforeEach(() => {
+      origJwt = process.env.SIGNALWIRE_JWT_TOKEN;
+    });
+    afterEach(() => {
+      if (origJwt === undefined) delete process.env.SIGNALWIRE_JWT_TOKEN;
+      else process.env.SIGNALWIRE_JWT_TOKEN = origJwt;
+    });
+
+    it('reads SIGNALWIRE_JWT_TOKEN from env when option omitted', () => {
+      process.env.SIGNALWIRE_JWT_TOKEN = 'env-jwt';
+      const client = new RelayClient({});
+      expect(client.jwtToken).toBe('env-jwt');
+    });
+
+    it('explicit jwtToken option wins over env', () => {
+      process.env.SIGNALWIRE_JWT_TOKEN = 'env-jwt';
+      const client = new RelayClient({ jwtToken: 'arg-jwt' });
+      expect(client.jwtToken).toBe('arg-jwt');
+    });
+  });
+
+  describe('maxActiveCalls env precedence', () => {
+    let origMax: string | undefined;
+
+    beforeEach(() => {
+      origMax = process.env.RELAY_MAX_ACTIVE_CALLS;
+    });
+    afterEach(() => {
+      if (origMax === undefined) delete process.env.RELAY_MAX_ACTIVE_CALLS;
+      else process.env.RELAY_MAX_ACTIVE_CALLS = origMax;
+    });
+
+    it('reads RELAY_MAX_ACTIVE_CALLS from env when option omitted', () => {
+      process.env.RELAY_MAX_ACTIVE_CALLS = '42';
+      const client = new RelayClient({ project: 'p', token: 't' });
+      expect((client as any)._maxActiveCalls).toBe(42);
+    });
+
+    it('explicit maxActiveCalls option wins over env', () => {
+      process.env.RELAY_MAX_ACTIVE_CALLS = '42';
+      const client = new RelayClient({ project: 'p', token: 't', maxActiveCalls: 7 });
+      expect((client as any)._maxActiveCalls).toBe(7);
+    });
+
+    it('invalid env value falls back to default 1000', () => {
+      process.env.RELAY_MAX_ACTIVE_CALLS = 'not-a-number';
+      const client = new RelayClient({ project: 'p', token: 't' });
+      expect((client as any)._maxActiveCalls).toBe(1000);
+    });
+
+    it('non-positive env value clamps to 1', () => {
+      process.env.RELAY_MAX_ACTIVE_CALLS = '0';
+      const client = new RelayClient({ project: 'p', token: 't' });
+      expect((client as any)._maxActiveCalls).toBe(1);
+    });
+
+    it('non-positive explicit option clamps to 1', () => {
+      const client = new RelayClient({ project: 'p', token: 't', maxActiveCalls: -5 });
+      expect((client as any)._maxActiveCalls).toBe(1);
+    });
+
+    it('defaults to 1000 when env and option are absent', () => {
+      delete process.env.RELAY_MAX_ACTIVE_CALLS;
+      const client = new RelayClient({ project: 'p', token: 't' });
+      expect((client as any)._maxActiveCalls).toBe(1000);
+    });
+  });
+
+  describe('Symbol.asyncDispose', () => {
+    it('exposes an asyncDispose method', () => {
+      const client = new RelayClient({ project: 'p', token: 't' });
+      expect(typeof (client as any)[Symbol.asyncDispose]).toBe('function');
+    });
+
+    it('invoking asyncDispose calls disconnect (removes from active set)', async () => {
+      const { client } = createClient();
+      await client.connect();
+      // Explicitly invoke the disposer
+      await (client as any)[Symbol.asyncDispose]();
+      // After disposal, a second client should be able to connect without
+      // tripping the _MAX_CONNECTIONS guard.
+      const { client: other } = createClient();
+      await expect(other.connect()).resolves.toBeUndefined();
+      await other.disconnect();
+    });
+  });
+
+  describe('_MAX_CONNECTIONS guard', () => {
+    it('rejects a second concurrent client.connect() with default limit of 1', async () => {
+      const { client: a } = createClient();
+      const { client: b } = createClient();
+      await a.connect();
+      try {
+        await expect(b.connect()).rejects.toThrow(/connection limit reached/);
+      } finally {
+        await a.disconnect();
+      }
+    });
+
+    it('reconnecting the same instance does not trip the guard', async () => {
+      const { client } = createClient();
+      await client.connect();
+      // Simulate the reconnect case — same instance reconnects after a drop.
+      // Don't disconnect() first (that would remove it from the set).
+      await expect(client.connect()).resolves.toBeUndefined();
+      await client.disconnect();
+    });
+
+    it('after disconnect, a new client can connect', async () => {
+      const { client: a } = createClient();
+      await a.connect();
+      await a.disconnect();
+      const { client: b } = createClient();
+      await expect(b.connect()).resolves.toBeUndefined();
+      await b.disconnect();
+    });
+
+    it('RELAY_MAX_CONNECTIONS env > 1 allows additional clients', async () => {
+      const origMaxConn = process.env.RELAY_MAX_CONNECTIONS;
+      process.env.RELAY_MAX_CONNECTIONS = '3';
+      // Module caches _MAX_CONNECTIONS at load time, so we re-import fresh.
+      vi.resetModules();
+      try {
+        const mod = await import('../../src/relay/RelayClient.js');
+        const { MockWebSocket: FreshMockWs } = await import('./helpers.js');
+        const freshCreate = (): { client: InstanceType<typeof mod.RelayClient>; ws: any } => {
+          const mockWs = new FreshMockWs();
+          const client = new mod.RelayClient({
+            project: 'p', token: 't', host: 'relay.test.com',
+          });
+          (client as any)._wsFactory = () => {
+            mockWs.autoAuthenticate();
+            return mockWs;
+          };
+          return { client, ws: mockWs };
+        };
+        const a = freshCreate().client;
+        const b = freshCreate().client;
+        const c = freshCreate().client;
+        await a.connect();
+        await b.connect();
+        await c.connect();
+        try {
+          // Fourth should fail
+          const d = freshCreate().client;
+          await expect(d.connect()).rejects.toThrow(/connection limit reached \(3\)/);
+        } finally {
+          await a.disconnect();
+          await b.disconnect();
+          await c.disconnect();
+        }
+      } finally {
+        if (origMaxConn === undefined) delete process.env.RELAY_MAX_CONNECTIONS;
+        else process.env.RELAY_MAX_CONNECTIONS = origMaxConn;
+        vi.resetModules();
+      }
+    });
+  });
 });

--- a/tests/relay/RelayClient.test.ts
+++ b/tests/relay/RelayClient.test.ts
@@ -30,16 +30,16 @@ describe('RelayClient', () => {
 
     it('throws if project/token missing', () => {
       const origProject = process.env.SIGNALWIRE_PROJECT_ID;
-      const origToken = process.env.SIGNALWIRE_TOKEN;
+      const origToken = process.env.SIGNALWIRE_API_TOKEN;
       const origJwt = process.env.SIGNALWIRE_JWT_TOKEN;
       delete process.env.SIGNALWIRE_PROJECT_ID;
-      delete process.env.SIGNALWIRE_TOKEN;
+      delete process.env.SIGNALWIRE_API_TOKEN;
       delete process.env.SIGNALWIRE_JWT_TOKEN;
       try {
         expect(() => new RelayClient({})).toThrow('project and token are required');
       } finally {
         if (origProject !== undefined) process.env.SIGNALWIRE_PROJECT_ID = origProject;
-        if (origToken !== undefined) process.env.SIGNALWIRE_TOKEN = origToken;
+        if (origToken !== undefined) process.env.SIGNALWIRE_API_TOKEN = origToken;
         if (origJwt !== undefined) process.env.SIGNALWIRE_JWT_TOKEN = origJwt;
       }
     });
@@ -330,8 +330,8 @@ describe('RelayClient', () => {
       await client.connect();
 
       const msgPromise = client.sendMessage({
-        to: '+222',
-        from: '+111',
+        toNumber: '+222',
+        fromNumber: '+111',
         body: 'Hello',
       });
 
@@ -357,7 +357,7 @@ describe('RelayClient', () => {
       const { client } = createClient();
       await client.connect();
 
-      await expect(client.sendMessage({ to: '+222', from: '+111' }))
+      await expect(client.sendMessage({ toNumber: '+222', fromNumber: '+111' }))
         .rejects.toThrow('At least one of body or media');
 
       await client.disconnect();
@@ -583,7 +583,7 @@ describe('RelayClient', () => {
       await client.connect();
 
       // Send a message first
-      const msgPromise = client.sendMessage({ to: '+222', from: '+111', body: 'Hi' });
+      const msgPromise = client.sendMessage({ toNumber: '+222', fromNumber: '+111', body: 'Hi' });
 
       await new Promise((r) => setTimeout(r, 10));
       const sendReq = ws.getAllSent().find((m) => m.method === 'messaging.send');


### PR DESCRIPTION
## What this PR does

Aligns the relay layer with Python — 12 gaps across RelayClient, RelayError, RelayEvent, and Room (livewire).

## Why

Users porting Python relay code to TypeScript hit multiple porting surprises: the token env var has a different name, constructor options are missing, handler methods return void instead of chainable objects, timeouts use different units, and the error constructor has swapped parameter order.

## Changes

### RelayClient (8 gaps)
- Token env var: `SIGNALWIRE_TOKEN` → `SIGNALWIRE_API_TOKEN` matching Python
- Added `jwtToken` and `maxActiveCalls` constructor options
- `onCall()`/`onMessage()` now return handler objects (not void) for chaining
- `dialTimeout` converted from milliseconds to seconds matching Python
- `sendMessage` params renamed `to`/`from` → `toNumber`/`fromNumber`
- Added `Symbol.asyncDispose` support matching Python's `__aenter__`/`__aexit__`

### RelayError (2 gaps)
- Constructor parameter order: `(code, message)` matching Python
- Error message format: `RELAY error ${code}: ${message}`

### RelayEvent (1 gap)
- Exported `EVENT_CLASS_MAP` and `EventClass` matching Python module-level exports

### Room_livewire (1 gap)
- Added `Room` class stub to livewire module matching Python

## Verification

- `npm run build` passes
- 1437/1437 tests pass

Closes #46
Closes #47
Closes #48
Closes #50

Closes #91
