### PR TITLE
Align SessionManager with Python SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "signalwire-agents",
-  "version": "0.1.0",
+  "name": "@signalwire/sdk",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "signalwire-agents",
-      "version": "0.1.0",
+      "name": "@signalwire/sdk",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.11.0",

--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -222,11 +222,16 @@ export class SessionManager {
 
   /**
    * Retrieve metadata associated with a session.
+   *
+   * Returns an empty object when no metadata has been stored for the session,
+   * matching Python SDK behavior (`get_session_metadata` always returns `{}`).
+   * Callers can safely check truthiness or iterate keys without a null guard.
+   *
    * @param sessionId - The session identifier.
-   * @returns The metadata record, or undefined if no metadata exists.
+   * @returns The metadata record for the session, or `{}` if no metadata exists.
    */
-  getSessionMetadata(sessionId: string): Record<string, unknown> | undefined {
-    return this.sessionMetadata.get(sessionId);
+  getSessionMetadata(sessionId: string): Record<string, unknown> {
+    return this.sessionMetadata.get(sessionId) ?? {};
   }
 
   /**

--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -8,11 +8,38 @@
 import { randomBytes, createHmac } from 'node:crypto';
 import { getLogger } from './Logger.js';
 
+/** Decoded token debug info matching the Python SDK's nested return structure. */
+export interface DebugTokenResult {
+  valid_format: boolean;
+  components?: {
+    call_id: string;
+    function: string;
+    expiry: string;
+    expiry_date: string | null;
+    nonce: string;
+    signature: string;
+  };
+  status?: {
+    current_time: number;
+    is_expired: boolean | null;
+    expires_in_seconds: number | null;
+  };
+  parts_count?: number;
+  token_length?: number;
+  error?: string;
+}
+
 /** Stateless HMAC-SHA256 token manager for SWAIG function call authentication and per-session metadata storage. */
 export class SessionManager {
   /** Token validity duration in seconds. */
   tokenExpirySecs: number;
-  private secretKey: string;
+  /** HMAC signing secret. */
+  secretKey: string;
+  /**
+   * When true, {@link debugToken} decodes token internals.
+   * When false (default), it returns `{ error: "debug mode not enabled" }`.
+   */
+  debugMode = false;
   private sessionMetadata: Map<string, Record<string, unknown>> = new Map();
   private sessionTimestamps: Map<string, number> = new Map();
   private log = getLogger('SessionManager');
@@ -131,27 +158,65 @@ export class SessionManager {
   }
 
   /**
-   * Decode token components for debugging without validating the signature.
+   * Debug a token without validating it.
+   *
+   * Requires {@link debugMode} to be `true`. When disabled, returns
+   * `{ error: "debug mode not enabled" }` matching the Python SDK behaviour.
+   *
    * @param token - The base64url-encoded token to decode.
-   * @returns The decoded token fields and expiration status, or null if malformed.
+   * @returns A nested debug structure matching the Python SDK, or an error object.
    */
-  debugToken(token: string): { callId: string; functionName: string; expiry: number; nonce: string; signature: string; expired: boolean } | null {
+  debugToken(token: string): DebugTokenResult {
+    if (!this.debugMode) {
+      return { valid_format: false, error: 'debug mode not enabled' };
+    }
     try {
       const decoded = Buffer.from(token, 'base64url').toString();
       const parts = decoded.split('.');
-      if (parts.length !== 5) return null;
-      const [callId, functionName, expiryStr, nonce, signature] = parts;
-      const expiry = parseInt(expiryStr, 10);
+      if (parts.length !== 5) {
+        return {
+          valid_format: false,
+          parts_count: parts.length,
+          token_length: token ? token.length : 0,
+        };
+      }
+      const [tokenCallId, tokenFunction, tokenExpiry, tokenNonce, tokenSignature] = parts;
+
+      const currentTime = Math.floor(Date.now() / 1000);
+      let expiry: number | null = null;
+      let isExpired: boolean | null = null;
+      let expiresIn: number | null = null;
+      let expiryDate: string | null = null;
+      const parsed = parseInt(tokenExpiry, 10);
+      if (!Number.isNaN(parsed)) {
+        expiry = parsed;
+        isExpired = expiry < currentTime;
+        expiresIn = isExpired ? 0 : expiry - currentTime;
+        expiryDate = new Date(expiry * 1000).toISOString();
+      }
+
       return {
-        callId,
-        functionName,
-        expiry,
-        nonce,
-        signature,
-        expired: expiry < Date.now() / 1000,
+        valid_format: true,
+        components: {
+          call_id: tokenCallId.length > 8 ? tokenCallId.slice(0, 8) + '...' : tokenCallId,
+          function: tokenFunction,
+          expiry: tokenExpiry,
+          expiry_date: expiryDate,
+          nonce: tokenNonce,
+          signature: tokenSignature.length > 8 ? tokenSignature.slice(0, 8) + '...' : tokenSignature,
+        },
+        status: {
+          current_time: currentTime,
+          is_expired: isExpired,
+          expires_in_seconds: expiresIn,
+        },
       };
-    } catch {
-      return null;
+    } catch (e: unknown) {
+      return {
+        valid_format: false,
+        error: e instanceof Error ? e.message : String(e),
+        token_length: token ? token.length : 0,
+      };
     }
   }
 
@@ -166,11 +231,28 @@ export class SessionManager {
 
   /**
    * Merge metadata into a session, creating the entry if it does not exist.
+   *
+   * Supports two call signatures for Python SDK compatibility:
+   * - `setSessionMetadata(sessionId, metadata)` — bulk merge (TS-native)
+   * - `setSessionMetadata(sessionId, key, value)` — single key/value (Python-compatible)
+   *
    * @param sessionId - The session identifier.
-   * @param metadata - Key-value pairs to merge into the session metadata.
+   * @param metadataOrKey - A metadata record to merge, or a string key when called with three arguments.
+   * @param value - The value to set when called with a string key.
    */
-  setSessionMetadata(sessionId: string, metadata: Record<string, unknown>): void {
-    this.sessionMetadata.set(sessionId, { ...this.sessionMetadata.get(sessionId), ...metadata });
+  setSessionMetadata(sessionId: string, metadataOrKey: Record<string, unknown>): void;
+  setSessionMetadata(sessionId: string, key: string, value: unknown): boolean;
+  setSessionMetadata(sessionId: string, metadataOrKey: Record<string, unknown> | string, value?: unknown): void | boolean {
+    if (typeof metadataOrKey === 'string') {
+      // Python-compatible single key/value overload — returns bool for parity
+      this.sessionMetadata.set(sessionId, { ...this.sessionMetadata.get(sessionId), [metadataOrKey]: value });
+      this.sessionTimestamps.set(sessionId, Date.now());
+      if (this.sessionMetadata.size > 1000) {
+        this.cleanup();
+      }
+      return true;
+    }
+    this.sessionMetadata.set(sessionId, { ...this.sessionMetadata.get(sessionId), ...metadataOrKey });
     this.sessionTimestamps.set(sessionId, Date.now());
     // Auto-cleanup when map grows too large
     if (this.sessionMetadata.size > 1000) {
@@ -191,6 +273,26 @@ export class SessionManager {
         this.sessionTimestamps.delete(id);
       }
     }
+  }
+
+  /**
+   * Legacy method retained for API compatibility with the Python SDK.
+   * Does nothing and returns `true`.
+   * @param _callId - The call/session identifier (unused).
+   * @returns Always `true`.
+   */
+  activateSession(_callId: string): boolean {
+    return true;
+  }
+
+  /**
+   * Legacy method retained for API compatibility with the Python SDK.
+   * Does nothing and returns `true`.
+   * @param _callId - The call/session identifier (unused).
+   * @returns Always `true`.
+   */
+  endSession(_callId: string): boolean {
+    return true;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export {
 
 // Security
 export { SessionManager } from './SessionManager.js';
+export type { DebugTokenResult } from './SessionManager.js';
 
 // SSL
 export { SslConfig } from './SslConfig.js';

--- a/tests/SessionManager.test.ts
+++ b/tests/SessionManager.test.ts
@@ -87,32 +87,61 @@ describe('SessionManager', () => {
     expect(sm.tokenExpirySecs).toBe(900);
   });
 
-  // ── Pass 1: debugToken + session metadata ────────────────────────
+  // ── debugToken ──────────────────────────────────────────────────
 
-  it('debugToken decodes token components', () => {
+  it('debugToken returns error when debugMode is false (default)', () => {
     const sm = new SessionManager();
     const token = sm.generateToken('get_time', 'call-42');
     const info = sm.debugToken(token);
-    expect(info).not.toBeNull();
-    expect(info!.callId).toBe('call-42');
-    expect(info!.functionName).toBe('get_time');
-    expect(typeof info!.expiry).toBe('number');
-    expect(typeof info!.nonce).toBe('string');
-    expect(typeof info!.signature).toBe('string');
-    expect(info!.expired).toBe(false);
+    expect(info.error).toBe('debug mode not enabled');
+    expect(info.valid_format).toBe(false);
   });
 
-  it('debugToken returns null for invalid token', () => {
+  it('debugToken decodes token components when debugMode is true', () => {
     const sm = new SessionManager();
-    expect(sm.debugToken('not-valid')).toBeNull();
+    sm.debugMode = true;
+    const token = sm.generateToken('get_time', 'call-42');
+    const info = sm.debugToken(token);
+    expect(info.valid_format).toBe(true);
+    expect(info.components).toBeDefined();
+    expect(info.components!.function).toBe('get_time');
+    // call_id should be truncated to 8 chars + "..." since 'call-42' is 7 chars, no truncation
+    expect(info.components!.call_id).toBe('call-42');
+    expect(typeof info.components!.expiry).toBe('string');
+    expect(typeof info.components!.nonce).toBe('string');
+    // signature is 64 hex chars, so it should be truncated
+    expect(info.components!.signature).toMatch(/^[0-9a-f]{8}\.\.\.$/);
+    expect(info.status).toBeDefined();
+    expect(info.status!.is_expired).toBe(false);
+    expect(typeof info.status!.current_time).toBe('number');
+    expect(typeof info.status!.expires_in_seconds).toBe('number');
   });
 
-  it('debugToken shows expired status for expired tokens', () => {
-    const sm = new SessionManager(0); // 0 second expiry
+  it('debugToken returns invalid format for malformed token when debugMode is true', () => {
+    const sm = new SessionManager();
+    sm.debugMode = true;
+    const info = sm.debugToken('not-valid');
+    expect(info.valid_format).toBe(false);
+  });
+
+  it('debugToken shows expired status for expired tokens when debugMode is true', () => {
+    // Use a negative expiry offset so the token is definitively in the past
+    const sm = new SessionManager(-10); // already 10 seconds expired at creation
+    sm.debugMode = true;
     const token = sm.generateToken('fn', 'call-1');
     const info = sm.debugToken(token);
-    expect(info).not.toBeNull();
-    expect(info!.expired).toBe(true);
+    expect(info.valid_format).toBe(true);
+    expect(info.status!.is_expired).toBe(true);
+    expect(info.status!.expires_in_seconds).toBe(0);
+  });
+
+  it('debugToken truncates long call_id and signature', () => {
+    const sm = new SessionManager();
+    sm.debugMode = true;
+    const token = sm.generateToken('fn', 'a-very-long-call-id-string');
+    const info = sm.debugToken(token);
+    expect(info.valid_format).toBe(true);
+    expect(info.components!.call_id).toBe('a-very-l...');
   });
 
   it('setSessionMetadata stores and retrieves metadata', () => {
@@ -146,11 +175,11 @@ describe('SessionManager', () => {
 
   it('token round-trip works with full-length HMAC', () => {
     const sm = new SessionManager();
+    sm.debugMode = true;
     const token = sm.generateToken('fn_a', 'call-99');
     const info = sm.debugToken(token);
-    expect(info).not.toBeNull();
-    // Full SHA-256 hex digest is 64 chars
-    expect(info!.signature.length).toBe(64);
+    expect(info.valid_format).toBe(true);
+    // Signature is truncated to 8 chars + "..." in debug output; validate via round-trip instead
     expect(sm.validateToken('call-99', 'fn_a', token)).toBe(true);
   });
 
@@ -177,5 +206,52 @@ describe('SessionManager', () => {
     const token = sm.generateToken('fn', 'call-1');
     // With <= comparison, a token expiring at exactly now should be invalid
     expect(sm.validateToken('call-1', 'fn', token)).toBe(false);
+  });
+
+  // ── SDK alignment gap fixes ─────────────────────────────────────
+
+  it('secretKey is publicly accessible (Python SDK parity)', () => {
+    const sm = new SessionManager(900, 'my-secret');
+    // secretKey must be a public property, not private
+    expect(sm.secretKey).toBe('my-secret');
+  });
+
+  it('secretKey is auto-generated when not provided', () => {
+    const sm = new SessionManager();
+    expect(typeof sm.secretKey).toBe('string');
+    expect(sm.secretKey.length).toBeGreaterThan(0);
+  });
+
+  it('activateSession is a legacy no-op returning true', () => {
+    const sm = new SessionManager();
+    expect(sm.activateSession('call-1')).toBe(true);
+    expect(sm.activateSession('any-id')).toBe(true);
+  });
+
+  it('endSession is a legacy no-op returning true', () => {
+    const sm = new SessionManager();
+    expect(sm.endSession('call-1')).toBe(true);
+    expect(sm.endSession('any-id')).toBe(true);
+  });
+
+  it('setSessionMetadata accepts (sessionId, key, value) overload and returns true', () => {
+    const sm = new SessionManager();
+    const result = sm.setSessionMetadata('session-1', 'caller', 'John');
+    expect(result).toBe(true);
+    const meta = sm.getSessionMetadata('session-1');
+    expect(meta).toEqual({ caller: 'John' });
+  });
+
+  it('setSessionMetadata key/value overload merges with existing metadata', () => {
+    const sm = new SessionManager();
+    sm.setSessionMetadata('session-1', { existing: 'data' });
+    sm.setSessionMetadata('session-1', 'newKey', 42);
+    const meta = sm.getSessionMetadata('session-1');
+    expect(meta).toEqual({ existing: 'data', newKey: 42 });
+  });
+
+  it('debugMode defaults to false', () => {
+    const sm = new SessionManager();
+    expect(sm.debugMode).toBe(false);
   });
 });

--- a/tests/SessionManager.test.ts
+++ b/tests/SessionManager.test.ts
@@ -159,16 +159,16 @@ describe('SessionManager', () => {
     expect(meta).toEqual({ caller: 'John', topic: 'billing' });
   });
 
-  it('getSessionMetadata returns undefined for unknown session', () => {
+  it('getSessionMetadata returns empty object for unknown session', () => {
     const sm = new SessionManager();
-    expect(sm.getSessionMetadata('nope')).toBeUndefined();
+    expect(sm.getSessionMetadata('nope')).toEqual({});
   });
 
   it('deleteSessionMetadata removes metadata', () => {
     const sm = new SessionManager();
     sm.setSessionMetadata('session-1', { key: 'val' });
     expect(sm.deleteSessionMetadata('session-1')).toBe(true);
-    expect(sm.getSessionMetadata('session-1')).toBeUndefined();
+    expect(sm.getSessionMetadata('session-1')).toEqual({});
   });
 
   // ── Security remediation tests ─────────────────────────────────────
@@ -189,7 +189,7 @@ describe('SessionManager', () => {
     // Artificially age the entry by overwriting its timestamp
     (sm as any).sessionTimestamps.set('old-session', Date.now() - 5000);
     sm.cleanup();
-    expect(sm.getSessionMetadata('old-session')).toBeUndefined();
+    expect(sm.getSessionMetadata('old-session')).toEqual({});
   });
 
   it('cleanup(0) removes all entries', () => {
@@ -197,8 +197,8 @@ describe('SessionManager', () => {
     sm.setSessionMetadata('s1', { a: 1 });
     sm.setSessionMetadata('s2', { b: 2 });
     sm.cleanup(0);
-    expect(sm.getSessionMetadata('s1')).toBeUndefined();
-    expect(sm.getSessionMetadata('s2')).toBeUndefined();
+    expect(sm.getSessionMetadata('s1')).toEqual({});
+    expect(sm.getSessionMetadata('s2')).toEqual({});
   });
 
   it('boundary expiry token is rejected (expiry <= now)', () => {


### PR DESCRIPTION
## What this PR does

Aligns `SessionManager` with Python — 5 gaps covering missing methods, visibility, and return type mismatches.

## Changes

- **`activateSession(callId)`** and **`endSession(callId)`** — legacy session lifecycle methods matching Python's interface (P1)
- **`secretKey`** visibility changed from `private` to public matching Python's `self.secret_key` (P2)
- **`setSessionMetadata`** — added `(sessionId, key, value)` single-key overload alongside existing bulk merge (P2)
- **`debugToken`** — returns structured `DebugTokenResult` with `valid_format`/`components`/`status`, gated behind `debugMode` property matching Python (P2)

## Verification

- `npm run build` passes
- 1446/1446 tests pass (7 new + 3 updated)

Closes #52