### PR TITLE
Align REST + Compatibility layer with Python SDK

### DIFF
--- a/src/rest/HttpClient.ts
+++ b/src/rest/HttpClient.ts
@@ -19,7 +19,15 @@ export class HttpClient {
   private readonly _fetch: typeof globalThis.fetch;
 
   constructor(options: HttpClientOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    if (!options.host && !options.baseUrl) {
+      throw new Error('HttpClientOptions requires either "host" or "baseUrl".');
+    }
+
+    // host takes precedence (matches Python's HttpClient(project, token, host) convention
+    // where a bare hostname is expected and https:// is prepended automatically).
+    const rawUrl = options.host ? `https://${options.host}` : options.baseUrl!;
+    this.baseUrl = rawUrl.replace(/\/+$/, '');
+
     this._authHeader = 'Basic ' + Buffer.from(`${options.project}:${options.token}`).toString('base64');
     this._fetch = options.fetchImpl ?? globalThis.fetch;
   }
@@ -55,7 +63,13 @@ export class HttpClient {
 
     if (!resp.ok) {
       const text = await resp.text();
-      throw new RestError(resp.status, text, url, method);
+      let errBody: string | Record<string, unknown> = text;
+      try {
+        errBody = JSON.parse(text) as Record<string, unknown>;
+      } catch {
+        // Response was not valid JSON — keep as plain string.
+      }
+      throw new RestError(resp.status, errBody, url, method);
     }
 
     if (resp.status === 204) {

--- a/src/rest/RestError.ts
+++ b/src/rest/RestError.ts
@@ -1,14 +1,24 @@
 /**
  * Custom error class for REST API errors.
+ *
+ * `body` may be a parsed JSON object (when the server returned valid JSON)
+ * or a plain string (when JSON parsing failed), matching the Python SDK's
+ * `SignalWireRestError` behavior.
  */
 export class RestError extends Error {
   readonly statusCode: number;
-  readonly body: string;
+  readonly body: string | Record<string, unknown>;
   readonly url: string;
   readonly method: string;
 
-  constructor(statusCode: number, body: string, url: string, method: string) {
-    super(`${method} ${url} returned ${statusCode}: ${body}`);
+  constructor(
+    statusCode: number,
+    body: string | Record<string, unknown>,
+    url: string,
+    method: string = 'GET',
+  ) {
+    const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
+    super(`${method} ${url} returned ${statusCode}: ${bodyStr}`);
     this.name = 'RestError';
     this.statusCode = statusCode;
     this.body = body;
@@ -16,3 +26,6 @@ export class RestError extends Error {
     this.method = method;
   }
 }
+
+/** Alias matching the Python SDK class name. */
+export { RestError as SignalWireRestError };

--- a/src/rest/base/BaseResource.ts
+++ b/src/rest/base/BaseResource.ts
@@ -13,7 +13,7 @@ export abstract class BaseResource {
   }
 
   /** Build a sub-resource path by joining parts onto the base path. */
-  protected _path(...parts: string[]): string {
-    return [this._basePath, ...parts].join('/');
+  protected _path(...parts: (string | number)[]): string {
+    return [this._basePath, ...parts.map(String)].join('/');
   }
 }

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -165,7 +165,7 @@ export class RestClient {
 
 // Client
 export { HttpClient } from './HttpClient.js';
-export { RestError } from './RestError.js';
+export { RestError, SignalWireRestError } from './RestError.js';
 export { paginate, paginateAll } from './pagination.js';
 
 // Types

--- a/src/rest/namespaces/compat.ts
+++ b/src/rest/namespaces/compat.ts
@@ -29,7 +29,7 @@ export class CompatAccounts extends BaseResource {
     return this._http.get(this._path(sid));
   }
 
-  async update(sid: string, body: any): Promise<any> {
+  async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 }
@@ -40,7 +40,7 @@ export class CompatCalls extends CrudResource {
     super(http, basePath);
   }
 
-  override async update(sid: string, body: any): Promise<any> {
+  override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
@@ -48,7 +48,7 @@ export class CompatCalls extends CrudResource {
     return this._http.post(this._path(callSid, 'Recordings'), body);
   }
 
-  async updateRecording(callSid: string, recordingSid: string, body: any): Promise<any> {
+  async updateRecording(callSid: string, recordingSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(callSid, 'Recordings', recordingSid), body);
   }
 
@@ -67,7 +67,7 @@ export class CompatMessages extends CrudResource {
     super(http, basePath);
   }
 
-  override async update(sid: string, body: any): Promise<any> {
+  override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
@@ -90,7 +90,7 @@ export class CompatFaxes extends CrudResource {
     super(http, basePath);
   }
 
-  override async update(sid: string, body: any): Promise<any> {
+  override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
@@ -121,7 +121,7 @@ export class CompatConferences extends BaseResource {
     return this._http.get(this._path(sid));
   }
 
-  async update(sid: string, body: any): Promise<any> {
+  async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
@@ -134,7 +134,7 @@ export class CompatConferences extends BaseResource {
     return this._http.get(this._path(conferenceSid, 'Participants', callSid));
   }
 
-  async updateParticipant(conferenceSid: string, callSid: string, body: any): Promise<any> {
+  async updateParticipant(conferenceSid: string, callSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(conferenceSid, 'Participants', callSid), body);
   }
 
@@ -151,7 +151,7 @@ export class CompatConferences extends BaseResource {
     return this._http.get(this._path(conferenceSid, 'Recordings', recordingSid));
   }
 
-  async updateRecording(conferenceSid: string, recordingSid: string, body: any): Promise<any> {
+  async updateRecording(conferenceSid: string, recordingSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(conferenceSid, 'Recordings', recordingSid), body);
   }
 
@@ -190,7 +190,7 @@ export class CompatPhoneNumbers extends BaseResource {
     return this._http.get(this._path(sid));
   }
 
-  async update(sid: string, body: any): Promise<any> {
+  async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
@@ -222,7 +222,7 @@ export class CompatApplications extends CrudResource {
     super(http, basePath);
   }
 
-  override async update(sid: string, body: any): Promise<any> {
+  override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 }
@@ -233,7 +233,7 @@ export class CompatLamlBins extends CrudResource {
     super(http, basePath);
   }
 
-  override async update(sid: string, body: any): Promise<any> {
+  override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 }
@@ -244,7 +244,7 @@ export class CompatQueues extends CrudResource {
     super(http, basePath);
   }
 
-  override async update(sid: string, body: any): Promise<any> {
+  override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
@@ -309,7 +309,7 @@ export class CompatTokens extends BaseResource {
     return this._http.post(this._basePath, body);
   }
 
-  async update(tokenId: string, body: any): Promise<any> {
+  async update(tokenId: string, body: any = {}): Promise<any> {
     return this._http.patch(this._path(tokenId), body);
   }
 

--- a/src/rest/namespaces/phone-numbers.ts
+++ b/src/rest/namespaces/phone-numbers.ts
@@ -8,7 +8,18 @@ import type { HttpClient } from '../HttpClient.js';
 import type { QueryParams } from '../types.js';
 import { CrudResource } from '../base/CrudResource.js';
 
-/** Phone number management. */
+/**
+ * Phone number management.
+ *
+ * `create` and `update` accept an untyped body object (`body: any = {}`).
+ * No `PhoneNumberCreateParams` / `PhoneNumberUpdateParams` interfaces are
+ * defined because the Python reference SDK uses bare `**kwargs` with no
+ * named or typed parameters — there is no Python type contract to port.
+ * This is an intentional IDIOMATIC_DEVIATION: Python kwargs ↔ TS `any` object
+ * literal with an optional default of `{}` to preserve call-without-args
+ * semantics.  If the REST API stabilises a known field set, consider adding
+ * typed interfaces and specialising `CrudResource<>` generics here.
+ */
 export class PhoneNumbersResource extends CrudResource {
   protected override _updateMethod: 'PATCH' | 'PUT' = 'PUT';
 

--- a/src/rest/namespaces/phone-numbers.ts
+++ b/src/rest/namespaces/phone-numbers.ts
@@ -16,6 +16,16 @@ export class PhoneNumbersResource extends CrudResource {
     super(http, '/api/relay/rest/phone_numbers');
   }
 
+  /** Create a phone number resource. Body is optional to match Python **kwargs. */
+  override async create(body: any = {}): Promise<any> {
+    return this._http.post(this._basePath, body);
+  }
+
+  /** Update a phone number resource by ID. Body is optional to match Python **kwargs. */
+  override async update(resourceId: string, body: any = {}): Promise<any> {
+    return this._http.put(this._path(resourceId), body);
+  }
+
   /** Search available phone numbers for purchase. */
   async search(params?: QueryParams): Promise<any> {
     return this._http.get(this._path('search'), params);

--- a/src/rest/types.ts
+++ b/src/rest/types.ts
@@ -18,8 +18,17 @@ export interface ClientOptions {
 
 /** Options for constructing an HttpClient. */
 export interface HttpClientOptions {
-  /** Base URL (e.g. "https://example.signalwire.com"). */
-  baseUrl: string;
+  /**
+   * Base URL (e.g. "https://example.signalwire.com").
+   * Either `baseUrl` or `host` must be provided. If both are given, `host` takes precedence
+   * (matching the Python SDK convention where `host` is the canonical parameter).
+   */
+  baseUrl?: string;
+  /**
+   * Bare hostname (e.g. "example.signalwire.com"). `https://` is prepended automatically,
+   * matching the Python SDK's `HttpClient(project, token, host)` convention.
+   */
+  host?: string;
   /** Project ID for Basic Auth username. */
   project: string;
   /** API token for Basic Auth password. */

--- a/tests/rest/HttpClient.test.ts
+++ b/tests/rest/HttpClient.test.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '../../src/rest/HttpClient.js';
 import { RestError } from '../../src/rest/RestError.js';
-import { mockClientOptions } from './helpers.js';
+import { createMockFetch, mockClientOptions } from './helpers.js';
 
 describe('HttpClient', () => {
   it('sends Basic Auth header', async () => {
@@ -185,5 +185,90 @@ describe('HttpClient', () => {
 
     const reqs = getRequests();
     expect(reqs[0].url).toBe('https://other.signalwire.com/api/test?page=2');
+  });
+
+  it('accepts host option and prepends https://', async () => {
+    const [fetchImpl, getRequests] = createMockFetch([
+      { status: 200, body: { ok: true } },
+    ]);
+    const http = new HttpClient({
+      host: 'example.signalwire.com',
+      project: 'test-project',
+      token: 'test-token',
+      fetchImpl,
+    });
+
+    expect(http.baseUrl).toBe('https://example.signalwire.com');
+
+    await http.get('/api/test');
+
+    const reqs = getRequests();
+    expect(reqs[0].url).toBe('https://example.signalwire.com/api/test');
+  });
+
+  it('host takes precedence over baseUrl when both are provided', () => {
+    const [fetchImpl] = createMockFetch();
+    const http = new HttpClient({
+      host: 'from-host.signalwire.com',
+      baseUrl: 'https://from-baseurl.signalwire.com',
+      project: 'test-project',
+      token: 'test-token',
+      fetchImpl,
+    });
+
+    expect(http.baseUrl).toBe('https://from-host.signalwire.com');
+  });
+
+  it('throws when neither host nor baseUrl is provided', () => {
+    const [fetchImpl] = createMockFetch();
+    expect(() => new HttpClient({
+      project: 'test-project',
+      token: 'test-token',
+      fetchImpl,
+    })).toThrow('HttpClientOptions requires either "host" or "baseUrl".');
+  });
+
+  it('RestError body is parsed JSON object when server returns JSON error', async () => {
+    const { options } = mockClientOptions([
+      { status: 422, body: { errors: ['invalid'] } },
+    ]);
+    const http = new HttpClient(options);
+
+    try {
+      await http.post('/api/test', { bad: true });
+      throw new Error('Should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(RestError);
+      const err = e as RestError;
+      expect(typeof err.body).toBe('object');
+      expect(err.body).toEqual({ errors: ['invalid'] });
+    }
+  });
+
+  it('RestError body is plain string when server returns non-JSON error', async () => {
+    const [fetchImpl] = createMockFetch();
+    // Override the mock to return a non-JSON text body
+    const http = new HttpClient({
+      baseUrl: 'https://test.signalwire.com',
+      project: 'test-project',
+      token: 'test-token',
+      fetchImpl: async (input, init) => {
+        return new Response('Internal Server Error', {
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      },
+    });
+
+    try {
+      await http.get('/api/test');
+      throw new Error('Should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(RestError);
+      const err = e as RestError;
+      expect(typeof err.body).toBe('string');
+      expect(err.body).toBe('Internal Server Error');
+    }
   });
 });

--- a/tests/rest/RestError.test.ts
+++ b/tests/rest/RestError.test.ts
@@ -1,4 +1,4 @@
-import { RestError } from '../../src/rest/RestError.js';
+import { RestError, SignalWireRestError } from '../../src/rest/RestError.js';
 
 describe('RestError', () => {
   it('formats error message from status, body, url, method', () => {
@@ -21,5 +21,33 @@ describe('RestError', () => {
     const err = new RestError(400, 'Bad Request', '/api/test', 'PUT');
     expect(err.stack).toBeDefined();
     expect(err.stack).toContain('RestError');
+  });
+
+  it('defaults method to GET when omitted', () => {
+    const err = new RestError(500, 'Server Error', '/api/test');
+    expect(err.method).toBe('GET');
+    expect(err.message).toBe('GET /api/test returned 500: Server Error');
+  });
+
+  it('accepts an object body and stringifies it in the message', () => {
+    const bodyObj = { errors: ['invalid field'] };
+    const err = new RestError(422, bodyObj, '/api/test', 'POST');
+    expect(err.body).toEqual(bodyObj);
+    expect(typeof err.body).toBe('object');
+    expect(err.message).toBe('POST /api/test returned 422: {"errors":["invalid field"]}');
+  });
+
+  it('preserves string body as-is', () => {
+    const err = new RestError(400, 'Bad Request', '/api/test', 'POST');
+    expect(err.body).toBe('Bad Request');
+    expect(typeof err.body).toBe('string');
+  });
+
+  it('SignalWireRestError is the same class as RestError', () => {
+    expect(SignalWireRestError).toBe(RestError);
+    const err = new SignalWireRestError(404, 'Not Found', '/api/test');
+    expect(err).toBeInstanceOf(RestError);
+    expect(err).toBeInstanceOf(SignalWireRestError);
+    expect(err.name).toBe('RestError');
   });
 });


### PR DESCRIPTION
## What this PR does

Aligns the REST and Compat layers with Python — 23 gaps across 7 interfaces.

## Why

The compat layer wraps the REST API for Twilio-style compatibility. Python's `**kwargs` pattern makes body parameters optional by default, but TypeScript required callers to pass explicit `{}` — a porting friction. Additionally, HttpClient lacked Python's bare-hostname constructor, BaseResource couldn't handle numeric resource IDs, and SignalWireRestError had type/naming mismatches.

## Changes

### CompatNamespace (13 gaps)
- All 13 `update` methods across compat sub-resources: `body: any` → `body: any = {}` making body optional

### HttpClient (2 gaps)
- Added `host` option matching Python's bare-hostname constructor (`host` → `https://${host}`)
- P3 `fetchImpl` extra: TS-only testing hook, no fix needed

### SignalWireRestError (3 gaps)
- Added `SignalWireRestError` alias for `RestError` matching Python class name
- `body` property widened to `string | Record<string, unknown>` matching Python's JSON parsing
- `method` parameter default: `'GET'` matching Python

### BaseResource (1 gap)
- `_path()` now accepts `string | number` matching Python's `str(p)` coercion

### PhoneNumbersResource (1 gap)
- `create`/`update` body params now optional with `= {}` defaults

### CompatCalls (2 gaps)
- Already fixed by CompatNamespace changes (same file)

### RestClient (1 gap)
- P3 extra: no fix needed

## Verification

- `npm run build` passes
- 1446/1446 tests pass (including new HttpClient and RestError tests)

Closes #18
Closes #13
Closes #17
Closes #28
Closes #42
Closes #49
Closes #53
