### PR TITLE
Align core misc classes with Python SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "signalwire-agents",
-  "version": "0.1.0",
+  "name": "@signalwire/sdk",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "signalwire-agents",
-      "version": "0.1.0",
+      "name": "@signalwire/sdk",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.11.0",
+        "ajv": "^8.18.0",
         "hono": "^4.4.0",
         "js-yaml": "^4.1.1",
         "ws": "^8.17.0"
@@ -942,6 +943,22 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1149,6 +1166,28 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1244,6 +1283,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/local-pkg": {
       "version": "0.5.1",
@@ -1512,6 +1557,15 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/rollup": {
       "version": "4.59.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@hono/node-server": "^1.11.0",
+    "ajv": "^8.18.0",
     "hono": "^4.4.0",
     "js-yaml": "^4.1.1",
     "ws": "^8.17.0"

--- a/src/FunctionResult.ts
+++ b/src/FunctionResult.ts
@@ -305,7 +305,7 @@ export class FunctionResult {
    * @param transfer - Whether this SWML execution should transfer the call.
    * @returns This instance for chaining.
    */
-  executeSwml(swmlContent: string | Record<string, unknown>, transfer = false): this {
+  executeSwml(swmlContent: string | Record<string, unknown> | { toDict(): Record<string, unknown> }, transfer = false): this {
     let swmlData: Record<string, unknown>;
     if (typeof swmlContent === 'string') {
       try {
@@ -313,8 +313,10 @@ export class FunctionResult {
       } catch {
         swmlData = { raw_swml: swmlContent };
       }
+    } else if (typeof (swmlContent as { toDict?: unknown }).toDict === 'function') {
+      swmlData = (swmlContent as { toDict(): Record<string, unknown> }).toDict();
     } else {
-      swmlData = { ...swmlContent };
+      swmlData = { ...(swmlContent as Record<string, unknown>) };
     }
     if (transfer) {
       swmlData['transfer'] = 'true';

--- a/src/PomBuilder.ts
+++ b/src/PomBuilder.ts
@@ -142,6 +142,63 @@ export class PomSection {
 
     return lines.join('\n');
   }
+
+  /**
+   * Renders this section and its subsections as an XML string.
+   * @param indent - The indentation depth (default 0).
+   * @param sectionNumber - Hierarchical numbering prefix for numbered sections.
+   * @returns The rendered XML string.
+   */
+  renderXml(indent = 0, sectionNumber: number[] = []): string {
+    const pad = '  '.repeat(indent);
+    const lines: string[] = [];
+
+    lines.push(`${pad}<section>`);
+
+    if (this.title !== null) {
+      const prefix = sectionNumber.length ? `${sectionNumber.join('.')}. ` : '';
+      lines.push(`${pad}  <title>${prefix}${this.title}</title>`);
+    }
+
+    if (this.body) {
+      lines.push(`${pad}  <body>${this.body}</body>`);
+    }
+
+    if (this.bullets.length) {
+      lines.push(`${pad}  <bullets>`);
+      for (let i = 0; i < this.bullets.length; i++) {
+        if (this.numberedBullets) {
+          lines.push(`${pad}    <bullet id="${i + 1}">${this.bullets[i]}</bullet>`);
+        } else {
+          lines.push(`${pad}    <bullet>${this.bullets[i]}</bullet>`);
+        }
+      }
+      lines.push(`${pad}  </bullets>`);
+    }
+
+    if (this.subsections.length) {
+      lines.push(`${pad}  <subsections>`);
+      const anyNumbered = this.subsections.some((s) => s.numbered);
+      for (let i = 0; i < this.subsections.length; i++) {
+        const sub = this.subsections[i];
+        let newNumber: number[];
+        if (this.title !== null || sectionNumber.length) {
+          if (anyNumbered && sub.numbered !== false) {
+            newNumber = [...sectionNumber, i + 1];
+          } else {
+            newNumber = sectionNumber;
+          }
+        } else {
+          newNumber = sectionNumber;
+        }
+        lines.push(sub.renderXml(indent + 2, newNumber));
+      }
+      lines.push(`${pad}  </subsections>`);
+    }
+
+    lines.push(`${pad}</section>`);
+    return lines.join('\n');
+  }
 }
 
 /** Builds a structured prompt by composing named POM sections, with Markdown and dict export. */
@@ -276,6 +333,33 @@ export class PomBuilder {
   }
 
   /**
+   * Serializes all sections to a JSON string.
+   * @returns A JSON string representation of all top-level sections.
+   */
+  toJson(): string {
+    return JSON.stringify(this.toDict());
+  }
+
+  /**
+   * Creates a PomBuilder from an array of section data objects.
+   * @param sections - Array of section data to reconstruct.
+   * @returns A new PomBuilder populated with the given sections.
+   */
+  static fromSections(sections: PomSectionData[]): PomBuilder {
+    const builder = new PomBuilder();
+    for (const s of sections) {
+      builder.addSection(s.title ?? '', {
+        body: s.body,
+        bullets: s.bullets,
+        numbered: s.numbered,
+        numberedBullets: s.numberedBullets,
+        subsections: s.subsections as { title: string; body?: string; bullets?: string[] }[],
+      });
+    }
+    return builder;
+  }
+
+  /**
    * Renders all sections as a combined Markdown string.
    * @returns The complete rendered Markdown prompt text.
    */
@@ -294,5 +378,27 @@ export class PomBuilder {
       parts.push(section.renderMarkdown(2, sectionNumber));
     }
     return parts.join('\n');
+  }
+
+  /**
+   * Renders all sections as a combined XML string with a `<prompt>` root element.
+   * @returns The complete rendered XML prompt text.
+   */
+  renderXml(): string {
+    const anyNumbered = this.sections.some((s) => s.numbered);
+    const lines: string[] = ['<?xml version="1.0" encoding="UTF-8"?>', '<prompt>'];
+    let counter = 0;
+    for (const section of this.sections) {
+      let sectionNumber: number[] = [];
+      if (section.title !== null) {
+        counter++;
+        if (anyNumbered && section.numbered !== false) {
+          sectionNumber = [counter];
+        }
+      }
+      lines.push(section.renderXml(1, sectionNumber));
+    }
+    lines.push('</prompt>');
+    return lines.join('\n');
   }
 }

--- a/src/PomBuilder.ts
+++ b/src/PomBuilder.ts
@@ -325,6 +325,31 @@ export class PomBuilder {
   }
 
   /**
+   * Appends every top-level section of another PomBuilder as subsections of a target section.
+   * @param target - The heading of the target section, or the PomSection to append into.
+   * @param pomToAdd - The PomBuilder whose sections should be appended as subsections.
+   * @returns This builder for chaining.
+   * @throws {Error} If target is a string and no section with that title is found.
+   */
+  addPomAsSubsection(target: string | PomSection, pomToAdd: PomBuilder): this {
+    let targetSection: PomSection;
+    if (typeof target === 'string') {
+      const found = this.findSection(target);
+      if (!found) {
+        throw new Error(`No section with title '${target}' found.`);
+      }
+      targetSection = found;
+    } else {
+      targetSection = target;
+    }
+
+    for (const section of pomToAdd.sections) {
+      targetSection.subsections.push(section);
+    }
+    return this;
+  }
+
+  /**
    * Serializes all sections to an array of plain data objects.
    * @returns An array of PomSectionData representing all top-level sections.
    */

--- a/src/SwaigFunction.ts
+++ b/src/SwaigFunction.ts
@@ -43,7 +43,24 @@ export interface SwaigFunctionOptions {
   webhookUrl?: string;
   /** List of required parameter names. */
   required?: string[];
-  /** Additional fields to include in the SWAIG definition output. */
+  /**
+   * Additional fields to merge directly into the SWAIG function definition.
+   *
+   * **Python equivalent:** `**extra_swaig_fields` kwargs on the constructor.
+   * In Python these are passed as bare keyword arguments and merged directly
+   * into the output dict via `function_def.update(self.extra_swaig_fields)`.
+   * In TypeScript the same fields are collected under this single options key
+   * and merged identically in `toSwaig()` — the wire format is identical.
+   *
+   * @example
+   * ```typescript
+   * // Python: SWAIGFunction(..., meta_data_token="abc", web_hook_auth_user="u")
+   * new SwaigFunction({
+   *   ...,
+   *   extraFields: { meta_data_token: 'abc', web_hook_auth_user: 'u' },
+   * });
+   * ```
+   */
   extraFields?: Record<string, unknown>;
   /** Whether this tool uses a typed handler with named parameters. */
   isTypedHandler?: boolean;
@@ -109,7 +126,14 @@ export class SwaigFunction {
   isExternal: boolean;
 
   /**
+   * Create a new SwaigFunction.
+   *
    * @param opts - Configuration options for the SWAIG function.
+   *   Use `opts.extraFields` to pass any additional SWAIG-only fields
+   *   (e.g. `meta_data_token`, `web_hook_auth_user`, `web_hook_auth_password`).
+   *   This mirrors the Python constructor's `**extra_swaig_fields` kwargs:
+   *   both are merged directly into the serialized SWAIG definition, so the
+   *   wire format is identical — only the call-site syntax differs.
    */
   constructor(opts: SwaigFunctionOptions) {
     this.name = opts.name;
@@ -194,6 +218,12 @@ export class SwaigFunction {
       const result = await this.handler(args, rawData ?? {});
       if (result instanceof FunctionResult) {
         return result.toDict();
+      }
+      if (typeof result === 'object' && result !== null && !('response' in result)) {
+        // Plain object without a "response" key — matches Python's behavior:
+        // `elif isinstance(result, dict): return FunctionResult("Function completed successfully").to_dict()`
+        // Python replaces such dicts entirely; do the same here.
+        return new FunctionResult('Function completed successfully').toDict();
       }
       if (typeof result === 'object' && result !== null) {
         return result as Record<string, unknown>;

--- a/src/SwaigFunction.ts
+++ b/src/SwaigFunction.ts
@@ -140,6 +140,76 @@ export class SwaigFunction {
   }
 
   /**
+   * Validate arguments against the parameter JSON schema.
+   *
+   * Performs a best-effort validation: checks that required properties are
+   * present and that the argument types match the declared schema types.
+   * If the schema has no properties, validation is skipped and the args are
+   * considered valid.
+   *
+   * @param args - Arguments to validate.
+   * @returns A tuple of `[isValid, errors]`. When no validation is needed
+   *          (empty schema), returns `[true, []]`.
+   */
+  validateArgs(args: Record<string, unknown>): [boolean, string[]] {
+    const schema = this.ensureParameterStructure();
+    const properties = schema['properties'] as Record<string, Record<string, unknown>> | undefined;
+    if (!properties || Object.keys(properties).length === 0) {
+      return [true, []];
+    }
+
+    const errors: string[] = [];
+
+    // Check required fields
+    const requiredFields = (schema['required'] as string[] | undefined) ?? [];
+    for (const field of requiredFields) {
+      if (!(field in args)) {
+        errors.push(`'${field}' is a required property`);
+      }
+    }
+
+    // Type-check each provided arg against schema
+    for (const [key, value] of Object.entries(args)) {
+      const propSchema = properties[key];
+      if (!propSchema) continue;
+
+      const expectedType = propSchema['type'] as string | undefined;
+      if (!expectedType) continue;
+
+      const actual = value;
+      let typeOk = true;
+
+      switch (expectedType) {
+        case 'string':
+          typeOk = typeof actual === 'string';
+          break;
+        case 'number':
+        case 'integer':
+          typeOk = typeof actual === 'number';
+          break;
+        case 'boolean':
+          typeOk = typeof actual === 'boolean';
+          break;
+        case 'array':
+          typeOk = Array.isArray(actual);
+          break;
+        case 'object':
+          typeOk = typeof actual === 'object' && actual !== null && !Array.isArray(actual);
+          break;
+        default:
+          // Unknown type — skip
+          break;
+      }
+
+      if (!typeOk && actual !== null && actual !== undefined) {
+        errors.push(`'${key}' expected type '${expectedType}' but got '${typeof actual}'`);
+      }
+    }
+
+    return errors.length === 0 ? [true, []] : [false, errors];
+  }
+
+  /**
    * Invoke the handler with the given arguments and return a serialized result.
    * @param args - Parsed arguments from the AI.
    * @param rawData - The full raw request payload.

--- a/src/SwaigFunction.ts
+++ b/src/SwaigFunction.ts
@@ -2,8 +2,11 @@
  * SwaigFunction - Wraps a handler function with metadata for SWAIG registration.
  */
 
+import Ajv from 'ajv';
 import { FunctionResult } from './FunctionResult.js';
 import { getLogger } from './Logger.js';
+
+const ajv = new Ajv({ allErrors: true });
 
 const log = getLogger('SwaigFunction');
 
@@ -140,12 +143,17 @@ export class SwaigFunction {
   }
 
   /**
-   * Validate arguments against the parameter JSON schema.
+   * Validate arguments against the parameter JSON schema using full
+   * JSON Schema Draft-7 validation (via ajv).
    *
-   * Performs a best-effort validation: checks that required properties are
-   * present and that the argument types match the declared schema types.
+   * Mirrors Python's `validate_args` which tries `jsonschema_rs` (Rust-based
+   * Draft-7 validator) then falls back to `jsonschema` (pure Python Draft-7).
+   * All JSON Schema constraint keywords are honoured: `required`, `type`,
+   * `minLength`, `maxLength`, `pattern`, `format`, `minimum`, `maximum`,
+   * `enum`, `anyOf`, `oneOf`, `$ref`, nested object/array validation, etc.
+   *
    * If the schema has no properties, validation is skipped and the args are
-   * considered valid.
+   * considered valid — matching Python's early-return path.
    *
    * @param args - Arguments to validate.
    * @returns A tuple of `[isValid, errors]`. When no validation is needed
@@ -153,60 +161,23 @@ export class SwaigFunction {
    */
   validateArgs(args: Record<string, unknown>): [boolean, string[]] {
     const schema = this.ensureParameterStructure();
-    const properties = schema['properties'] as Record<string, Record<string, unknown>> | undefined;
+    const properties = schema['properties'] as Record<string, unknown> | undefined;
     if (!properties || Object.keys(properties).length === 0) {
       return [true, []];
     }
 
-    const errors: string[] = [];
-
-    // Check required fields
-    const requiredFields = (schema['required'] as string[] | undefined) ?? [];
-    for (const field of requiredFields) {
-      if (!(field in args)) {
-        errors.push(`'${field}' is a required property`);
-      }
+    const validate = ajv.compile(schema);
+    const valid = validate(args);
+    if (valid) {
+      return [true, []];
     }
-
-    // Type-check each provided arg against schema
-    for (const [key, value] of Object.entries(args)) {
-      const propSchema = properties[key];
-      if (!propSchema) continue;
-
-      const expectedType = propSchema['type'] as string | undefined;
-      if (!expectedType) continue;
-
-      const actual = value;
-      let typeOk = true;
-
-      switch (expectedType) {
-        case 'string':
-          typeOk = typeof actual === 'string';
-          break;
-        case 'number':
-        case 'integer':
-          typeOk = typeof actual === 'number';
-          break;
-        case 'boolean':
-          typeOk = typeof actual === 'boolean';
-          break;
-        case 'array':
-          typeOk = Array.isArray(actual);
-          break;
-        case 'object':
-          typeOk = typeof actual === 'object' && actual !== null && !Array.isArray(actual);
-          break;
-        default:
-          // Unknown type — skip
-          break;
-      }
-
-      if (!typeOk && actual !== null && actual !== undefined) {
-        errors.push(`'${key}' expected type '${expectedType}' but got '${typeof actual}'`);
-      }
-    }
-
-    return errors.length === 0 ? [true, []] : [false, errors];
+    const errors = (validate.errors ?? []).map((e) => {
+      // Produce messages similar to Python's jsonschema:
+      // "instancePath message" or just "message" when path is empty.
+      const path = e.instancePath ? e.instancePath.replace(/^\//, '').replace(/\//g, '.') : '';
+      return path ? `'${path}' ${e.message}` : (e.message ?? String(e));
+    });
+    return [false, errors];
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export type { OnRequestCallback, SWMLServiceOptions } from './SWMLService.js';
 
 // Tool results & functions
 export { FunctionResult } from './FunctionResult.js';
+/** @deprecated Use {@link FunctionResult} instead. */
+export { FunctionResult as SwaigFunctionResult } from './FunctionResult.js';
 export type { PaymentPrompt, PaymentAction, PaymentParameter } from './FunctionResult.js';
 export { SwaigFunction } from './SwaigFunction.js';
 export type { SwaigHandler, SwaigFunctionOptions } from './SwaigFunction.js';

--- a/src/livewire/index.ts
+++ b/src/livewire/index.ts
@@ -502,18 +502,37 @@ export namespace plugins {
   }
 
   export class OpenAILLM {
-    constructor(_opts?: any) {}
+    model: string;
+    constructor(_opts?: any) {
+      this.model = ((_opts as any)?.model as string) ?? '';
+      globalNoop.once(
+        'openai_llm',
+        'OpenAILLM(): model selection is mapped to SignalWire AI params -- OpenAI plugin wrapper is a no-op',
+      );
+    }
   }
 
   export class CartesiaTTS {
-    constructor(_opts?: any) {}
+    constructor(_opts?: any) {
+      globalNoop.once(
+        'cartesia_tts',
+        "CartesiaTTS: SignalWire's control plane handles the full media pipeline at scale",
+      );
+    }
   }
 
   export class ElevenLabsTTS {
-    constructor(_opts?: any) {}
+    constructor(_opts?: any) {
+      globalNoop.once(
+        'elevenlabs_tts',
+        "ElevenLabsTTS: SignalWire's control plane handles the full media pipeline at scale",
+      );
+    }
   }
 
   export class SileroVAD {
+    constructor(_opts?: Record<string, unknown>) {}
+
     static load(): SileroVAD {
       globalNoop.once(
         'vad_plugin',
@@ -531,7 +550,9 @@ export namespace plugins {
 /** Stub inference types matching LiveKit's inference namespace. */
 export namespace inference {
   export class STT {
-    constructor(_model: string, _opts?: any) {
+    model: string;
+    constructor(model: string = '', _opts?: any) {
+      this.model = model;
       globalNoop.once(
         'inference_stt',
         'inference.STT: SignalWire\'s control plane handles speech recognition at scale',
@@ -540,11 +561,16 @@ export namespace inference {
   }
 
   export class LLM {
-    constructor(_model: string, _opts?: any) {}
+    model: string;
+    constructor(model: string = '', _opts?: any) {
+      this.model = model;
+    }
   }
 
   export class TTS {
-    constructor(_model: string, _opts?: any) {
+    model: string;
+    constructor(model: string = '', _opts?: any) {
+      this.model = model;
       globalNoop.once(
         'inference_tts',
         'inference.TTS: SignalWire\'s control plane handles text-to-speech at scale',

--- a/src/relay/Action.ts
+++ b/src/relay/Action.ts
@@ -86,13 +86,17 @@ export class Action {
     }
   }
 
-  /** Wait for the action to complete. Returns the terminal event. */
+  /**
+   * Wait for the action to complete. Returns the terminal event.
+   * @param timeout - Maximum time to wait in seconds (matches Python SDK convention).
+   */
   async wait(timeout?: number): Promise<RelayEvent> {
     if (timeout != null) {
+      const ms = timeout * 1000;
       return new Promise<RelayEvent>((resolve, reject) => {
         const timer = setTimeout(() => {
-          reject(new Error(`Action wait timed out after ${timeout}ms`));
-        }, timeout);
+          reject(new Error(`Action wait timed out after ${timeout}s`));
+        }, ms);
 
         this._done.promise.then(
           (v) => { clearTimeout(timer); resolve(v); },

--- a/src/relay/Message.ts
+++ b/src/relay/Message.ts
@@ -74,13 +74,17 @@ export class Message {
     this._listeners.push(handler);
   }
 
-  /** Wait for the message to reach a terminal state. */
+  /**
+   * Wait for the message to reach a terminal state.
+   * @param timeout - Maximum time to wait in seconds (matches Python SDK convention).
+   */
   async wait(timeout?: number): Promise<RelayEvent> {
     if (timeout != null) {
+      const ms = timeout * 1000;
       return new Promise<RelayEvent>((resolve, reject) => {
         const timer = setTimeout(() => {
-          reject(new Error(`Message wait timed out after ${timeout}ms`));
-        }, timeout);
+          reject(new Error(`Message wait timed out after ${timeout}s`));
+        }, ms);
 
         this._done.promise.then(
           (v) => { clearTimeout(timer); resolve(v); },

--- a/tests/PomBuilder.test.ts
+++ b/tests/PomBuilder.test.ts
@@ -121,6 +121,70 @@ describe('PomBuilder', () => {
   });
 });
 
+describe('addPomAsSubsection', () => {
+  it('appends sections of another PomBuilder by target title', () => {
+    const target = new PomBuilder().addSection('Parent', { body: 'parent body' });
+    const other = new PomBuilder()
+      .addSection('Child A', { body: 'a' })
+      .addSection('Child B', { bullets: ['x', 'y'] });
+
+    target.addPomAsSubsection('Parent', other);
+
+    const parent = target.getSection('Parent')!;
+    expect(parent.subsections.length).toBe(2);
+    expect(parent.subsections[0].title).toBe('Child A');
+    expect(parent.subsections[0].body).toBe('a');
+    expect(parent.subsections[1].title).toBe('Child B');
+    expect(parent.subsections[1].bullets).toEqual(['x', 'y']);
+  });
+
+  it('appends sections when target is a PomSection reference', () => {
+    const target = new PomBuilder().addSection('Parent');
+    const parent = target.getSection('Parent')!;
+    const other = new PomBuilder()
+      .addSection('One')
+      .addSection('Two');
+
+    target.addPomAsSubsection(parent, other);
+
+    expect(parent.subsections.length).toBe(2);
+    expect(parent.subsections[0].title).toBe('One');
+    expect(parent.subsections[1].title).toBe('Two');
+  });
+
+  it('throws when target title does not match any section', () => {
+    const target = new PomBuilder().addSection('Exists');
+    const other = new PomBuilder().addSection('Anything');
+
+    expect(() => target.addPomAsSubsection('Missing', other)).toThrow(
+      "No section with title 'Missing' found.",
+    );
+  });
+
+  it('preserves order and count of appended sections', () => {
+    const target = new PomBuilder().addSection('Parent');
+    const other = new PomBuilder()
+      .addSection('First')
+      .addSection('Second')
+      .addSection('Third');
+
+    target.addPomAsSubsection('Parent', other);
+
+    const parent = target.getSection('Parent')!;
+    expect(parent.subsections.length).toBe(3);
+    expect(parent.subsections.map((s) => s.title)).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('returns this for fluent chaining', () => {
+    const builder = new PomBuilder().addSection('Parent');
+    const other = new PomBuilder().addSection('Child');
+
+    const result = builder.addPomAsSubsection('Parent', other);
+
+    expect(result).toBe(builder);
+  });
+});
+
 describe('SwmlBuilder', () => {
   it('creates empty document', () => {
     const b = new SwmlBuilder();

--- a/tests/relay/Action.test.ts
+++ b/tests/relay/Action.test.ts
@@ -95,7 +95,7 @@ describe('Action (base)', () => {
     // Resolve it
     a._checkEvent(makeEvent('calling.call.play', { state: 'finished' }));
 
-    const result = await a.wait(5000);
+    const result = await a.wait(5);
     expect(result.eventType).toBe('calling.call.play');
   });
 
@@ -103,7 +103,8 @@ describe('Action (base)', () => {
     const call = mockCall();
     const a = new Action(call, 'ctrl1', 'calling.call.play', ['finished']);
 
-    await expect(a.wait(10)).rejects.toThrow('timed out');
+    // timeout is in seconds (0.01s = 10ms)
+    await expect(a.wait(0.01)).rejects.toThrow('timed out');
   });
 });
 

--- a/tests/relay/Message.test.ts
+++ b/tests/relay/Message.test.ts
@@ -144,14 +144,15 @@ describe('Message', () => {
     });
     await dispatchPromise;
 
-    const event = await msg.wait(5000);
+    const event = await msg.wait(5);
     expect(event).toBeInstanceOf(RelayEvent);
   });
 
   it('wait with timeout rejects on timeout', async () => {
     const msg = new Message({ messageId: 'm1' });
 
-    await expect(msg.wait(10)).rejects.toThrow('timed out');
+    // timeout is in seconds (0.01s = 10ms)
+    await expect(msg.wait(0.01)).rejects.toThrow('timed out');
   });
 
   it('toString returns human-readable string', () => {


### PR DESCRIPTION
## What this PR does

Aligns 14 smaller core interfaces with Python — 21 gaps covering builders, inference plugins, Action subclasses, and misc utilities.

## Changes

**PomBuilder:** added `renderXml()` (PomSection + PomBuilder), `toJson()`, `static fromSections()` matching Python serialization.

**SWAIGFunction:** added `validateArgs()` with required-field + type-checking validation against JSON schema.

**Inference stubs (InferenceLLM/STT/TTS):** added `model` property with default `""` matching Python.

**OpenAILLM:** `model` property from opts + noop warning log.

**CartesiaTTS, ElevenLabsTTS:** noop warning logs matching Python.

**SileroVAD:** explicit constructor.

**Action subclasses (Action, TapAction, PayAction) + Message:** `wait(timeout)` changed from milliseconds to seconds matching Python's `asyncio.wait_for` convention. Tests updated.

**FunctionResult:** `SwaigFunctionResult` backwards-compat alias.

## Verification

- `npm run build` passes
- 1437/1437 tests pass

Closes #5
Closes #14
Closes #24
Closes #26
Closes #29
Closes #30
Closes #31
Closes #38
Closes #40
Closes #41
Closes #44
Closes #54
Closes #59
Closes #64