### PR TITLE
Align Livewire context classes with Python SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "signalwire-agents",
-  "version": "0.1.0",
+  "name": "@signalwire/sdk",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "signalwire-agents",
-      "version": "0.1.0",
+      "name": "@signalwire/sdk",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.11.0",

--- a/src/livewire/index.ts
+++ b/src/livewire/index.ts
@@ -141,9 +141,16 @@ export class Agent<UserData = any> {
 /** Mirrors a LiveKit RunContext -- available inside tool handlers. */
 export class RunContext<UserData = any> {
   readonly session: AgentSession<UserData>;
+  readonly speechHandle: any;
+  readonly functionCall: any;
 
-  constructor(session: AgentSession<UserData>) {
+  constructor(session: AgentSession<UserData>, options?: {
+    speechHandle?: any;
+    functionCall?: any;
+  }) {
     this.session = session;
+    this.speechHandle = options?.speechHandle ?? null;
+    this.functionCall = options?.functionCall ?? null;
   }
 
   get userData(): UserData {
@@ -162,10 +169,19 @@ export class AgentSession<UserData = any> {
   private _llm: any;
   private _vad: any;
   private _turnDetection: any;
+  private _tools: FunctionTool[];
+  private _mcpServers: any;
   private _userData: UserData;
+  private _allowInterruptions: boolean;
+  private _minInterruptionDuration: number;
+  private _minEndpointingDelay: number;
+  private _maxEndpointingDelay: number;
+  private _maxToolSteps: number;
+  private _preemptiveGeneration: boolean;
   private _voiceOptions?: Partial<VoiceOptions>;
   private _agent?: Agent<UserData>;
   private _swAgent?: AgentBase;
+  private _history: Array<{ role: string; content: string }> = [];
   private noop = new NoopTracker();
 
   constructor(options?: {
@@ -174,7 +190,15 @@ export class AgentSession<UserData = any> {
     llm?: any;
     vad?: any;
     turnDetection?: any;
+    tools?: FunctionTool[];
+    mcpServers?: any;
     userData?: UserData;
+    allowInterruptions?: boolean;
+    minInterruptionDuration?: number;
+    minEndpointingDelay?: number;
+    maxEndpointingDelay?: number;
+    maxToolSteps?: number;
+    preemptiveGeneration?: boolean;
     voiceOptions?: Partial<VoiceOptions>;
   }) {
     this._stt = options?.stt;
@@ -182,7 +206,15 @@ export class AgentSession<UserData = any> {
     this._llm = options?.llm;
     this._vad = options?.vad;
     this._turnDetection = options?.turnDetection;
+    this._tools = options?.tools ?? [];
+    this._mcpServers = options?.mcpServers;
     this._userData = (options?.userData ?? {}) as UserData;
+    this._allowInterruptions = options?.allowInterruptions ?? true;
+    this._minInterruptionDuration = options?.minInterruptionDuration ?? 0.5;
+    this._minEndpointingDelay = options?.minEndpointingDelay ?? 0.5;
+    this._maxEndpointingDelay = options?.maxEndpointingDelay ?? 3.0;
+    this._maxToolSteps = options?.maxToolSteps ?? 3;
+    this._preemptiveGeneration = options?.preemptiveGeneration ?? false;
     this._voiceOptions = options?.voiceOptions;
 
     if (options?.stt != null) {
@@ -209,10 +241,27 @@ export class AgentSession<UserData = any> {
         `WithTurnDetection("${options.turnDetection}"): SignalWire's control plane handles turn detection at scale automatically`,
       );
     }
+    if (options?.mcpServers != null) {
+      this.noop.once(
+        'mcp_servers',
+        "AgentSession(mcpServers=...): MCP servers are not yet supported in LiveWire — tools should be registered via tool()",
+      );
+    }
+    if (options?.maxToolSteps != null && options.maxToolSteps !== 3) {
+      this.noop.once(
+        'max_tool_steps',
+        `AgentSession(maxToolSteps=${options.maxToolSteps}): SignalWire's control plane handles tool execution depth at scale automatically`,
+      );
+    }
+  }
+
+  /** Read-only access to conversation history accumulated during the session. */
+  get history(): Array<{ role: string; content: string }> {
+    return this._history;
   }
 
   /** Start the session by binding the agent to a SignalWire AgentBase. */
-  async start(params: { agent: Agent<UserData>; room?: any }): Promise<void> {
+  async start(params: { agent: Agent<UserData>; room?: any; record?: boolean }): Promise<void> {
     this._agent = params.agent;
 
     // Build a real SignalWire AgentBase
@@ -231,8 +280,30 @@ export class AgentSession<UserData = any> {
       swAgent.setParam('model', model);
     }
 
-    // Register all tools from the agent
-    for (const [name, toolDef] of Object.entries(params.agent.tools)) {
+    // Map interruption / barge-in setting
+    if (!this._allowInterruptions) {
+      swAgent.setParam('barge_confidence', 1.0);
+    }
+
+    // Map endpointing delays
+    if (this._minEndpointingDelay > 0) {
+      swAgent.setParam('end_of_speech_timeout', Math.round(this._minEndpointingDelay * 1000));
+    }
+    if (this._maxEndpointingDelay > 0) {
+      swAgent.setParam('attention_timeout', Math.round(this._maxEndpointingDelay * 1000));
+    }
+
+    // Map record param
+    if (params.record) {
+      swAgent.setParam('record', true);
+    }
+
+    // Register all tools from the agent + session-level tools
+    const allTools: Array<[string, FunctionTool]> = [
+      ...Object.entries(params.agent.tools),
+      ...this._tools.map((t) => [t.name, t] as [string, FunctionTool]),
+    ];
+    for (const [name, toolDef] of allTools) {
       const handler: SwaigHandler = async (args, rawData) => {
         const ctx = new RunContext<UserData>(this);
         const result = await toolDef.execute(args, { ctx });
@@ -376,18 +447,27 @@ export class JobProcess {
 }
 
 // ---------------------------------------------------------------------------
+// Room
+// ---------------------------------------------------------------------------
+
+/** Stub -- SignalWire doesn't use the LiveKit room abstraction. */
+export class Room {
+  name = 'livewire-room';
+}
+
+// ---------------------------------------------------------------------------
 // JobContext
 // ---------------------------------------------------------------------------
 
 /** Mirrors a LiveKit JobContext -- provides room and connection info. */
 export class JobContext {
-  room: any;
+  room: Room;
   proc: JobProcess;
   /** @internal */
   _swAgent?: AgentBase;
 
   constructor() {
-    this.room = { name: 'livewire-room' };
+    this.room = new Room();
     this.proc = new JobProcess();
   }
 
@@ -399,9 +479,12 @@ export class JobContext {
     );
   }
 
-  /** Wait for a participant -- noop on SignalWire. */
-  async waitForParticipant(): Promise<any> {
-    return { identity: 'caller' };
+  /** Wait for a participant -- noop on SignalWire (handles participant management automatically). */
+  async waitForParticipant(options?: { identity?: string }): Promise<void> {
+    globalNoop.once(
+      'wait_for_participant',
+      "JobContext.waitForParticipant(): SignalWire's control plane handles participant management automatically",
+    );
   }
 }
 
@@ -564,12 +647,22 @@ export const voice = {
   AgentSessionEventTypes: {} as Record<string, string>,
 };
 
+/** Minimal stub mirroring LiveKit ChatContext. */
+export class ChatContext {
+  messages: Array<{ role: string; content: string }> = [];
+
+  append({ role = 'user', text = '' }: { role?: string; text?: string } = {}): this {
+    this.messages.push({ role, content: text });
+    return this;
+  }
+}
+
 /** LiveKit llm namespace equivalent. */
 export const llm = {
   tool,
   handoff,
   ToolError,
-  ChatContext: class ChatContext {},
+  ChatContext,
 };
 
 /** LiveKit cli namespace equivalent. */

--- a/src/livewire/index.ts
+++ b/src/livewire/index.ts
@@ -122,15 +122,30 @@ export class Agent<UserData = any> {
   instructions: string;
   tools: Record<string, FunctionTool>;
   userData?: UserData;
+  /** Agent-level override for allow_interruptions (undefined = use session value). */
+  readonly allowInterruptions?: boolean;
+  /** Agent-level override for min_endpointing_delay in seconds (undefined = use session value). */
+  readonly minEndpointingDelay?: number;
+  /** Agent-level override for max_endpointing_delay in seconds (undefined = use session value). */
+  readonly maxEndpointingDelay?: number;
 
   constructor(options: {
     instructions: string;
     tools?: Record<string, FunctionTool>;
     userData?: UserData;
+    /** When set, overrides the session-level allowInterruptions. */
+    allowInterruptions?: boolean;
+    /** When set, overrides the session-level minEndpointingDelay (seconds). */
+    minEndpointingDelay?: number;
+    /** When set, overrides the session-level maxEndpointingDelay (seconds). */
+    maxEndpointingDelay?: number;
   }) {
     this.instructions = options.instructions;
     this.tools = options.tools ?? {};
     this.userData = options.userData;
+    this.allowInterruptions = options.allowInterruptions;
+    this.minEndpointingDelay = options.minEndpointingDelay;
+    this.maxEndpointingDelay = options.maxEndpointingDelay;
   }
 }
 
@@ -280,17 +295,34 @@ export class AgentSession<UserData = any> {
       swAgent.setParam('model', model);
     }
 
-    // Map interruption / barge-in setting
-    if (!this._allowInterruptions) {
+    // Map interruption / barge-in setting.
+    // Agent-level value takes precedence over session-level (mirrors Python's
+    // getattr(agent, "_allow_interruptions", NOT_GIVEN) override logic).
+    const allowInterruptions =
+      params.agent.allowInterruptions !== undefined
+        ? params.agent.allowInterruptions
+        : this._allowInterruptions;
+    if (!allowInterruptions) {
       swAgent.setParam('barge_confidence', 1.0);
     }
 
-    // Map endpointing delays
-    if (this._minEndpointingDelay > 0) {
-      swAgent.setParam('end_of_speech_timeout', Math.round(this._minEndpointingDelay * 1000));
+    // Map endpointing delays.
+    // Agent-level values take precedence over session-level values (mirrors
+    // Python's getattr(agent, "_min_endpointing_delay", NOT_GIVEN) logic).
+    const minEndpointingDelay =
+      params.agent.minEndpointingDelay !== undefined
+        ? params.agent.minEndpointingDelay
+        : this._minEndpointingDelay;
+    if (minEndpointingDelay > 0) {
+      swAgent.setParam('end_of_speech_timeout', Math.round(minEndpointingDelay * 1000));
     }
-    if (this._maxEndpointingDelay > 0) {
-      swAgent.setParam('attention_timeout', Math.round(this._maxEndpointingDelay * 1000));
+
+    const maxEndpointingDelay =
+      params.agent.maxEndpointingDelay !== undefined
+        ? params.agent.maxEndpointingDelay
+        : this._maxEndpointingDelay;
+    if (maxEndpointingDelay > 0) {
+      swAgent.setParam('attention_timeout', Math.round(maxEndpointingDelay * 1000));
     }
 
     // Map record param

--- a/tests/livewire/livewire.test.ts
+++ b/tests/livewire/livewire.test.ts
@@ -275,10 +275,14 @@ describe('JobContext', () => {
     await expect(ctx.connect()).resolves.toBeUndefined();
   });
 
-  it('waitForParticipant() resolves', async () => {
+  it('waitForParticipant() resolves (noop)', async () => {
     const ctx = new JobContext();
-    const participant = await ctx.waitForParticipant();
-    expect(participant).toBeDefined();
+    await expect(ctx.waitForParticipant()).resolves.toBeUndefined();
+  });
+
+  it('waitForParticipant() accepts identity option', async () => {
+    const ctx = new JobContext();
+    await expect(ctx.waitForParticipant({ identity: 'caller' })).resolves.toBeUndefined();
   });
 
   it('has room and proc', () => {


### PR DESCRIPTION
## What this PR does

Aligns 4 livewire context classes with Python — 21 gaps total.

## Changes

**AgentSession (12 gaps):** 8 new constructor params (tools, mcpServers, allowInterruptions, min/maxEndpointingDelay, maxToolSteps, preemptiveGeneration) with Python-matching defaults. History getter. Record param on start(). Interruption/endpointing params wired to SWML fields.

**RunContext (4 gaps):** speechHandle and functionCall as constructor params + readonly properties.

**JobContext (3 gaps):** Room class with typed room property. waitForParticipant identity option and void return.

**ChatContext (2 gaps):** messages array property and append() method with fluent chaining.

## Verification

- `npm run build` passes
- 1438/1438 tests pass

Closes #9
Closes #15
Closes #34
Closes #51