### PR TITLE
Align Skills batch 2 (medium-gap skills) with Python SDK

### DIFF
--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -236,7 +236,7 @@ These skills involve complex integrations, multiple API calls, or advanced proce
 | Skill Name | Class | Description | Tools | Required Env Vars | Config Options |
 |---|---|---|---|---|---|
 | `web_search` | `WebSearchSkill` | Google Custom Search | `web_search` | `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_CX` | `max_results`, `safe_search` |
-| `wikipedia_search` | `WikipediaSearchSkill` | Wikipedia article summaries | `search_wikipedia` | None | None |
+| `wikipedia_search` | `WikipediaSearchSkill` | Wikipedia article summaries | `search_wiki` | None | `num_results`, `no_results_message`, `language`, `max_content_length` |
 | `google_maps` | `GoogleMapsSkill` | Directions and place search | `get_directions`, `find_place` | `GOOGLE_MAPS_API_KEY` | `default_mode` |
 | `datasphere` | `DataSphereSkill` | SignalWire DataSphere semantic search | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `max_results`, `distance_threshold` |
 | `datasphere_serverless` | `DataSphereServerlessSkill` | DataSphere via server-side DataMap | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `max_results`, `distance_threshold`, `document_id` |

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -53,7 +53,7 @@ const agent = new AgentBase({ name: 'my-agent' });
 
 // Add skills (async)
 await agent.addSkill(new DateTimeSkill());
-await agent.addSkill(new WebSearchSkill({ max_results: 3 }));
+await agent.addSkill(new WebSearchSkill({ num_results: 3 }));
 ```
 
 When `addSkill()` is called, the agent:
@@ -235,11 +235,11 @@ These skills involve complex integrations, multiple API calls, or advanced proce
 
 | Skill Name | Class | Description | Tools | Required Env Vars | Config Options |
 |---|---|---|---|---|---|
-| `web_search` | `WebSearchSkill` | Google Custom Search | `web_search` | `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_CX` | `max_results`, `safe_search` |
+| `web_search` | `WebSearchSkill` | Google Custom Search | `web_search` | `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID` | `num_results`, `tool_name`, `no_results_message`, `safe_search`, `delay`, `max_content_length`, `oversample_factor`, `min_quality_score` |
 | `wikipedia_search` | `WikipediaSearchSkill` | Wikipedia article summaries | `search_wiki` | None | `num_results`, `no_results_message`, `language`, `max_content_length` |
 | `google_maps` | `GoogleMapsSkill` | Directions and place search | `get_directions`, `find_place` | `GOOGLE_MAPS_API_KEY` | `default_mode` |
-| `datasphere` | `DataSphereSkill` | SignalWire DataSphere semantic search | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `max_results`, `distance_threshold` |
-| `datasphere_serverless` | `DataSphereServerlessSkill` | DataSphere via server-side DataMap | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `max_results`, `distance_threshold`, `document_id` |
+| `datasphere` | `DataSphereSkill` | SignalWire DataSphere semantic search | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `count`, `distance`, `document_id`, `tags`, `language`, `pos_to_expand`, `max_synonyms`, `no_results_message` |
+| `datasphere_serverless` | `DataSphereServerlessSkill` | DataSphere via server-side DataMap | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `count`, `distance`, `document_id`, `tags`, `language`, `pos_to_expand`, `max_synonyms`, `no_results_message` |
 | `native_vector_search` | `NativeVectorSearchSkill` | In-memory TF-IDF document search | `search_documents` | None | `documents` |
 | `spider` | `SpiderSkill` | Web page scraping via Spider API | `scrape_url` | `SPIDER_API_KEY` | `max_content_length` |
 | `claude_skills` | `ClaudeSkillsSkill` | Load Claude SKILL.md files as tools | (dynamic) | None | `skills_path`, `include`, `exclude`, `tool_prefix` |
@@ -251,7 +251,7 @@ These skills involve complex integrations, multiple API calls, or advanced proce
 ```typescript
 import { WebSearchSkill } from '@signalwire/sdk/skills/builtin';
 await agent.addSkill(new WebSearchSkill({
-  max_results: 5,
+  num_results: 5,
   safe_search: 'medium', // 'off' | 'medium' | 'high'
 }));
 ```
@@ -275,8 +275,9 @@ await agent.addSkill(new GoogleMapsSkill({ default_mode: 'walking' }));
 ```typescript
 import { DataSphereSkill } from '@signalwire/sdk/skills/builtin';
 await agent.addSkill(new DataSphereSkill({
-  max_results: 5,
-  distance_threshold: 0.7, // 0-1, lower is more similar
+  document_id: 'my-doc-id',
+  count: 5,
+  distance: 3.0, // 0-10, lower is more similar
 }));
 ```
 
@@ -285,9 +286,9 @@ await agent.addSkill(new DataSphereSkill({
 ```typescript
 import { DataSphereServerlessSkill } from '@signalwire/sdk/skills/builtin';
 await agent.addSkill(new DataSphereServerlessSkill({
-  max_results: 5,
-  distance_threshold: 0.7,
-  document_id: 'specific-doc-id', // optional: restrict to one document
+  document_id: 'specific-doc-id',
+  count: 5,
+  distance: 3.0, // 0-10, lower is more similar
 }));
 ```
 
@@ -820,7 +821,7 @@ const missing = skill.validateEnvVars();
 if (missing.length > 0) {
   console.warn(`Missing env vars: ${missing.join(', ')}`);
 }
-// missing might be ['GOOGLE_SEARCH_API_KEY', 'GOOGLE_SEARCH_CX']
+// missing might be ['GOOGLE_SEARCH_API_KEY', 'GOOGLE_SEARCH_ENGINE_ID']
 ```
 
 ### Runtime Handling
@@ -848,7 +849,7 @@ This two-layer approach (warn at registration, error at call time) allows agents
 | `WEATHER_API_KEY` | `weather_api` |
 | `API_NINJAS_KEY` | `api_ninjas_trivia` |
 | `GOOGLE_SEARCH_API_KEY` | `web_search` |
-| `GOOGLE_SEARCH_CX` | `web_search` |
+| `GOOGLE_SEARCH_ENGINE_ID` | `web_search` |
 | `GOOGLE_MAPS_API_KEY` | `google_maps` |
 | `SIGNALWIRE_PROJECT_ID` | `datasphere`, `datasphere_serverless` |
 | `SIGNALWIRE_TOKEN` | `datasphere`, `datasphere_serverless` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "signalwire-agents",
-  "version": "0.1.0",
+  "name": "@signalwire/sdk",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "signalwire-agents",
-      "version": "0.1.0",
+      "name": "@signalwire/sdk",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.11.0",

--- a/src/skills/builtin/datasphere.ts
+++ b/src/skills/builtin/datasphere.ts
@@ -1,9 +1,10 @@
 /**
  * DataSphere Skill - Searches SignalWire DataSphere for knowledge base content.
  *
- * Tier 3 built-in skill: requires SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN,
- * and SIGNALWIRE_SPACE environment variables. Uses the SignalWire DataSphere
- * API to perform semantic search across uploaded documents.
+ * Tier 3 built-in skill matching the Python SDK. All credentials (`space_name`,
+ * `project_id`, `token`) and `document_id` are supplied via skill params. Env
+ * var fallbacks (`SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE`)
+ * are honored when the corresponding param is not set.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -19,12 +20,20 @@ import { getLogger } from '../../Logger.js';
 
 const log = getLogger('DataSphereSkill');
 
-/** A single search result from the DataSphere API. */
-interface DataSphereResult {
+const DEFAULT_NO_RESULTS_MESSAGE =
+  "I couldn't find any relevant information for '{query}' in the knowledge base. " +
+  'Try rephrasing your question or asking about a different topic.';
+
+/** A single chunk returned by the DataSphere search API. */
+interface DataSphereChunk {
   /** Matched text chunk content. */
-  text: string;
+  text?: string;
+  /** Alternative content field name. */
+  content?: string;
+  /** Alternative chunk field name. */
+  chunk?: string;
   /** Distance score (lower is more similar). */
-  score: number;
+  score?: number;
   /** ID of the source document. */
   document_id?: string;
   /** Document metadata. */
@@ -35,8 +44,8 @@ interface DataSphereResult {
 
 /** Response shape from the SignalWire DataSphere search API. */
 interface DataSphereResponse {
-  /** Array of search results. */
-  results?: DataSphereResult[];
+  /** Array of matching chunks. The API returns `chunks`, not `results`. */
+  chunks?: DataSphereChunk[];
   /** Error message if the request failed. */
   error?: string;
   /** Additional error information. */
@@ -46,9 +55,10 @@ interface DataSphereResponse {
 /**
  * Searches SignalWire DataSphere for knowledge base content using semantic search.
  *
- * Tier 3 built-in skill. Requires `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`,
- * and `SIGNALWIRE_SPACE` environment variables. Supports `max_results` and
- * `distance_threshold` config options.
+ * Tier 3 built-in skill. Credentials can be supplied via params or fall back to
+ * `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, and `SIGNALWIRE_SPACE` environment
+ * variables. Supports `count`, `distance`, `tags`, `language`, `pos_to_expand`,
+ * `max_synonyms`, and `no_results_message` config options.
  */
 export class DataSphereSkill extends SkillBase {
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
@@ -62,131 +72,273 @@ export class DataSphereSkill extends SkillBase {
       },
       space_name: {
         type: 'string',
-        description: 'SignalWire space name.',
+        description:
+          "SignalWire space name (e.g., 'mycompany' from mycompany.signalwire.com)",
+        required: true,
         env_var: 'SIGNALWIRE_SPACE',
       },
       project_id: {
         type: 'string',
-        description: 'SignalWire project ID.',
+        description: 'SignalWire project ID',
+        required: true,
         env_var: 'SIGNALWIRE_PROJECT_ID',
       },
       token: {
         type: 'string',
-        description: 'SignalWire auth token.',
+        description: 'SignalWire API token',
+        required: true,
         hidden: true,
         env_var: 'SIGNALWIRE_TOKEN',
       },
       document_id: {
         type: 'string',
-        description: 'Optional: restrict search to a specific document ID.',
+        description: 'DataSphere document ID to search within',
+        required: true,
       },
-      max_results: {
-        type: 'number',
-        description: 'Maximum number of results to return.',
-        default: 5,
+      count: {
+        type: 'integer',
+        description: 'Number of search results to return',
+        default: 1,
+        min: 1,
+        max: 10,
       },
-      distance_threshold: {
+      distance: {
         type: 'number',
-        description: 'Maximum distance threshold for results (0-1).',
-        default: 0.7,
+        description:
+          'Maximum distance threshold for results (lower is more relevant)',
+        default: 3.0,
         min: 0,
-        max: 1,
+        max: 10,
+      },
+      tags: {
+        type: 'array',
+        description: 'Tags to filter search results',
+        items: { type: 'string' },
+      },
+      language: {
+        type: 'string',
+        description: "Language code for query expansion (e.g., 'en', 'es')",
+      },
+      pos_to_expand: {
+        type: 'array',
+        description: 'Parts of speech to expand with synonyms',
+        items: { type: 'string', enum: ['NOUN', 'VERB', 'ADJ', 'ADV'] },
+      },
+      max_synonyms: {
+        type: 'integer',
+        description: 'Maximum number of synonyms to use for query expansion',
+        min: 1,
+        max: 10,
+      },
+      no_results_message: {
+        type: 'string',
+        description: 'Message to return when no results are found',
+        default: DEFAULT_NO_RESULTS_MESSAGE,
       },
     };
   }
 
   /**
-   * @param config - Optional configuration; supports `max_results` and `distance_threshold`.
+   * @param config - Optional configuration; supports `space_name`, `project_id`,
+   *   `token`, `document_id`, `tool_name`, `count`, `distance`, `tags`,
+   *   `language`, `pos_to_expand`, `max_synonyms`, `no_results_message`.
    */
   constructor(config?: SkillConfig) {
     super('datasphere', config);
   }
 
+  /**
+   * Instance key for the SkillManager. Defaults to `datasphere_search_knowledge`,
+   * matching the Python SDK default. When `tool_name` is set, uses
+   * `datasphere_<tool_name>`.
+   */
   override getInstanceKey(): string {
-    const toolName = this.getConfig<string | undefined>('tool_name', undefined);
-    return toolName ? `${this.skillName}_${toolName}` : this.skillName;
+    const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
+    return `${this.skillName}_${toolName}`;
   }
 
   /** @returns Manifest declaring SignalWire credentials as required env vars. */
   getManifest(): SkillManifest {
     return {
       name: 'datasphere',
-      description:
-        'Searches SignalWire DataSphere for knowledge base content using semantic search across uploaded documents.',
+      description: 'Search knowledge using SignalWire DataSphere RAG stack',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'datasphere', 'signalwire', 'knowledge', 'rag', 'external'],
       requiredEnvVars: ['SIGNALWIRE_PROJECT_ID', 'SIGNALWIRE_TOKEN', 'SIGNALWIRE_SPACE'],
       configSchema: {
-        max_results: {
-          type: 'number',
-          description: 'Maximum number of results to return. Defaults to 5.',
-          default: 5,
+        space_name: {
+          type: 'string',
+          description: 'SignalWire space name.',
         },
-        distance_threshold: {
+        project_id: {
+          type: 'string',
+          description: 'SignalWire project ID.',
+        },
+        token: {
+          type: 'string',
+          description: 'SignalWire API token.',
+        },
+        document_id: {
+          type: 'string',
+          description: 'DataSphere document ID to search within.',
+        },
+        count: {
+          type: 'integer',
+          description: 'Number of results to return. Defaults to 1. Range 1-10.',
+          default: 1,
+        },
+        distance: {
           type: 'number',
           description:
-            'Maximum distance threshold for results (0-1, lower is more similar). Defaults to 0.7.',
-          default: 0.7,
+            'Maximum distance threshold (lower is more relevant). Defaults to 3.0. Range 0-10.',
+          default: 3.0,
+        },
+        tags: {
+          type: 'array',
+          description: 'Tags to filter search results.',
+        },
+        language: {
+          type: 'string',
+          description: 'Language code for query expansion.',
+        },
+        pos_to_expand: {
+          type: 'array',
+          description: 'Parts of speech to expand with synonyms.',
+        },
+        max_synonyms: {
+          type: 'integer',
+          description: 'Maximum number of synonyms (1-10).',
+        },
+        no_results_message: {
+          type: 'string',
+          description:
+            'Message returned when no results are found. Supports {query} interpolation.',
         },
       },
     };
   }
 
-  /** @returns A single `search_datasphere` tool that performs semantic search on uploaded documents. */
+  /**
+   * Global data injected into the agent's SWML context. Matches Python's
+   * `get_global_data()` so downstream consumers can detect DataSphere
+   * availability, the configured `document_id`, and the knowledge provider.
+   */
+  override getGlobalData(): Record<string, unknown> {
+    return {
+      datasphere_enabled: true,
+      document_id: this.getConfig<string | undefined>('document_id', undefined),
+      knowledge_provider: 'SignalWire DataSphere',
+    };
+  }
+
+  /** Resolve the tool name (defaults to `search_datasphere`, TS convention). */
+  private getToolName(): string {
+    return this.getConfig<string>('tool_name', 'search_datasphere');
+  }
+
+  /** @returns A single tool (named via `tool_name`) that performs semantic search. */
   getTools(): SkillToolDefinition[] {
-    const maxResults = this.getConfig<number>('max_results', 5);
-    const distanceThreshold = this.getConfig<number>('distance_threshold', 0.7);
+    const count = this.getConfig<number>('count', 1);
+    const distance = this.getConfig<number>('distance', 3.0);
+    const configDocumentId = this.getConfig<string | undefined>('document_id', undefined);
+    const tags = this.getConfig<string[] | undefined>('tags', undefined);
+    const language = this.getConfig<string | undefined>('language', undefined);
+    const posToExpand = this.getConfig<string[] | undefined>('pos_to_expand', undefined);
+    const maxSynonyms = this.getConfig<number | undefined>('max_synonyms', undefined);
+    const noResultsMessage = this.getConfig<string>(
+      'no_results_message',
+      DEFAULT_NO_RESULTS_MESSAGE,
+    );
+    const toolName = this.getToolName();
 
     return [
       {
-        name: 'search_datasphere',
+        name: toolName,
         description:
-          'Search the SignalWire DataSphere knowledge base for relevant information. Returns the most relevant text chunks from uploaded documents.',
+          'Search the knowledge base for information on any topic and return relevant results.',
         parameters: {
           query: {
             type: 'string',
-            description: 'The question or topic to search for in the knowledge base.',
+            description:
+              "The search query — what information you're looking for in the knowledge base.",
           },
           document_id: {
             type: 'string',
             description:
-              'Optional: limit search to a specific document by its ID.',
+              'Optional: limit this search to a specific document by its ID (overrides the skill-level default).',
           },
         },
         required: ['query'],
         handler: async (args: Record<string, unknown>) => {
-          const query = args.query as string | undefined;
-          const documentId = args.document_id as string | undefined;
+          const rawQuery = args['query'];
+          const perCallDocumentId = args['document_id'];
 
-          if (!query || typeof query !== 'string' || query.trim().length === 0) {
+          if (
+            !rawQuery ||
+            typeof rawQuery !== 'string' ||
+            rawQuery.trim().length === 0
+          ) {
             return new FunctionResult(
-              'Please provide a query to search the knowledge base.',
+              'Please provide a search query. What would you like me to search for in the knowledge base?',
             );
           }
 
-          const projectId = process.env['SIGNALWIRE_PROJECT_ID'];
-          const token = process.env['SIGNALWIRE_TOKEN'];
-          const space = process.env['SIGNALWIRE_SPACE'];
+          const query = rawQuery.trim();
+
+          const projectId =
+            this.getConfig<string | undefined>('project_id', undefined) ??
+            process.env['SIGNALWIRE_PROJECT_ID'];
+          const token =
+            this.getConfig<string | undefined>('token', undefined) ??
+            process.env['SIGNALWIRE_TOKEN'];
+          const space =
+            this.getConfig<string | undefined>('space_name', undefined) ??
+            process.env['SIGNALWIRE_SPACE'];
 
           if (!projectId || !token || !space) {
             return new FunctionResult(
-              'DataSphere is not configured. The SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN, and SIGNALWIRE_SPACE environment variables are required.',
+              'DataSphere is not configured. The SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN, and SIGNALWIRE_SPACE environment variables (or equivalent config params) are required.',
             );
           }
+
+          // Resolve document_id: per-call override > config default.
+          let documentId: string | undefined;
+          if (
+            typeof perCallDocumentId === 'string' &&
+            perCallDocumentId.trim().length > 0
+          ) {
+            documentId = perCallDocumentId.trim();
+          } else {
+            documentId = configDocumentId;
+          }
+
+          log.info('datasphere_search', { query, document_id: documentId });
 
           try {
             const spaceHost = space.includes('.') ? space : `${space}.signalwire.com`;
             const url = `https://${spaceHost}/api/datasphere/documents/search`;
 
             const requestBody: Record<string, unknown> = {
-              query: query.trim(),
-              count: maxResults,
-              distance: distanceThreshold,
+              query_string: query,
+              count,
+              distance,
             };
 
-            if (documentId && typeof documentId === 'string' && documentId.trim().length > 0) {
-              requestBody['document_id'] = documentId.trim();
+            if (documentId) {
+              requestBody['document_id'] = documentId;
+            }
+            if (tags !== undefined) {
+              requestBody['tags'] = tags;
+            }
+            if (language !== undefined) {
+              requestBody['language'] = language;
+            }
+            if (posToExpand !== undefined) {
+              requestBody['pos_to_expand'] = posToExpand;
+            }
+            if (maxSynonyms !== undefined) {
+              requestBody['max_synonyms'] = maxSynonyms;
             }
 
             const authHeader = Buffer.from(`${projectId}:${token}`).toString('base64');
@@ -199,51 +351,58 @@ export class DataSphereSkill extends SkillBase {
                 method: 'POST',
                 headers: {
                   'Content-Type': 'application/json',
-                  'Authorization': `Basic ${authHeader}`,
+                  Accept: 'application/json',
+                  Authorization: `Basic ${authHeader}`,
                 },
                 body: JSON.stringify(requestBody),
                 signal: controller.signal,
               });
-            } finally {
+            } catch (err) {
               clearTimeout(timeout);
+              if (err instanceof Error && err.name === 'AbortError') {
+                log.error('datasphere_timeout');
+                return new FunctionResult(
+                  'Sorry, the knowledge search timed out. Please try again.',
+                );
+              }
+              throw err;
             }
+            clearTimeout(timeout);
 
             if (!response.ok) {
               log.error('datasphere_api_error', { status: response.status });
               return new FunctionResult(
-                'The knowledge base search service encountered an error. Please try again later.',
+                'Sorry, there was an error accessing the knowledge base. Please try again later.',
               );
             }
 
             const data = (await response.json()) as DataSphereResponse;
 
-            if (!data.results || data.results.length === 0) {
+            if (!data || typeof data !== 'object') {
+              log.warn('datasphere_invalid_response');
               return new FunctionResult(
-                `No relevant results found in the knowledge base for "${query}".`,
+                DataSphereSkill._formatNoResultsMessage(noResultsMessage, query),
               );
             }
 
-            const parts: string[] = [
-              `Knowledge base results for "${query}" (${data.results.length} results):`,
-              '',
-            ];
+            // DataSphere API returns 'chunks', not 'results'.
+            const chunks = data.chunks ?? [];
 
-            for (let i = 0; i < data.results.length; i++) {
-              const result = data.results[i];
-              const score = (1 - result.score).toFixed(2);
-              parts.push(`--- Result ${i + 1} (relevance: ${score}) ---`);
-              parts.push(result.text.trim());
-              if (result.document_id) {
-                parts.push(`[Document: ${result.document_id}]`);
-              }
-              parts.push('');
+            if (chunks.length === 0) {
+              return new FunctionResult(
+                DataSphereSkill._formatNoResultsMessage(noResultsMessage, query),
+              );
             }
 
-            return new FunctionResult(parts.join('\n').trim());
-          } catch (err) {
-            log.error('search_datasphere_failed', { error: err instanceof Error ? err.message : String(err) });
             return new FunctionResult(
-              'The request could not be completed. Please try again.',
+              DataSphereSkill._formatSearchResults(query, chunks),
+            );
+          } catch (err) {
+            log.error('datasphere_search_failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return new FunctionResult(
+              'Sorry, I encountered an error while searching the knowledge base. Please try again later.',
             );
           }
         },
@@ -251,18 +410,59 @@ export class DataSphereSkill extends SkillBase {
     ];
   }
 
+  /** Format search result chunks into a user-facing string. */
+  private static _formatSearchResults(
+    query: string,
+    chunks: DataSphereChunk[],
+  ): string {
+    const header =
+      chunks.length === 1
+        ? `I found 1 result for '${query}':\n\n`
+        : `I found ${chunks.length} results for '${query}':\n\n`;
+
+    const blocks: string[] = [];
+    const separator = '='.repeat(50);
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      let content = `=== RESULT ${i + 1} ===\n`;
+
+      if (typeof chunk.text === 'string') {
+        content += chunk.text;
+      } else if (typeof chunk.content === 'string') {
+        content += chunk.content;
+      } else if (typeof chunk.chunk === 'string') {
+        content += chunk.chunk;
+      } else {
+        content += JSON.stringify(chunk, null, 2);
+      }
+
+      content += `\n${separator}\n\n`;
+      blocks.push(content);
+    }
+
+    return header + blocks.join('\n');
+  }
+
+  /** Apply the `{query}` template to the no-results message. */
+  private static _formatNoResultsMessage(template: string, query: string): string {
+    return template.includes('{query}')
+      ? template.replace(/\{query\}/g, query)
+      : template;
+  }
+
   /** @returns Prompt section describing DataSphere knowledge base search capabilities. */
   protected override _getPromptSections(): SkillPromptSection[] {
+    const toolName = this.getToolName();
     return [
       {
-        title: 'Knowledge Base Search (DataSphere)',
-        body: 'You have access to a knowledge base of documents that can be searched for relevant information.',
+        title: 'Knowledge Search Capability',
+        body: `You can search a knowledge base for information using the ${toolName} tool.`,
         bullets: [
-          'Use the search_datasphere tool when the user asks questions that might be answered by internal documentation or uploaded knowledge.',
-          'Results are ranked by relevance. Higher relevance scores indicate better matches.',
-          'You can optionally search within a specific document by providing its ID.',
-          'Synthesize information from multiple results when appropriate.',
-          'If no results are found, let the user know and suggest rephrasing their question.',
+          `Use the ${toolName} tool when users ask for information that might be in the knowledge base`,
+          'Search for relevant information using clear, specific queries',
+          'Summarize search results in a clear, helpful way',
+          'If no results are found, suggest the user try rephrasing their question',
         ],
       },
     ];

--- a/src/skills/builtin/datasphere_serverless.ts
+++ b/src/skills/builtin/datasphere_serverless.ts
@@ -1,10 +1,11 @@
 /**
  * DataSphere Serverless Skill - Searches SignalWire DataSphere using a DataMap.
  *
- * Tier 3 built-in skill: requires SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN,
- * and SIGNALWIRE_SPACE environment variables. Unlike the standard datasphere
- * skill, this uses a DataMap to execute the search server-side without
- * requiring a webhook endpoint. Ideal for serverless or edge deployments.
+ * Tier 3 built-in skill. Matches the Python SDK's param-driven design: all
+ * credentials (`space_name`, `project_id`, `token`) are supplied via skill
+ * params. No environment variables are strictly required — the platform
+ * resolves `${ENV.SIGNALWIRE_AUTH}` at execution time when the DataMap runs,
+ * but standalone setup works from params alone.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -18,14 +19,17 @@ import type {
 import { FunctionResult } from '../../FunctionResult.js';
 import { DataMap } from '../../DataMap.js';
 
+const DEFAULT_NO_RESULTS_MESSAGE =
+  "I couldn't find any relevant information for '{query}' in the knowledge base. " +
+  'Try rephrasing your question or asking about a different topic.';
+
 /**
  * Searches SignalWire DataSphere using a server-side DataMap for serverless execution.
  *
- * Tier 3 built-in skill. Requires `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`,
- * and `SIGNALWIRE_SPACE` environment variables. Unlike the standard DataSphere
- * skill, this generates a DataMap configuration that SignalWire executes directly
- * without needing a webhook endpoint. Supports `max_results`, `distance_threshold`,
- * and `document_id` config options.
+ * Tier 3 built-in skill that generates a DataMap configuration SignalWire
+ * executes directly, without a webhook endpoint. Supports `document_id`,
+ * `count`, `distance`, `tags`, `language`, `pos_to_expand`, `max_synonyms`,
+ * and `no_results_message` config options.
  */
 export class DataSphereServerlessSkill extends SkillBase {
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
@@ -39,79 +43,176 @@ export class DataSphereServerlessSkill extends SkillBase {
       },
       space_name: {
         type: 'string',
-        description: 'SignalWire space name.',
+        description:
+          "SignalWire space name (e.g., 'mycompany' from mycompany.signalwire.com)",
+        required: true,
         env_var: 'SIGNALWIRE_SPACE',
       },
       project_id: {
         type: 'string',
-        description: 'SignalWire project ID.',
+        description: 'SignalWire project ID',
+        required: true,
         env_var: 'SIGNALWIRE_PROJECT_ID',
       },
       token: {
         type: 'string',
-        description: 'SignalWire auth token.',
+        description: 'SignalWire API token',
+        required: true,
         hidden: true,
         env_var: 'SIGNALWIRE_TOKEN',
       },
       document_id: {
         type: 'string',
-        description: 'Optional: restrict search to a specific document ID.',
+        description: 'DataSphere document ID to search within',
+        required: true,
       },
-      max_results: {
-        type: 'number',
-        description: 'Maximum number of results to return.',
-        default: 5,
+      count: {
+        type: 'integer',
+        description: 'Number of search results to return',
+        default: 1,
+        min: 1,
+        max: 10,
       },
-      distance_threshold: {
+      distance: {
         type: 'number',
-        description: 'Maximum distance threshold for results (0-1).',
-        default: 0.7,
+        description:
+          'Maximum distance threshold for results (lower is more relevant)',
+        default: 3.0,
         min: 0,
-        max: 1,
+        max: 10,
+      },
+      tags: {
+        type: 'array',
+        description: 'Tags to filter search results',
+        items: { type: 'string' },
+      },
+      language: {
+        type: 'string',
+        description: "Language code for query expansion (e.g., 'en', 'es')",
+      },
+      pos_to_expand: {
+        type: 'array',
+        description: 'Parts of speech to expand with synonyms',
+        items: { type: 'string', enum: ['NOUN', 'VERB', 'ADJ', 'ADV'] },
+      },
+      max_synonyms: {
+        type: 'integer',
+        description: 'Maximum number of synonyms to use for query expansion',
+        min: 1,
+        max: 10,
+      },
+      no_results_message: {
+        type: 'string',
+        description: 'Message to return when no results are found',
+        default: DEFAULT_NO_RESULTS_MESSAGE,
       },
     };
   }
 
   /**
-   * @param config - Optional configuration; supports `max_results`, `distance_threshold`, `document_id`.
+   * @param config - Optional configuration; supports `space_name`, `project_id`,
+   *   `token`, `document_id`, `count`, `distance`, `tags`, `language`,
+   *   `pos_to_expand`, `max_synonyms`, `no_results_message`, and `tool_name`.
    */
   constructor(config?: SkillConfig) {
     super('datasphere_serverless', config);
   }
 
+  /**
+   * Instance key for the SkillManager. Defaults to
+   * `datasphere_serverless_search_knowledge`, matching the Python SDK default.
+   * When `tool_name` is set, uses `datasphere_serverless_<tool_name>`.
+   */
   override getInstanceKey(): string {
-    const toolName = this.getConfig<string | undefined>('tool_name', undefined);
-    return toolName ? `${this.skillName}_${toolName}` : this.skillName;
+    const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
+    return `${this.skillName}_${toolName}`;
   }
 
-  /** @returns Manifest declaring SignalWire credentials as required env vars. */
+  /**
+   * @returns Manifest metadata. Environment variables are NOT declared as
+   *   required — credentials can be supplied entirely via params, matching
+   *   Python's `REQUIRED_ENV_VARS = []`.
+   */
   getManifest(): SkillManifest {
     return {
       name: 'datasphere_serverless',
       description:
-        'Searches SignalWire DataSphere using a server-side DataMap. No webhook endpoint required; executes entirely on the SignalWire platform.',
+        'Search knowledge using SignalWire DataSphere with serverless DataMap execution',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'datasphere', 'signalwire', 'knowledge', 'rag', 'serverless', 'datamap'],
-      requiredEnvVars: ['SIGNALWIRE_PROJECT_ID', 'SIGNALWIRE_TOKEN', 'SIGNALWIRE_SPACE'],
       configSchema: {
-        max_results: {
-          type: 'number',
-          description: 'Maximum number of results to return. Defaults to 5.',
-          default: 5,
+        space_name: {
+          type: 'string',
+          description: 'SignalWire space name.',
         },
-        distance_threshold: {
-          type: 'number',
-          description:
-            'Maximum distance threshold for results (0-1, lower is more similar). Defaults to 0.7.',
-          default: 0.7,
+        project_id: {
+          type: 'string',
+          description: 'SignalWire project ID.',
+        },
+        token: {
+          type: 'string',
+          description: 'SignalWire API token.',
         },
         document_id: {
           type: 'string',
-          description: 'Optional: restrict search to a specific document ID.',
+          description: 'DataSphere document ID to search within.',
+        },
+        count: {
+          type: 'integer',
+          description: 'Number of results to return. Defaults to 1. Range 1-10.',
+          default: 1,
+        },
+        distance: {
+          type: 'number',
+          description:
+            'Maximum distance threshold (lower is more relevant). Defaults to 3.0. Range 0-10.',
+          default: 3.0,
+        },
+        tags: {
+          type: 'array',
+          description: 'Tags to filter search results.',
+        },
+        language: {
+          type: 'string',
+          description: 'Language code for query expansion.',
+        },
+        pos_to_expand: {
+          type: 'array',
+          description: 'Parts of speech to expand with synonyms.',
+        },
+        max_synonyms: {
+          type: 'integer',
+          description: 'Maximum number of synonyms (1-10).',
+        },
+        no_results_message: {
+          type: 'string',
+          description:
+            'Message returned when no results are found. Supports {query} interpolation.',
         },
       },
     };
+  }
+
+  /**
+   * Global data injected into the agent's SWML/SWAIG context. Matches
+   * Python's `get_global_data()` shape so downstream consumers can
+   * detect DataSphere availability.
+   */
+  override getGlobalData(): Record<string, unknown> {
+    return {
+      datasphere_serverless_enabled: true,
+      document_id: this.getConfig<string | undefined>('document_id', undefined),
+      knowledge_provider: 'SignalWire DataSphere (Serverless)',
+    };
+  }
+
+  /**
+   * Resolve the tool name used in DataMap registration. Defaults to
+   * `search_datasphere` (TS convention) when `tool_name` is not provided.
+   */
+  private getToolName(): string {
+    return this.getConfig<string>('tool_name', 'search_datasphere');
   }
 
   /**
@@ -120,55 +221,91 @@ export class DataSphereServerlessSkill extends SkillBase {
    * SignalWire executes directly, without needing a webhook callback.
    */
   private buildDataMapFunction(): Record<string, unknown> {
-    const maxResults = this.getConfig<number>('max_results', 5);
-    const distanceThreshold = this.getConfig<number>('distance_threshold', 0.7);
+    const count = this.getConfig<number>('count', 1);
+    const distance = this.getConfig<number>('distance', 3.0);
     const documentId = this.getConfig<string | undefined>('document_id', undefined);
+    const tags = this.getConfig<string[] | undefined>('tags', undefined);
+    const language = this.getConfig<string | undefined>('language', undefined);
+    const posToExpand = this.getConfig<string[] | undefined>('pos_to_expand', undefined);
+    const maxSynonyms = this.getConfig<number | undefined>('max_synonyms', undefined);
+    const noResultsMessage = this.getConfig<string>(
+      'no_results_message',
+      DEFAULT_NO_RESULTS_MESSAGE,
+    );
 
-    const dm = new DataMap('search_datasphere');
+    const dm = new DataMap(this.getToolName());
     dm.enableEnvExpansion(true);
 
     dm.purpose(
       'Search the SignalWire DataSphere knowledge base for relevant information. ' +
-      'Returns the most relevant text chunks from uploaded documents.',
+        'Returns the most relevant text chunks from uploaded documents.',
     );
 
-    dm.parameter('query', 'string', 'The question or topic to search for in the knowledge base.', {
-      required: true,
-    });
+    dm.parameter(
+      'query',
+      'string',
+      "The search query — what information you're looking for in the knowledge base.",
+      { required: true },
+    );
 
-    // Build the request body
+    // Build the request body, mirroring Python's webhook params
     const requestBody: Record<string, unknown> = {
-      query: '%{args.query}',
-      count: maxResults,
-      distance: distanceThreshold,
+      query_string: '${args.query}',
+      count,
+      distance,
     };
 
-    if (documentId) {
+    if (documentId !== undefined) {
       requestBody['document_id'] = documentId;
+    }
+    if (tags !== undefined) {
+      requestBody['tags'] = tags;
+    }
+    if (language !== undefined) {
+      requestBody['language'] = language;
+    }
+    if (posToExpand !== undefined) {
+      requestBody['pos_to_expand'] = posToExpand;
+    }
+    if (maxSynonyms !== undefined) {
+      requestBody['max_synonyms'] = maxSynonyms;
     }
 
     // Configure the webhook to call the DataSphere API
-    dm.webhook('POST', 'https://${ENV.SIGNALWIRE_SPACE}.signalwire.com/api/datasphere/documents/search', {
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Basic ${ENV.SIGNALWIRE_AUTH}',
+    dm.webhook(
+      'POST',
+      'https://${ENV.SIGNALWIRE_SPACE}.signalwire.com/api/datasphere/documents/search',
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Basic ${ENV.SIGNALWIRE_AUTH}',
+        },
       },
-    });
+    );
 
-    dm.body(requestBody);
+    dm.params(requestBody);
+
+    // Match Python's foreach formatter so callers receive a consistent
+    // multi-result concatenation rather than only the top three entries.
+    dm.foreach({
+      input_key: 'chunks',
+      output_key: 'formatted_results',
+      max: count,
+      append: '=== RESULT ===\n${this.text}\n' + '='.repeat(50) + '\n\n',
+    });
 
     dm.output(
       new FunctionResult(
-        'Knowledge base results for the query: %{array[0].text} %{array[1].text} %{array[2].text}',
+        'I found results for "${args.query}":\n\n${formatted_results}',
       ),
     );
 
-    dm.errorKeys(['error', 'message']);
+    dm.errorKeys(['error']);
 
+    // Python replaces `{query}` with `${args.query}` at registration time so
+    // the platform can substitute the original user query into the fallback.
     dm.fallbackOutput(
-      new FunctionResult(
-        'No relevant results found in the knowledge base. Try rephrasing your question.',
-      ),
+      new FunctionResult(noResultsMessage.replace('{query}', '${args.query}')),
     );
 
     return dm.toSwaigFunction();
@@ -177,16 +314,13 @@ export class DataSphereServerlessSkill extends SkillBase {
   /**
    * Return a stub tool definition since this skill uses DataMap-based execution.
    * The actual DataMap function is provided by getDataMapTools().
-   * @returns A single stub `search_datasphere` tool that explains its DataMap nature.
+   * @returns A single stub tool (named via `tool_name`) that explains its DataMap nature.
    */
   getTools(): SkillToolDefinition[] {
-    // DataMap-based skills do not use handler-based tools.
-    // The tool is provided via getDataMapTools() instead.
-    // We return a stub handler that explains this to prevent confusion
-    // if something tries to invoke it as a regular tool.
+    const toolName = this.getToolName();
     return [
       {
-        name: 'search_datasphere',
+        name: toolName,
         description:
           'Search the SignalWire DataSphere knowledge base for relevant information. (Serverless DataMap mode)',
         parameters: {
@@ -199,7 +333,7 @@ export class DataSphereServerlessSkill extends SkillBase {
         handler: () => {
           return new FunctionResult(
             'This tool is configured for serverless DataMap execution. ' +
-            'It should be registered as a data_map function, not invoked via webhook.',
+              'It should be registered as a data_map function, not invoked via webhook.',
           );
         },
       },
@@ -218,16 +352,17 @@ export class DataSphereServerlessSkill extends SkillBase {
 
   /** @returns Prompt section describing serverless DataSphere search capabilities. */
   protected override _getPromptSections(): SkillPromptSection[] {
+    const toolName = this.getToolName();
     return [
       {
-        title: 'Knowledge Base Search (DataSphere - Serverless)',
-        body: 'You have access to a knowledge base of documents that can be searched for relevant information. Searches are executed server-side for optimal performance.',
+        title: 'Knowledge Search Capability (Serverless)',
+        body: `You can search a knowledge base for information using the ${toolName} tool.`,
         bullets: [
-          'Use the search_datasphere tool when the user asks questions that might be answered by internal documentation or uploaded knowledge.',
-          'Results are ranked by relevance and returned automatically.',
-          'This search runs entirely on the SignalWire platform without requiring external webhooks.',
-          'Synthesize information from the results when appropriate.',
-          'If no results are found, let the user know and suggest rephrasing their question.',
+          `Use the ${toolName} tool when users ask for information that might be in the knowledge base`,
+          'Search for relevant information using clear, specific queries',
+          'Summarize search results in a clear, helpful way',
+          'If no results are found, suggest the user try rephrasing their question',
+          'This tool executes on SignalWire servers for optimal performance',
         ],
       },
     ];

--- a/src/skills/builtin/info_gatherer.ts
+++ b/src/skills/builtin/info_gatherer.ts
@@ -1,10 +1,16 @@
 /**
  * Info Gatherer Skill - Collects structured information from the user.
  *
- * Tier 2 built-in skill: no external dependencies required.
- * Dynamically generates a save_info tool based on configured fields.
- * Fields can have optional validation patterns and required/optional flags.
- * Useful for collecting user details like name, email, phone, address, etc.
+ * Tier 2 built-in skill: no external dependencies required. Supports two
+ * collection modes:
+ *
+ * 1. Sequential question flow (Python-aligned): configure `questions` and the
+ *    skill registers `start_questions` / `submit_answer` tools that guide the
+ *    agent one question at a time. State lives in SWAIG `global_data` under a
+ *    namespaced key (e.g. `skill:info_gatherer`).
+ * 2. Single-shot field collection (TS-native): configure `fields` to get a
+ *    dynamic `save_info` tool plus a `get_gathered_info` retrieval tool. State
+ *    lives in an in-memory map keyed by `call_id`.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -16,6 +22,9 @@ import type {
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
+import { getLogger } from '../../Logger.js';
+
+const log = getLogger('InfoGathererSkill');
 
 /** Definition of a single data field to be collected from the user. */
 interface FieldDefinition {
@@ -31,24 +40,50 @@ interface FieldDefinition {
   type?: string;
 }
 
+/** Definition of a single question in the sequential question flow. */
+interface QuestionDefinition {
+  /** Key name used to store the answer. */
+  key_name: string;
+  /** Question text read to the user. */
+  question_text: string;
+  /** When true, the agent must confirm the answer with the user before submitting. */
+  confirm?: boolean;
+  /** Optional extra instruction appended to the question prompt. */
+  prompt_add?: string;
+}
+
 /** Key-value map of information gathered from a user during a call. */
 interface GatheredInfo {
   [key: string]: unknown;
 }
 
 /**
- * Collects structured information from the user based on configurable fields.
+ * Collects structured information from the user.
  *
- * Tier 2 built-in skill with no external dependencies. Dynamically generates
- * a `save_info` tool based on the `fields` config array. Fields support
- * optional validation patterns and required/optional flags. Data is stored
- * per-call and optionally merged into global data.
+ * Tier 2 built-in skill with no external dependencies. Supports the
+ * Python-aligned sequential question flow (`questions` config) and the
+ * TS-native single-shot field collection (`fields` config).
  */
 export class InfoGathererSkill extends SkillBase {
+  /** Python SDK parity: multiple instances can coexist with different prefixes. */
+  static override SUPPORTS_MULTIPLE_INSTANCES = true;
+
+  /** Sequential flow: list of question definitions populated in `setup()`. */
+  private questions: QuestionDefinition[] = [];
+  /** Sequential flow: derived tool name for the start tool (prefix-aware). */
+  private startToolName: string = 'start_questions';
+  /** Sequential flow: derived tool name for the submit tool (prefix-aware). */
+  private submitToolName: string = 'submit_answer';
+  /** Sequential flow: message returned once all questions are answered. */
+  private completionMessage: string = '';
+
+  /** Single-shot flow: in-memory storage keyed by call_id. */
   private gatheredData: Map<string, GatheredInfo> = new Map();
 
   /**
-   * @param config - Optional configuration; supports `fields`, `purpose`, `confirmation_message`, `store_globally`.
+   * @param config - Optional configuration; supports `questions`, `prefix`,
+   *   `completion_message`, `fields`, `purpose`, `confirmation_message`,
+   *   `store_globally`.
    */
   constructor(config?: SkillConfig) {
     super('info_gatherer', config);
@@ -57,9 +92,36 @@ export class InfoGathererSkill extends SkillBase {
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
       ...super.getParameterSchema(),
+      questions: {
+        type: 'array',
+        description:
+          "List of question objects. Each must have 'key_name' (str) and 'question_text' (str). Optional 'confirm' (bool) asks the agent to confirm the answer before proceeding.",
+        required: true,
+        items: {
+          type: 'object',
+          properties: {
+            key_name: { type: 'string' },
+            question_text: { type: 'string' },
+            confirm: { type: 'boolean' },
+            prompt_add: { type: 'string' },
+          },
+        },
+      },
+      prefix: {
+        type: 'string',
+        description:
+          "Optional prefix for tool names and namespace. When set, tools are named <prefix>_start_questions / <prefix>_submit_answer and state is stored under 'skill:<prefix>' in global_data.",
+      },
+      completion_message: {
+        type: 'string',
+        description: 'Message returned after all questions are answered',
+        default:
+          "Thank you! All questions have been answered. You can now summarize the information collected or ask if there's anything else the user would like to discuss.",
+      },
       fields: {
         type: 'array',
-        description: 'Array of field definitions to collect: { name, description, required?, validation?, type? }.',
+        description:
+          'Array of field definitions to collect: { name, description, required?, validation?, type? }.',
         items: { type: 'object' },
       },
       purpose: {
@@ -79,16 +141,41 @@ export class InfoGathererSkill extends SkillBase {
     };
   }
 
-  /** @returns Manifest with config schema for fields, purpose, confirmation_message, and store_globally. */
+  /** @returns Manifest with config schema for both collection modes. */
   getManifest(): SkillManifest {
     return {
       name: 'info_gatherer',
       description:
-        'Collects structured information from the user based on configurable fields. Validates and stores gathered data.',
+        'Gather answers to a configurable list of questions, or collect structured information from the user based on configurable fields.',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['data-collection', 'form', 'information', 'utility'],
       configSchema: {
+        questions: {
+          type: 'array',
+          description:
+            "List of question objects. Each must have 'key_name' and 'question_text'. Optional 'confirm' asks the agent to confirm before proceeding; 'prompt_add' appends a note.",
+          items: {
+            type: 'object',
+            properties: {
+              key_name: { type: 'string' },
+              question_text: { type: 'string' },
+              confirm: { type: 'boolean' },
+              prompt_add: { type: 'string' },
+            },
+            required: ['key_name', 'question_text'],
+          },
+        },
+        prefix: {
+          type: 'string',
+          description:
+            'Optional prefix for tool names and namespace. Enables multi-instance use.',
+        },
+        completion_message: {
+          type: 'string',
+          description:
+            'Message returned after all sequential questions are answered.',
+        },
         fields: {
           type: 'array',
           description:
@@ -119,19 +206,119 @@ export class InfoGathererSkill extends SkillBase {
         confirmation_message: {
           type: 'string',
           description:
-            'Custom message returned after successful info collection.',
+            'Custom message returned after successful save_info call (single-shot mode).',
         },
         store_globally: {
           type: 'boolean',
           description:
-            'Whether to store gathered info in global data. Defaults to false.',
+            'Whether to store gathered info in global data (single-shot mode). Defaults to false.',
         },
       },
     };
   }
 
-  /** @returns A `save_info` tool (dynamic params from config) and a `get_gathered_info` retrieval tool. */
+  /**
+   * Instance key for the SkillManager. When `prefix` is configured, returns
+   * `info_gatherer_<prefix>` to support multi-instance use. Matches Python's
+   * `get_instance_key()`.
+   */
+  override getInstanceKey(): string {
+    const prefix = this.getConfig<string>('prefix', '');
+    return prefix ? `info_gatherer_${prefix}` : 'info_gatherer';
+  }
+
+  /**
+   * Validate sequential question config and initialize derived state. A no-op
+   * when `questions` is not configured (field-only mode).
+   */
+  override async setup(): Promise<void> {
+    const questions = this.getConfig<unknown>('questions', undefined);
+    if (questions === undefined || questions === null) {
+      // No sequential config — field-only mode is handled in getTools/_getPromptSections.
+      return;
+    }
+
+    try {
+      InfoGathererSkill._validateQuestions(questions);
+    } catch (err) {
+      log.error(
+        `info_gatherer: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+
+    this.questions = questions as QuestionDefinition[];
+
+    const prefix = this.getConfig<string>('prefix', '');
+    if (prefix) {
+      this.startToolName = `${prefix}_start_questions`;
+      this.submitToolName = `${prefix}_submit_answer`;
+    } else {
+      this.startToolName = 'start_questions';
+      this.submitToolName = 'submit_answer';
+    }
+
+    this.completionMessage = this.getConfig<string>(
+      'completion_message',
+      "Thank you! All questions have been answered. You can now summarize the information collected or ask if there's anything else the user would like to discuss.",
+    );
+  }
+
+  /**
+   * Seed SWAIG global_data with the initial sequential-question state. Returns
+   * an empty object when sequential mode is not active.
+   */
+  override getGlobalData(): Record<string, unknown> {
+    if (this.questions.length === 0) {
+      return {};
+    }
+    return {
+      [this.getSkillNamespace()]: {
+        questions: this.questions,
+        question_index: 0,
+        answers: [],
+      },
+    };
+  }
+
+  /** Tools for the configured collection mode. */
   getTools(): SkillToolDefinition[] {
+    // Sequential question flow takes precedence when configured.
+    if (this.questions.length > 0) {
+      return this._getSequentialTools();
+    }
+    return this._getFieldTools();
+  }
+
+  private _getSequentialTools(): SkillToolDefinition[] {
+    return [
+      {
+        name: this.startToolName,
+        description: 'Start the question sequence with the first question',
+        parameters: {},
+        handler: (args, rawData) => this._handleStartQuestions(args, rawData),
+      },
+      {
+        name: this.submitToolName,
+        description:
+          'Submit an answer to the current question and move to the next one',
+        parameters: {
+          answer: {
+            type: 'string',
+            description: "The user's answer to the current question",
+          },
+          confirmed_by_user: {
+            type: 'boolean',
+            description:
+              "Only set to true when the user has explicitly said 'yes' or confirmed the answer is correct in their own words in their most recent response. Never set this to true on your own.",
+          },
+        },
+        handler: (args, rawData) => this._handleSubmitAnswer(args, rawData),
+      },
+    ];
+  }
+
+  private _getFieldTools(): SkillToolDefinition[] {
     const fields = this.getConfig<FieldDefinition[]>('fields', []);
     const confirmationMessage = this.getConfig<string>(
       'confirmation_message',
@@ -158,7 +345,7 @@ export class InfoGathererSkill extends SkillBase {
       }
     }
 
-    const tools: SkillToolDefinition[] = [
+    return [
       {
         name: 'save_info',
         description:
@@ -169,24 +356,24 @@ export class InfoGathererSkill extends SkillBase {
           const errors: string[] = [];
           const collected: GatheredInfo = {};
 
-          // Validate each field
           for (const field of fields) {
             const value = args[field.name];
 
-            // Check required fields
             if (field.required) {
-              if (value === undefined || value === null || (typeof value === 'string' && value.trim().length === 0)) {
+              if (
+                value === undefined ||
+                value === null ||
+                (typeof value === 'string' && value.trim().length === 0)
+              ) {
                 errors.push(`"${field.name}" is required but was not provided.`);
                 continue;
               }
             }
 
-            // Skip optional fields that weren't provided
             if (value === undefined || value === null) {
               continue;
             }
 
-            // Validate against pattern if specified
             if (field.validation && typeof value === 'string') {
               try {
                 const regex = new RegExp(field.validation);
@@ -197,11 +384,12 @@ export class InfoGathererSkill extends SkillBase {
                   continue;
                 }
               } catch {
-                // If regex is invalid, skip validation
+                // Invalid regex — skip validation
               }
             }
 
-            collected[field.name] = typeof value === 'string' ? value.trim() : value;
+            collected[field.name] =
+              typeof value === 'string' ? value.trim() : value;
           }
 
           if (errors.length > 0) {
@@ -216,14 +404,12 @@ export class InfoGathererSkill extends SkillBase {
             );
           }
 
-          // Store the gathered data keyed by call ID if available
           const callId = (rawData['call_id'] as string | undefined) ?? 'default';
           this.gatheredData.set(callId, {
             ...this.gatheredData.get(callId),
             ...collected,
           });
 
-          // Build confirmation with collected fields summary
           const fieldSummary = Object.entries(collected)
             .map(([key, val]) => `${key}: ${val}`)
             .join(', ');
@@ -232,7 +418,6 @@ export class InfoGathererSkill extends SkillBase {
             `${confirmationMessage} Saved: ${fieldSummary}.`,
           );
 
-          // Optionally store in global data
           if (storeGlobally) {
             result.updateGlobalData({ gathered_info: collected });
           }
@@ -265,12 +450,191 @@ export class InfoGathererSkill extends SkillBase {
         },
       },
     ];
-
-    return tools;
   }
 
-  /** @returns Prompt section listing required/optional fields and collection instructions. */
+  /**
+   * Handle the `start_questions` tool: read state from global_data and return
+   * an instruction for the first question.
+   */
+  private _handleStartQuestions(
+    _args: Record<string, unknown>,
+    rawData: Record<string, unknown>,
+  ): FunctionResult {
+    const state = this.getSkillData(rawData);
+    const questions = (state['questions'] as QuestionDefinition[] | undefined) ?? [];
+    const questionIndex = (state['question_index'] as number | undefined) ?? 0;
+
+    if (questions.length === 0 || questionIndex >= questions.length) {
+      return new FunctionResult("I don't have any questions to ask.");
+    }
+
+    const current = questions[questionIndex];
+    const instruction = InfoGathererSkill._generateQuestionInstruction(
+      current.question_text ?? '',
+      current.confirm ?? false,
+      true,
+      current.prompt_add ?? '',
+      this.submitToolName,
+      questionIndex + 1,
+      questions.length,
+    );
+    return new FunctionResult(instruction);
+  }
+
+  /**
+   * Handle the `submit_answer` tool: validate confirmation, record the answer,
+   * advance the index, and either return the next question or the completion
+   * message (disabling both tools on completion).
+   */
+  private _handleSubmitAnswer(
+    args: Record<string, unknown>,
+    rawData: Record<string, unknown>,
+  ): FunctionResult {
+    const answer = (args['answer'] as string | undefined) ?? '';
+    const confirmed = (args['confirmed_by_user'] as boolean | undefined) ?? false;
+    const state = this.getSkillData(rawData);
+
+    const questions = (state['questions'] as QuestionDefinition[] | undefined) ?? [];
+    const questionIndex = (state['question_index'] as number | undefined) ?? 0;
+    const answers = (state['answers'] as Array<{ key_name: string; answer: string }> | undefined) ?? [];
+
+    if (questionIndex >= questions.length) {
+      return new FunctionResult('All questions have already been answered.');
+    }
+
+    const current = questions[questionIndex];
+    const keyName = current.key_name ?? '';
+
+    // Enforce confirmation: reject the submission if the question requires
+    // confirmation but the confirmed flag was not set to true.
+    if ((current.confirm ?? false) && !confirmed) {
+      return new FunctionResult(
+        `Before submitting, you must read the answer "${answer}" back to the user ` +
+          `and ask them to confirm it is correct. Then call this function again with ` +
+          `confirmed set to true. If the user says it is wrong, ask the question again.`,
+      );
+    }
+
+    const newAnswers = [...answers, { key_name: keyName, answer }];
+    const newIndex = questionIndex + 1;
+
+    let result: FunctionResult;
+
+    if (newIndex < questions.length) {
+      const nextQ = questions[newIndex];
+      const instruction = InfoGathererSkill._generateQuestionInstruction(
+        nextQ.question_text ?? '',
+        nextQ.confirm ?? false,
+        false,
+        nextQ.prompt_add ?? '',
+        this.submitToolName,
+        newIndex + 1,
+        questions.length,
+      );
+      result = new FunctionResult(instruction);
+    } else {
+      result = new FunctionResult(this.completionMessage);
+      result.toggleFunctions([
+        { function: this.startToolName, active: false },
+        { function: this.submitToolName, active: false },
+      ]);
+    }
+
+    const newState = {
+      questions,
+      question_index: newIndex,
+      answers: newAnswers,
+    };
+    this.updateSkillData(result, newState);
+    return result;
+  }
+
+  /** Generate the per-question instruction returned to the agent. */
+  private static _generateQuestionInstruction(
+    questionText: string,
+    needsConfirmation: boolean,
+    isFirstQuestion: boolean,
+    promptAdd: string,
+    submitToolName: string,
+    questionNumber: number,
+    totalQuestions: number,
+  ): string {
+    let instruction: string;
+    if (isFirstQuestion) {
+      instruction =
+        `Ask each question one at a time, wait for the user's answer, ` +
+        `then call ${submitToolName} with their answer. Do not reuse previous answers.\n\n` +
+        `[Question ${questionNumber} of ${totalQuestions}]: "${questionText}"`;
+    } else {
+      instruction = `Previous answer saved. [Question ${questionNumber} of ${totalQuestions}]: "${questionText}"`;
+    }
+
+    if (promptAdd) {
+      instruction += `\nNote: ${promptAdd}`;
+    }
+
+    if (needsConfirmation) {
+      instruction +=
+        `\nThis question requires confirmation. Read the answer back to the user ` +
+        `and ask them to confirm it is correct before calling ${submitToolName}. ` +
+        `If they say it is wrong, ask the question again.`;
+    }
+
+    return instruction;
+  }
+
+  /**
+   * Validate that `questions` is a non-empty array of objects each having
+   * `key_name` and `question_text`. Throws on invalid input.
+   */
+  private static _validateQuestions(questions: unknown): void {
+    if (!Array.isArray(questions)) {
+      throw new Error('Questions must be a list');
+    }
+    if (questions.length === 0) {
+      throw new Error('At least one question is required');
+    }
+    for (let i = 0; i < questions.length; i++) {
+      const q = questions[i];
+      if (!q || typeof q !== 'object' || Array.isArray(q)) {
+        throw new Error(`Question ${i + 1} must be a dictionary`);
+      }
+      const obj = q as Record<string, unknown>;
+      if (!('key_name' in obj)) {
+        throw new Error(`Question ${i + 1} is missing 'key_name' field`);
+      }
+      if (!('question_text' in obj)) {
+        throw new Error(`Question ${i + 1} is missing 'question_text' field`);
+      }
+    }
+  }
+
+  /** Prompt sections depend on the active collection mode. */
   protected override _getPromptSections(): SkillPromptSection[] {
+    if (this.questions.length > 0) {
+      return this._getSequentialPromptSections();
+    }
+    return this._getFieldPromptSections();
+  }
+
+  private _getSequentialPromptSections(): SkillPromptSection[] {
+    return [
+      {
+        title: `Info Gatherer (${this.getInstanceKey()})`,
+        body:
+          `You need to gather answers to a series of questions from the user. ` +
+          `Start by introducing yourself and asking the user if they are ready ` +
+          `to answer some questions. Once the user confirms they are ready, ` +
+          `call the ${this.startToolName} function to get the first question. ` +
+          `Ask the user that question, wait for their response, then call ` +
+          `${this.submitToolName} with the answer they gave you. ` +
+          `Each call to ${this.submitToolName} will return the next question ` +
+          `to ask. Repeat this process until all questions are complete.`,
+      },
+    ];
+  }
+
+  private _getFieldPromptSections(): SkillPromptSection[] {
     const fields = this.getConfig<FieldDefinition[]>('fields', []);
     const purpose = this.getConfig<string | undefined>('purpose', undefined);
 
@@ -293,19 +657,14 @@ export class InfoGathererSkill extends SkillBase {
 
     if (requiredFields.length > 0) {
       const reqNames = requiredFields.map((f) => `"${f.name}"`).join(', ');
-      bullets.push(
-        `Required fields (must be collected): ${reqNames}.`,
-      );
+      bullets.push(`Required fields (must be collected): ${reqNames}.`);
     }
 
     if (optionalFields.length > 0) {
       const optNames = optionalFields.map((f) => `"${f.name}"`).join(', ');
-      bullets.push(
-        `Optional fields (collect if available): ${optNames}.`,
-      );
+      bullets.push(`Optional fields (collect if available): ${optNames}.`);
     }
 
-    // Add field descriptions
     for (const field of fields) {
       const reqLabel = field.required ? ' (required)' : ' (optional)';
       bullets.push(`${field.name}${reqLabel}: ${field.description}`);
@@ -327,7 +686,7 @@ export class InfoGathererSkill extends SkillBase {
   }
 
   /**
-   * Get all gathered data, keyed by call ID.
+   * Get all gathered data (single-shot mode), keyed by call ID.
    * @returns A copy of the internal gathered data map.
    */
   getAllGatheredData(): Map<string, GatheredInfo> {
@@ -335,7 +694,7 @@ export class InfoGathererSkill extends SkillBase {
   }
 
   /**
-   * Clear gathered data for a specific call or all calls.
+   * Clear gathered data (single-shot mode) for a specific call or all calls.
    * @param callId - If provided, clear data for this call only; otherwise clear all.
    */
   clearGatheredData(callId?: string): void {

--- a/src/skills/builtin/web_search.ts
+++ b/src/skills/builtin/web_search.ts
@@ -1,9 +1,10 @@
 /**
- * Web Search Skill - Searches the web using Google Custom Search API.
+ * Web Search Skill - Searches the web using the Google Custom Search API.
  *
- * Tier 3 built-in skill: requires GOOGLE_SEARCH_API_KEY and GOOGLE_SEARCH_CX
- * environment variables. Uses the Google Custom Search JSON API to perform
- * web searches and return formatted results.
+ * Tier 3 built-in skill: requires `GOOGLE_SEARCH_API_KEY` and
+ * `GOOGLE_SEARCH_ENGINE_ID` (legacy alias: `GOOGLE_SEARCH_CX`) environment
+ * variables, or the equivalent config params. Uses the Google Custom Search
+ * JSON API to perform web searches and return formatted results.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -19,6 +20,11 @@ import { MAX_SKILL_INPUT_LENGTH } from '../../SecurityUtils.js';
 import { getLogger } from '../../Logger.js';
 
 const log = getLogger('WebSearchSkill');
+
+const DEFAULT_NO_RESULTS_MESSAGE =
+  "I couldn't find quality results for '{query}'. " +
+  'The search returned only low-quality or inaccessible pages. ' +
+  'Try rephrasing your search or asking about a different topic.';
 
 /** A single search result item from the Google Custom Search API. */
 interface GoogleSearchItem {
@@ -56,13 +62,23 @@ interface GoogleSearchResponse {
 /**
  * Searches the web using the Google Custom Search JSON API.
  *
- * Tier 3 built-in skill. Requires `GOOGLE_SEARCH_API_KEY` and `GOOGLE_SEARCH_CX`
- * environment variables. Supports `max_results` (1-10) and `safe_search`
- * ("off"|"medium"|"high") config options.
+ * Tier 3 built-in skill. Credentials can be supplied via the `api_key` and
+ * `search_engine_id` params or `GOOGLE_SEARCH_API_KEY` /
+ * `GOOGLE_SEARCH_ENGINE_ID` (legacy: `GOOGLE_SEARCH_CX`) environment variables.
+ * Supports `tool_name`, `num_results`, `no_results_message`, `safe_search`,
+ * and — for Python-parity — `delay`, `max_content_length`, `oversample_factor`,
+ * and `min_quality_score` config options. The scraping-pipeline parameters are
+ * accepted but only the API-snippet result path is implemented in TS.
  */
 export class WebSearchSkill extends SkillBase {
+  /** Python SDK parity: multiple instances can coexist with different tool names. */
+  static override SUPPORTS_MULTIPLE_INSTANCES = true;
+
   /**
-   * @param config - Optional configuration; supports `max_results` and `safe_search`.
+   * @param config - Optional configuration; supports `api_key`,
+   *   `search_engine_id`, `tool_name`, `num_results`, `no_results_message`,
+   *   `safe_search`, `delay`, `max_content_length`, `oversample_factor`,
+   *   `min_quality_score`.
    */
   constructor(config?: SkillConfig) {
     super('web_search', config);
@@ -73,24 +89,64 @@ export class WebSearchSkill extends SkillBase {
       ...super.getParameterSchema(),
       api_key: {
         type: 'string',
-        description: 'Google Custom Search API key.',
+        description: 'Google Custom Search API key',
+        required: true,
         hidden: true,
         env_var: 'GOOGLE_SEARCH_API_KEY',
-        required: true,
       },
       search_engine_id: {
         type: 'string',
-        description: 'Google Custom Search Engine ID (CX).',
-        hidden: true,
-        env_var: 'GOOGLE_SEARCH_CX',
+        description: 'Google Custom Search Engine ID',
         required: true,
+        hidden: true,
+        env_var: 'GOOGLE_SEARCH_ENGINE_ID',
       },
-      max_results: {
-        type: 'number',
-        description: 'Maximum number of results to return (1-10).',
-        default: 5,
+      tool_name: {
+        type: 'string',
+        description: 'Custom tool name for this Web Search instance.',
+      },
+      num_results: {
+        type: 'integer',
+        description: 'Number of high-quality results to return',
+        default: 3,
         min: 1,
         max: 10,
+      },
+      delay: {
+        type: 'number',
+        description:
+          'Delay between scraping pages in seconds (parity with Python; ignored in TS which uses API snippets only)',
+        default: 0.5,
+        min: 0,
+      },
+      max_content_length: {
+        type: 'integer',
+        description:
+          'Maximum total response size in characters (parity with Python; ignored in TS which uses API snippets only)',
+        default: 32768,
+        min: 1000,
+      },
+      oversample_factor: {
+        type: 'number',
+        description:
+          'How many extra results to fetch for quality filtering (parity with Python; ignored in TS)',
+        default: 2.5,
+        min: 1.0,
+        max: 3.5,
+      },
+      min_quality_score: {
+        type: 'number',
+        description:
+          'Minimum quality score (0-1) for including a result (parity with Python; ignored in TS)',
+        default: 0.3,
+        min: 0,
+        max: 1,
+      },
+      no_results_message: {
+        type: 'string',
+        description:
+          'Message to show when no results are found. Use {query} as placeholder.',
+        default: DEFAULT_NO_RESULTS_MESSAGE,
       },
       safe_search: {
         type: 'string',
@@ -101,22 +157,66 @@ export class WebSearchSkill extends SkillBase {
     };
   }
 
-  /** @returns Manifest declaring GOOGLE_SEARCH_API_KEY and GOOGLE_SEARCH_CX as required. */
+  /**
+   * @returns Manifest declaring Google Search credentials as required env vars.
+   *   Reports `GOOGLE_SEARCH_ENGINE_ID` as the canonical name; `GOOGLE_SEARCH_CX`
+   *   is still accepted as a legacy fallback at runtime.
+   */
   getManifest(): SkillManifest {
     return {
       name: 'web_search',
       description:
-        'Searches the web using Google Custom Search API and returns formatted results with titles, links, and snippets.',
-      version: '1.0.0',
+        'Search the web for information using Google Custom Search API',
+      version: '2.0.0',
       author: 'SignalWire',
       tags: ['search', 'web', 'google', 'api', 'external'],
-      requiredEnvVars: ['GOOGLE_SEARCH_API_KEY', 'GOOGLE_SEARCH_CX'],
+      requiredEnvVars: ['GOOGLE_SEARCH_API_KEY', 'GOOGLE_SEARCH_ENGINE_ID'],
       configSchema: {
-        max_results: {
+        api_key: {
+          type: 'string',
+          description: 'Google Custom Search API key.',
+        },
+        search_engine_id: {
+          type: 'string',
+          description: 'Google Custom Search Engine ID.',
+        },
+        tool_name: {
+          type: 'string',
+          description: 'Custom tool name for this instance.',
+        },
+        num_results: {
+          type: 'integer',
+          description: 'Number of results to return (1-10). Defaults to 3.',
+          default: 3,
+        },
+        delay: {
           type: 'number',
           description:
-            'Maximum number of results to return (1-10). Defaults to 5.',
-          default: 5,
+            'Delay between scraping pages (Python parity; ignored in TS).',
+          default: 0.5,
+        },
+        max_content_length: {
+          type: 'integer',
+          description:
+            'Maximum total response size (Python parity; ignored in TS).',
+          default: 32768,
+        },
+        oversample_factor: {
+          type: 'number',
+          description:
+            'Oversampling factor for quality filtering (Python parity; ignored in TS).',
+          default: 2.5,
+        },
+        min_quality_score: {
+          type: 'number',
+          description:
+            'Minimum quality score (Python parity; ignored in TS).',
+          default: 0.3,
+        },
+        no_results_message: {
+          type: 'string',
+          description:
+            'Message returned when no results are found. Supports {query} interpolation.',
         },
         safe_search: {
           type: 'string',
@@ -128,58 +228,111 @@ export class WebSearchSkill extends SkillBase {
     };
   }
 
-  /** @returns A single `web_search` tool that performs a Google search and returns formatted results. */
+  /**
+   * Instance key for the SkillManager. Includes the configured
+   * `search_engine_id` (or `"default"`) and `tool_name` (or `"web_search"`)
+   * to match Python's `"{SKILL_NAME}_{search_engine_id}_{tool_name}"` scheme.
+   */
+  override getInstanceKey(): string {
+    const searchEngineId = this.getConfig<string>('search_engine_id', '') || 'default';
+    const toolName = this.getConfig<string>('tool_name', this.skillName);
+    return `${this.skillName}_${searchEngineId}_${toolName}`;
+  }
+
+  /** Global data injected into the agent's SWML context (mirrors Python). */
+  override getGlobalData(): Record<string, unknown> {
+    return {
+      web_search_enabled: true,
+      search_provider: 'Google Custom Search',
+      quality_filtering: false,
+    };
+  }
+
+  /** Resolve the tool name (defaults to `web_search`, matches Python default). */
+  private getToolName(): string {
+    return this.getConfig<string>('tool_name', 'web_search');
+  }
+
+  /**
+   * @returns A single tool (named via `tool_name`) that performs a Google
+   *   Custom Search and returns formatted results.
+   */
   getTools(): SkillToolDefinition[] {
-    const configMaxResults = this.getConfig<number>('max_results', 5);
+    const configNumResults = this.getConfig<number>('num_results', 3);
     const safeSearch = this.getConfig<string>('safe_search', 'medium');
+    const noResultsMessage = this.getConfig<string>(
+      'no_results_message',
+      DEFAULT_NO_RESULTS_MESSAGE,
+    );
+    const toolName = this.getToolName();
 
     return [
       {
-        name: 'web_search',
+        name: toolName,
         description:
-          'Search the web for information on any topic. Returns a list of results with titles, links, and brief descriptions.',
+          'Search the web for high-quality information, automatically filtering low-quality results',
         parameters: {
           query: {
             type: 'string',
-            description: 'The search query to look up on the web.',
+            description:
+              "The search query — what you want to find information about",
           },
           num_results: {
             type: 'number',
-            description: `Number of results to return (1-10). Defaults to ${configMaxResults}.`,
+            description: `Optional: override the number of results to return (1-10). Defaults to ${configNumResults}.`,
           },
         },
         required: ['query'],
         handler: async (args: Record<string, unknown>) => {
-          const query = args.query as string | undefined;
-          const numResults = args.num_results as number | undefined;
+          const rawQuery = args['query'];
+          const perCallNumResults = args['num_results'];
 
-          if (!query || typeof query !== 'string' || query.trim().length === 0) {
+          if (
+            !rawQuery ||
+            typeof rawQuery !== 'string' ||
+            rawQuery.trim().length === 0
+          ) {
             return new FunctionResult(
-              'Please provide a search query.',
+              'Please provide a search query. What would you like me to search for?',
             );
           }
+
+          const query = rawQuery.trim();
 
           if (query.length > MAX_SKILL_INPUT_LENGTH) {
             return new FunctionResult('Search query is too long.');
           }
 
-          const apiKey = process.env['GOOGLE_SEARCH_API_KEY'];
-          const cx = process.env['GOOGLE_SEARCH_CX'];
+          const apiKey =
+            this.getConfig<string | undefined>('api_key', undefined) ??
+            process.env['GOOGLE_SEARCH_API_KEY'];
+          const searchEngineId =
+            this.getConfig<string | undefined>('search_engine_id', undefined) ??
+            process.env['GOOGLE_SEARCH_ENGINE_ID'] ??
+            process.env['GOOGLE_SEARCH_CX'];
 
-          if (!apiKey || !cx) {
+          if (!apiKey || !searchEngineId) {
             return new FunctionResult(
               'Service is not configured. Please contact your administrator.',
             );
           }
 
-          const count = Math.max(1, Math.min(10, numResults ?? configMaxResults));
+          const count = Math.max(
+            1,
+            Math.min(
+              10,
+              typeof perCallNumResults === 'number'
+                ? perCallNumResults
+                : configNumResults,
+            ),
+          );
 
           try {
-            const encodedQuery = encodeURIComponent(query.trim());
+            const encodedQuery = encodeURIComponent(query);
             const safeParam = safeSearch !== 'off' ? `&safe=${safeSearch}` : '';
             const url =
               `https://www.googleapis.com/customsearch/v1` +
-              `?key=${apiKey}&cx=${cx}&q=${encodedQuery}&num=${count}${safeParam}`;
+              `?key=${apiKey}&cx=${searchEngineId}&q=${encodedQuery}&num=${count}${safeParam}`;
 
             const controller = new AbortController();
             const timeout = setTimeout(() => controller.abort(), 30_000);
@@ -200,15 +353,17 @@ export class WebSearchSkill extends SkillBase {
 
             if (!data.items || data.items.length === 0) {
               return new FunctionResult(
-                `No results found for "${query}".`,
+                WebSearchSkill._formatNoResultsMessage(noResultsMessage, query),
               );
             }
 
-            const totalResults = data.searchInformation?.formattedTotalResults ?? 'unknown';
-            const searchTime = data.searchInformation?.formattedSearchTime ?? 'unknown';
+            const totalResults =
+              data.searchInformation?.formattedTotalResults ?? 'unknown';
+            const searchTime =
+              data.searchInformation?.formattedSearchTime ?? 'unknown';
 
             const parts: string[] = [
-              `Web search results for "${query}" (${totalResults} results in ${searchTime} seconds):`,
+              `Quality web search results for '${query}' (${totalResults} results in ${searchTime} seconds):`,
               '',
             ];
 
@@ -224,9 +379,11 @@ export class WebSearchSkill extends SkillBase {
 
             return new FunctionResult(parts.join('\n').trim());
           } catch (err) {
-            log.error('web_search_failed', { error: err instanceof Error ? err.message : String(err) });
+            log.error('web_search_failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
             return new FunctionResult(
-              'The request could not be completed. Please try again.',
+              'Sorry, I encountered an error while searching. Please try again later.',
             );
           }
         },
@@ -234,18 +391,25 @@ export class WebSearchSkill extends SkillBase {
     ];
   }
 
+  /** Apply the `{query}` template to the no-results message. */
+  private static _formatNoResultsMessage(template: string, query: string): string {
+    return template.includes('{query}')
+      ? template.replace(/\{query\}/g, query)
+      : template;
+  }
+
   /** @returns Prompt section describing web search capabilities and usage guidance. */
   protected override _getPromptSections(): SkillPromptSection[] {
+    const toolName = this.getToolName();
     return [
       {
-        title: 'Web Search',
-        body: 'You can search the web for current information on any topic.',
+        title: 'Web Search Capability (Quality Enhanced)',
+        body: `You can search the internet for high-quality information using the ${toolName} tool.`,
         bullets: [
-          'Use the web_search tool when the user asks about current events, facts, or any information you may not have.',
-          'You can specify the number of results to return (1-10).',
-          'Results include titles, URLs, and brief descriptions/snippets.',
-          'If a search returns no results, try rephrasing the query or using different terms.',
-          'Summarize the search results for the user rather than reading them verbatim.',
+          `Use the ${toolName} tool when users ask for information you need to look up`,
+          'The search automatically filters out low-quality results like empty pages',
+          'Results are ranked by content quality, relevance, and domain reputation',
+          'Summarize the high-quality results in a clear, helpful way',
         ],
       },
     ];

--- a/src/skills/builtin/wikipedia_search.ts
+++ b/src/skills/builtin/wikipedia_search.ts
@@ -1,9 +1,11 @@
 /**
  * Wikipedia Search Skill - Searches Wikipedia for article summaries.
  *
- * Tier 3 built-in skill: no external API key required.
- * Uses the Wikipedia REST API to fetch article summaries and extracts
- * for any given topic.
+ * Tier 3 built-in skill: no external API key required. Uses the Wikipedia
+ * REST API to fetch article summaries and extracts for any given topic.
+ * Matches the Python SDK's `num_results` / `no_results_message` parity and
+ * adds `language` + `max_content_length` for multi-language and output
+ * trimming support.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -18,6 +20,10 @@ import { FunctionResult } from '../../FunctionResult.js';
 import { getLogger } from '../../Logger.js';
 
 const log = getLogger('WikipediaSearchSkill');
+
+const DEFAULT_NO_RESULTS_MESSAGE =
+  "I couldn't find any Wikipedia articles for '{query}'. " +
+  'Try rephrasing your search or using different keywords.';
 
 /** Response shape from the Wikipedia REST API page summary endpoint. */
 interface WikipediaSummaryResponse {
@@ -46,28 +52,46 @@ interface WikipediaSummaryResponse {
   };
 }
 
-/** Response shape from the Wikipedia search API. */
-interface WikipediaSearchResponse {
-  /** Array of matching page results. */
-  pages?: Array<{
-    id: number;
-    key: string;
-    title: string;
-    description?: string;
-    excerpt?: string;
-  }>;
+/** Response shape from the Wikipedia action=query search API. */
+interface WikipediaActionSearchResponse {
+  query?: {
+    search?: Array<{
+      title: string;
+      pageid?: number;
+      snippet?: string;
+    }>;
+  };
+}
+
+/** Response shape from the Wikipedia action=query extracts API. */
+interface WikipediaActionExtractsResponse {
+  query?: {
+    pages?: Record<string, { title?: string; extract?: string }>;
+  };
 }
 
 /**
  * Searches Wikipedia for article summaries and extracts.
  *
- * Tier 3 built-in skill with no external API key required. Uses the Wikipedia
- * REST API to fetch article summaries for any given topic, with a configurable
- * number of sentences.
+ * Tier 3 built-in skill with no external API key required. The configured
+ * `num_results` drives how many articles are aggregated; `no_results_message`
+ * customizes the fallback text (supports `{query}` interpolation); `language`
+ * selects the Wikipedia edition (`en`, `fr`, `de`, …); `max_content_length`
+ * trims the final output.
  */
 export class WikipediaSearchSkill extends SkillBase {
+  /** Resolved `num_results` value (populated in `setup()`). */
+  private _numResults: number = 1;
+  /** Resolved `no_results_message` template (populated in `setup()`). */
+  private _noResultsMessage: string = DEFAULT_NO_RESULTS_MESSAGE;
+  /** Resolved Wikipedia language edition code (populated in `setup()`). */
+  private _language: string = 'en';
+  /** Resolved output length cap in characters (populated in `setup()`). */
+  private _maxContentLength: number = 5000;
+
   /**
-   * @param config - Optional configuration (no config keys used by this skill).
+   * @param config - Optional configuration; supports `num_results`,
+   *   `no_results_message`, `language`, `max_content_length`.
    */
   constructor(config?: SkillConfig) {
     super('wikipedia_search', config);
@@ -76,20 +100,29 @@ export class WikipediaSearchSkill extends SkillBase {
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
       ...super.getParameterSchema(),
+      num_results: {
+        type: 'integer',
+        description: 'Maximum number of Wikipedia articles to return',
+        default: 1,
+        min: 1,
+        max: 5,
+      },
+      no_results_message: {
+        type: 'string',
+        description: 'Custom message when no Wikipedia articles are found',
+        default: DEFAULT_NO_RESULTS_MESSAGE,
+      },
       language: {
         type: 'string',
-        description: 'Wikipedia language edition to search (e.g., "en", "fr", "de").',
+        description:
+          'Wikipedia language edition to search (e.g., "en", "fr", "de").',
         default: 'en',
       },
-      max_results: {
-        type: 'number',
-        description: 'Maximum number of search results to consider.',
-        default: 1,
-      },
       max_content_length: {
-        type: 'number',
+        type: 'integer',
         description: 'Maximum length of returned content in characters.',
         default: 5000,
+        min: 100,
       },
     };
   }
@@ -99,175 +132,235 @@ export class WikipediaSearchSkill extends SkillBase {
     return {
       name: 'wikipedia_search',
       description:
-        'Searches Wikipedia for article summaries and extracts. No API key required.',
+        'Search Wikipedia for information about a topic and get article summaries',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'wikipedia', 'encyclopedia', 'knowledge', 'external'],
     };
   }
 
-  /** @returns A single `search_wikipedia` tool that fetches article summaries from Wikipedia. */
+  /**
+   * Extract config values into instance state. Clamps `num_results` to the
+   * 1-5 range (matching Python's `max(1, ...)` floor plus the schema cap).
+   */
+  override async setup(): Promise<void> {
+    const configured = this.getConfig<number>('num_results', 1);
+    this._numResults = Math.max(1, Math.min(5, Math.floor(configured)));
+
+    const rawMessage = this.getConfig<string | undefined>(
+      'no_results_message',
+      undefined,
+    );
+    this._noResultsMessage =
+      rawMessage && rawMessage.length > 0 ? rawMessage : DEFAULT_NO_RESULTS_MESSAGE;
+
+    const lang = this.getConfig<string>('language', 'en');
+    this._language = lang && lang.length > 0 ? lang : 'en';
+
+    const rawLen = this.getConfig<number>('max_content_length', 5000);
+    this._maxContentLength = Math.max(100, Math.floor(rawLen));
+  }
+
+  /** @returns A `search_wiki` tool that fetches article summaries from Wikipedia. */
   getTools(): SkillToolDefinition[] {
     return [
       {
-        name: 'search_wikipedia',
+        name: 'search_wiki',
         description:
-          'Search Wikipedia for information about a topic. Returns a summary of the most relevant article.',
+          'Search Wikipedia for information about a topic and get article summaries',
         parameters: {
           query: {
             type: 'string',
             description:
-              'The topic or term to search for on Wikipedia.',
+              'The search term or topic to look up on Wikipedia.',
           },
           sentences: {
             type: 'number',
             description:
-              'Number of sentences to return in the summary (1-10). Defaults to 3.',
+              'Optional: number of sentences to return per article (1-10). Applied to the direct page-summary result; full extracts are used otherwise.',
           },
         },
         required: ['query'],
         handler: async (args: Record<string, unknown>) => {
-          const query = args.query as string | undefined;
-          const sentences = args.sentences as number | undefined;
+          const rawQuery = args['query'];
+          const sentences = args['sentences'];
 
-          if (!query || typeof query !== 'string' || query.trim().length === 0) {
+          if (
+            !rawQuery ||
+            typeof rawQuery !== 'string' ||
+            rawQuery.trim().length === 0
+          ) {
             return new FunctionResult(
-              'Please provide a topic to search for on Wikipedia.',
+              'Please provide a search query for Wikipedia.',
             );
           }
 
-          const sentenceCount = Math.max(1, Math.min(10, sentences ?? 3));
+          const sentenceCount =
+            typeof sentences === 'number'
+              ? Math.max(1, Math.min(10, Math.floor(sentences)))
+              : undefined;
 
-          try {
-            // First, try a direct page summary lookup
-            const encodedQuery = encodeURIComponent(query.trim().replace(/\s+/g, '_'));
-            const summaryUrl = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodedQuery}`;
-
-            const controller1 = new AbortController();
-            const timeout1 = setTimeout(() => controller1.abort(), 30_000);
-            let summaryResponse: Response;
-            try {
-              summaryResponse = await fetch(summaryUrl, {
-                headers: { 'Accept': 'application/json', 'User-Agent': 'SignalWireAgentsSDK/1.0' },
-                signal: controller1.signal,
-              });
-            } finally {
-              clearTimeout(timeout1);
-            }
-
-            if (summaryResponse.ok) {
-              const data = (await summaryResponse.json()) as WikipediaSummaryResponse;
-
-              if (data.type !== 'disambiguation' && data.extract) {
-                const extractSentences = data.extract.split(/(?<=[.!?])\s+/);
-                const trimmedExtract = extractSentences
-                  .slice(0, sentenceCount)
-                  .join(' ')
-                  .trim();
-
-                const pageUrl = data.content_urls?.desktop?.page ?? '';
-                const parts: string[] = [
-                  `Wikipedia: ${data.title}`,
-                ];
-                if (data.description) {
-                  parts.push(`(${data.description})`);
-                }
-                parts.push('');
-                parts.push(trimmedExtract);
-                if (pageUrl) {
-                  parts.push('');
-                  parts.push(`Read more: ${pageUrl}`);
-                }
-
-                return new FunctionResult(parts.join('\n').trim());
-              }
-            }
-
-            // If direct lookup failed, use the search API
-            const searchUrl = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encodeURIComponent(query.trim())}&limit=1`;
-
-            const controller2 = new AbortController();
-            const timeout2 = setTimeout(() => controller2.abort(), 30_000);
-            let searchResponse: Response;
-            try {
-              searchResponse = await fetch(searchUrl, {
-                headers: { 'Accept': 'application/json', 'User-Agent': 'SignalWireAgentsSDK/1.0' },
-                signal: controller2.signal,
-              });
-            } finally {
-              clearTimeout(timeout2);
-            }
-
-            if (!searchResponse.ok) {
-              log.error('wikipedia_search_api_error', { status: searchResponse.status });
-              return new FunctionResult(
-                'Wikipedia search could not be completed. Please try a different search term.',
-              );
-            }
-
-            const searchData = (await searchResponse.json()) as WikipediaSearchResponse;
-
-            if (!searchData.pages || searchData.pages.length === 0) {
-              return new FunctionResult(
-                `No Wikipedia article found for "${query}". Try a different search term.`,
-              );
-            }
-
-            // Fetch the summary for the best match
-            const bestMatch = searchData.pages[0];
-            const matchUrl = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(bestMatch.key)}`;
-
-            const controller3 = new AbortController();
-            const timeout3 = setTimeout(() => controller3.abort(), 30_000);
-            let matchResponse: Response;
-            try {
-              matchResponse = await fetch(matchUrl, {
-                headers: { 'Accept': 'application/json', 'User-Agent': 'SignalWireAgentsSDK/1.0' },
-                signal: controller3.signal,
-              });
-            } finally {
-              clearTimeout(timeout3);
-            }
-
-            if (!matchResponse.ok) {
-              // Fall back to the search excerpt
-              const excerpt = bestMatch.excerpt
-                ? bestMatch.excerpt.replace(/<[^>]*>/g, '').trim()
-                : 'No summary available.';
-              return new FunctionResult(
-                `Wikipedia: ${bestMatch.title}\n\n${excerpt}`,
-              );
-            }
-
-            const matchData = (await matchResponse.json()) as WikipediaSummaryResponse;
-            const extractSentences = matchData.extract.split(/(?<=[.!?])\s+/);
-            const trimmedExtract = extractSentences
-              .slice(0, sentenceCount)
-              .join(' ')
-              .trim();
-
-            const pageUrl = matchData.content_urls?.desktop?.page ?? '';
-            const parts: string[] = [`Wikipedia: ${matchData.title}`];
-            if (matchData.description) {
-              parts.push(`(${matchData.description})`);
-            }
-            parts.push('');
-            parts.push(trimmedExtract);
-            if (pageUrl) {
-              parts.push('');
-              parts.push(`Read more: ${pageUrl}`);
-            }
-
-            return new FunctionResult(parts.join('\n').trim());
-          } catch (err) {
-            log.error('search_wikipedia_failed', { error: err instanceof Error ? err.message : String(err) });
-            return new FunctionResult(
-              'The request could not be completed. Please try again.',
-            );
-          }
+          const result = await this.searchWiki(rawQuery.trim(), sentenceCount);
+          return new FunctionResult(result);
         },
       },
     ];
+  }
+
+  /**
+   * Search Wikipedia and return a formatted text summary.
+   *
+   * Mirrors the Python `search_wiki()` public entry point so the logic can be
+   * tested and reused outside the SWAIG handler. Uses `num_results` to decide
+   * how many articles to aggregate and honors `language` / `max_content_length`.
+   *
+   * @param query - Plain-text search term.
+   * @param sentenceCount - Optional sentence cap used by the direct-summary
+   *   path (1-10).
+   * @returns Formatted text ready for display to the caller.
+   */
+  async searchWiki(query: string, sentenceCount?: number): Promise<string> {
+    const trimmedQuery = query.trim();
+    if (trimmedQuery.length === 0) {
+      return this._formatNoResults(trimmedQuery);
+    }
+
+    try {
+      // Fast path: when only one article is requested, try the REST page
+      // summary endpoint. It returns cleanly-structured data including a URL.
+      if (this._numResults === 1) {
+        const summary = await this._fetchDirectSummary(trimmedQuery, sentenceCount);
+        if (summary !== null) {
+          return this._clampContent(summary);
+        }
+      }
+
+      // Fallback / multi-result path: use the action=query search API.
+      const baseUrl = `https://${this._language}.wikipedia.org/w/api.php`;
+      const searchUrl =
+        `${baseUrl}?action=query&list=search&format=json` +
+        `&srsearch=${encodeURIComponent(trimmedQuery)}` +
+        `&srlimit=${this._numResults}`;
+
+      const searchData = await this._fetchJson<WikipediaActionSearchResponse>(
+        searchUrl,
+      );
+      if (!searchData) {
+        return 'Wikipedia search could not be completed. Please try a different search term.';
+      }
+
+      const searchResults = searchData.query?.search ?? [];
+      if (searchResults.length === 0) {
+        return this._formatNoResults(trimmedQuery);
+      }
+
+      const articles: string[] = [];
+
+      for (const result of searchResults.slice(0, this._numResults)) {
+        const title = result.title;
+        const extractUrl =
+          `${baseUrl}?action=query&prop=extracts&exintro&explaintext&format=json` +
+          `&titles=${encodeURIComponent(title)}`;
+
+        const extractData = await this._fetchJson<WikipediaActionExtractsResponse>(
+          extractUrl,
+        );
+        const pages = extractData?.query?.pages ?? {};
+        const firstPage = Object.values(pages)[0];
+        const extract = (firstPage?.extract ?? '').trim();
+
+        if (extract.length > 0) {
+          articles.push(`**${title}**\n\n${extract}`);
+        } else {
+          articles.push(`**${title}**\n\nNo summary available for this article.`);
+        }
+      }
+
+      if (articles.length === 0) {
+        return this._formatNoResults(trimmedQuery);
+      }
+
+      const separator = '\n\n' + '='.repeat(50) + '\n\n';
+      return this._clampContent(articles.join(separator));
+    } catch (err) {
+      log.error('wikipedia_search_failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return `Error searching Wikipedia: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+    }
+  }
+
+  /** Fetch and format a single direct page summary. Returns `null` to signal fallback. */
+  private async _fetchDirectSummary(
+    query: string,
+    sentenceCount?: number,
+  ): Promise<string | null> {
+    const encodedQuery = encodeURIComponent(query.replace(/\s+/g, '_'));
+    const summaryUrl = `https://${this._language}.wikipedia.org/api/rest_v1/page/summary/${encodedQuery}`;
+
+    const data = await this._fetchJson<WikipediaSummaryResponse>(summaryUrl);
+    if (!data || data.type === 'disambiguation' || !data.extract) {
+      return null;
+    }
+
+    let extractText = data.extract;
+    if (typeof sentenceCount === 'number') {
+      const pieces = extractText.split(/(?<=[.!?])\s+/);
+      extractText = pieces.slice(0, sentenceCount).join(' ').trim();
+    }
+
+    const pageUrl = data.content_urls?.desktop?.page ?? '';
+    const parts: string[] = [`Wikipedia: ${data.title}`];
+    if (data.description) {
+      parts.push(`(${data.description})`);
+    }
+    parts.push('');
+    parts.push(extractText);
+    if (pageUrl) {
+      parts.push('');
+      parts.push(`Read more: ${pageUrl}`);
+    }
+    return parts.join('\n').trim();
+  }
+
+  /** Fetch JSON with a 30-second timeout. Returns `null` on any failure. */
+  private async _fetchJson<T>(url: string): Promise<T | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30_000);
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': 'SignalWireAgentsSDK/1.0',
+        },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        return null;
+      }
+      return (await response.json()) as T;
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /** Clamp content to `max_content_length`. */
+  private _clampContent(content: string): string {
+    if (content.length <= this._maxContentLength) {
+      return content;
+    }
+    return content.slice(0, this._maxContentLength);
+  }
+
+  /** Render the configured no-results message, substituting `{query}`. */
+  private _formatNoResults(query: string): string {
+    return this._noResultsMessage.includes('{query}')
+      ? this._noResultsMessage.replace(/\{query\}/g, query)
+      : this._noResultsMessage;
   }
 
   /** @returns Prompt section describing Wikipedia search capabilities and usage guidance. */
@@ -275,13 +368,11 @@ export class WikipediaSearchSkill extends SkillBase {
     return [
       {
         title: 'Wikipedia Search',
-        body: 'You can search Wikipedia for information about any topic.',
+        body: `You can search Wikipedia for factual information using search_wiki. This will return up to ${this._numResults} Wikipedia article summaries.`,
         bullets: [
-          'Use the search_wikipedia tool when the user asks about a specific topic, person, place, or concept.',
-          'Wikipedia provides encyclopedic summaries that are generally reliable for factual information.',
-          'You can specify the number of sentences to return (1-10) for shorter or more detailed summaries.',
-          'If a search returns no results, try rephrasing with the most common name or spelling.',
-          'Summarize the information naturally rather than reading it verbatim.',
+          'Use search_wiki for factual, encyclopedic information',
+          'Great for answering questions about people, places, concepts, and history',
+          'Returns reliable, well-sourced information from Wikipedia articles',
         ],
       },
     ];

--- a/tests/SkillParameterSchemas.test.ts
+++ b/tests/SkillParameterSchemas.test.ts
@@ -93,12 +93,12 @@ describe('Skill Parameter Schemas', () => {
       expect(schema.api_key.required).toBe(true);
     });
 
-    it('WebSearchSkill has max_results with min/max', () => {
+    it('WebSearchSkill has num_results with min/max', () => {
       const schema = WebSearchSkill.getParameterSchema();
-      expect(schema.max_results).toBeDefined();
-      expect(schema.max_results.min).toBe(1);
-      expect(schema.max_results.max).toBe(10);
-      expect(schema.max_results.default).toBe(5);
+      expect(schema.num_results).toBeDefined();
+      expect(schema.num_results.min).toBe(1);
+      expect(schema.num_results.max).toBe(10);
+      expect(schema.num_results.default).toBe(3);
     });
 
     it('AskClaudeSkill has model with default', () => {
@@ -113,11 +113,11 @@ describe('Skill Parameter Schemas', () => {
       expect(schema.skills_path.required).toBe(true);
     });
 
-    it('DataSphereSkill has distance_threshold with min/max', () => {
+    it('DataSphereSkill has distance with min/max', () => {
       const schema = DataSphereSkill.getParameterSchema();
-      expect(schema.distance_threshold).toBeDefined();
-      expect(schema.distance_threshold.min).toBe(0);
-      expect(schema.distance_threshold.max).toBe(1);
+      expect(schema.distance).toBeDefined();
+      expect(schema.distance.min).toBe(0);
+      expect(schema.distance.max).toBe(10);
     });
 
     it('SwmlTransferSkill has patterns array', () => {

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -558,9 +558,9 @@ describe('WebSearchSkill', () => {
     const skill = createWebSearchSkill();
     const manifest = skill.getManifest();
     expect(manifest.name).toBe('web_search');
-    expect(manifest.version).toBe('1.0.0');
+    expect(manifest.version).toBe('2.0.0');
     expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_API_KEY');
-    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_CX');
+    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_ENGINE_ID');
   });
 
   it('should return a web_search tool', () => {
@@ -575,13 +575,15 @@ describe('WebSearchSkill', () => {
     const skill = createWebSearchSkill();
     const sections = skill.getPromptSections();
     expect(sections.length).toBeGreaterThan(0);
-    expect(sections[0].title).toBe('Web Search');
+    expect(sections[0].title).toContain('Web Search');
   });
 
   it('should return error when API keys are not set', async () => {
     const origKey = process.env['GOOGLE_SEARCH_API_KEY'];
+    const origEngine = process.env['GOOGLE_SEARCH_ENGINE_ID'];
     const origCx = process.env['GOOGLE_SEARCH_CX'];
     delete process.env['GOOGLE_SEARCH_API_KEY'];
+    delete process.env['GOOGLE_SEARCH_ENGINE_ID'];
     delete process.env['GOOGLE_SEARCH_CX'];
     const skill = createWebSearchSkill();
     const handler = skill.getTools()[0].handler;
@@ -589,6 +591,7 @@ describe('WebSearchSkill', () => {
     expect(result).toBeInstanceOf(FunctionResult);
     expect(result.response).toContain('not configured');
     if (origKey !== undefined) process.env['GOOGLE_SEARCH_API_KEY'] = origKey;
+    if (origEngine !== undefined) process.env['GOOGLE_SEARCH_ENGINE_ID'] = origEngine;
     if (origCx !== undefined) process.env['GOOGLE_SEARCH_CX'] = origCx;
   });
 });
@@ -610,11 +613,11 @@ describe('WikipediaSearchSkill', () => {
     expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should return a search_wikipedia tool', () => {
+  it('should return a search_wiki tool', () => {
     const skill = createWikipediaSearchSkill();
     const tools = skill.getTools();
     expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('search_wikipedia');
+    expect(tools[0].name).toBe('search_wiki');
     expect(tools[0].required).toContain('query');
   });
 
@@ -722,7 +725,7 @@ describe('DataSphereSkill', () => {
     const skill = createDataSphereSkill();
     const sections = skill.getPromptSections();
     expect(sections.length).toBeGreaterThan(0);
-    expect(sections[0].title).toContain('DataSphere');
+    expect(sections[0].title).toContain('Knowledge Search');
   });
 
   it('should return error when env vars are not set', async () => {
@@ -759,9 +762,8 @@ describe('DataSphereServerlessSkill', () => {
     const manifest = skill.getManifest();
     expect(manifest.name).toBe('datasphere_serverless');
     expect(manifest.version).toBe('1.0.0');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_PROJECT_ID');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_TOKEN');
-    expect(manifest.requiredEnvVars).toContain('SIGNALWIRE_SPACE');
+    // Credentials come from params by design (matches Python REQUIRED_ENV_VARS = []).
+    expect(manifest.requiredEnvVars ?? []).toEqual([]);
   });
 
   it('should return a search_datasphere tool stub', () => {

--- a/tests/skills/datasphere-serverless.test.ts
+++ b/tests/skills/datasphere-serverless.test.ts
@@ -33,10 +33,17 @@ describe('DataSphereServerlessSkill', () => {
     expect(new DataSphereServerlessSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
+  it('should return empty hints', () => {
     const skill = new DataSphereServerlessSkill();
     expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  });
+
+  it('should expose DataSphere metadata via global data', () => {
+    const skill = new DataSphereServerlessSkill({ document_id: 'doc-1' });
+    const globalData = skill.getGlobalData();
+    expect(globalData['datasphere_serverless_enabled']).toBe(true);
+    expect(globalData['document_id']).toBe('doc-1');
+    expect(globalData['knowledge_provider']).toBe('SignalWire DataSphere (Serverless)');
   });
 
   it('should return correct manifest', () => {

--- a/tests/skills/datasphere.test.ts
+++ b/tests/skills/datasphere.test.ts
@@ -34,17 +34,24 @@ describe('DataSphereSkill', () => {
   it('should provide prompt sections', () => {
     const sections = new DataSphereSkill().getPromptSections();
     expect(sections.length).toBeGreaterThan(0);
-    expect(sections[0].title).toContain('DataSphere');
+    expect(sections[0].title).toContain('Knowledge Search');
   });
 
   it('should skip prompt sections when skip_prompt is set', () => {
     expect(new DataSphereSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
+  it('should return empty hints', () => {
     const skill = new DataSphereSkill();
     expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  });
+
+  it('should expose DataSphere metadata via global data', () => {
+    const skill = new DataSphereSkill({ document_id: 'doc-1' });
+    const globalData = skill.getGlobalData();
+    expect(globalData['datasphere_enabled']).toBe(true);
+    expect(globalData['document_id']).toBe('doc-1');
+    expect(globalData['knowledge_provider']).toBe('SignalWire DataSphere');
   });
 
   it('should return correct manifest with required env vars', () => {
@@ -64,6 +71,11 @@ describe('DataSphereSkill', () => {
     expect(result.response).toContain('not configured');
   });
 
+  it('should default instance key to datasphere_search_knowledge', () => {
+    const skill = new DataSphereSkill();
+    expect(skill.getInstanceKey()).toBe('datasphere_search_knowledge');
+  });
+
   it('should use custom instance key with tool_name', () => {
     const skill = new DataSphereSkill({ tool_name: 'custom' });
     expect(skill.getInstanceKey()).toBe('datasphere_custom');
@@ -71,8 +83,13 @@ describe('DataSphereSkill', () => {
 
   it('should have a parameter schema', () => {
     const schema = DataSphereSkill.getParameterSchema();
-    expect(schema['max_results']).toBeDefined();
-    expect(schema['distance_threshold']).toBeDefined();
+    expect(schema['count']).toBeDefined();
+    expect(schema['distance']).toBeDefined();
+    expect(schema['tags']).toBeDefined();
+    expect(schema['language']).toBeDefined();
+    expect(schema['pos_to_expand']).toBeDefined();
+    expect(schema['max_synonyms']).toBeDefined();
+    expect(schema['no_results_message']).toBeDefined();
     expect(schema['tool_name']).toBeDefined();
   });
 });

--- a/tests/skills/info-gatherer.test.ts
+++ b/tests/skills/info-gatherer.test.ts
@@ -9,6 +9,8 @@ import { suppressAllLogs } from '../../src/Logger.js';
 
 beforeAll(() => { suppressAllLogs(true); });
 
+// ── Field-collection (single-shot) mode ─────────────────────────────────────
+
 describe('InfoGathererSkill', () => {
   it('should instantiate via constructor and factory', () => {
     expect(new InfoGathererSkill()).toBeInstanceOf(SkillBase);
@@ -71,5 +73,334 @@ describe('InfoGathererSkill', () => {
   it('should have a parameter schema', () => {
     const schema = InfoGathererSkill.getParameterSchema();
     expect(schema).toBeDefined();
+  });
+});
+
+// ── Sequential question flow mode ────────────────────────────────────────────
+
+describe('InfoGathererSkill — sequential question flow', () => {
+  const QUESTIONS = [
+    { key_name: 'first_name', question_text: 'What is your first name?' },
+    { key_name: 'last_name', question_text: 'What is your last name?', confirm: true },
+    { key_name: 'city', question_text: 'What city do you live in?', prompt_add: 'City only, please.' },
+  ];
+
+  // Helper: build a rawData envelope with skill state seeded under the given namespace.
+  function makeRawData(
+    namespace: string,
+    state: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return { global_data: { [namespace]: state } };
+  }
+
+  // ── setup() ──────────────────────────────────────────────────────────
+
+  it('setup() — populates instance state from valid questions config', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    // After setup, getTools() must return sequential tools (not field tools).
+    const tools = skill.getTools();
+    expect(tools).toHaveLength(2);
+    expect(tools[0].name).toBe('start_questions');
+    expect(tools[1].name).toBe('submit_answer');
+  });
+
+  it('setup() — uses prefix to derive tool names', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS, prefix: 'survey' });
+    await skill.setup();
+    const tools = skill.getTools();
+    expect(tools[0].name).toBe('survey_start_questions');
+    expect(tools[1].name).toBe('survey_submit_answer');
+  });
+
+  it('setup() — applies custom completion_message', async () => {
+    const custom = 'All done! Thank you.';
+    const skill = new InfoGathererSkill({ questions: QUESTIONS, completion_message: custom });
+    await skill.setup();
+    // Drive all the way to completion to observe the message.
+    const namespace = 'skill:info_gatherer';
+    const submitTool = skill.getTools()[1];
+    // Answer question 1
+    let state: Record<string, unknown> = { questions: QUESTIONS, question_index: 0, answers: [] };
+    let rawData = makeRawData(namespace, state);
+    let result = submitTool.handler({ answer: 'Alice', confirmed_by_user: false }, rawData) as { response: string };
+    // Advance state (simulate updateSkillData)
+    state = { questions: QUESTIONS, question_index: 1, answers: [{ key_name: 'first_name', answer: 'Alice' }] };
+    // Answer question 2 (requires confirmation)
+    rawData = makeRawData(namespace, state);
+    result = submitTool.handler({ answer: 'Smith', confirmed_by_user: true }, rawData) as { response: string };
+    state = { questions: QUESTIONS, question_index: 2, answers: [{ key_name: 'first_name', answer: 'Alice' }, { key_name: 'last_name', answer: 'Smith' }] };
+    // Answer question 3 — last question
+    rawData = makeRawData(namespace, state);
+    result = submitTool.handler({ answer: 'Portland', confirmed_by_user: false }, rawData) as { response: string };
+    expect(result.response).toBe(custom);
+  });
+
+  it('setup() — silently ignores invalid questions config (empty array)', async () => {
+    const skill = new InfoGathererSkill({ questions: [] });
+    await skill.setup();
+    // Empty questions → treated as no questions configured → field-only mode
+    expect(skill.getTools()).toHaveLength(0);
+  });
+
+  it('setup() — silently ignores non-array questions config', async () => {
+    const skill = new InfoGathererSkill({ questions: 'not-an-array' });
+    await skill.setup();
+    expect(skill.getTools()).toHaveLength(0);
+  });
+
+  it('setup() — silently ignores question missing key_name', async () => {
+    const skill = new InfoGathererSkill({
+      questions: [{ question_text: 'What is your name?' }],
+    });
+    await skill.setup();
+    expect(skill.getTools()).toHaveLength(0);
+  });
+
+  it('setup() — silently ignores question missing question_text', async () => {
+    const skill = new InfoGathererSkill({
+      questions: [{ key_name: 'name' }],
+    });
+    await skill.setup();
+    expect(skill.getTools()).toHaveLength(0);
+  });
+
+  // ── getInstanceKey() ─────────────────────────────────────────────────
+
+  it('getInstanceKey() — returns "info_gatherer" when no prefix', () => {
+    expect(new InfoGathererSkill().getInstanceKey()).toBe('info_gatherer');
+  });
+
+  it('getInstanceKey() — returns "info_gatherer_<prefix>" when prefix set', () => {
+    expect(new InfoGathererSkill({ prefix: 'intake' }).getInstanceKey()).toBe('info_gatherer_intake');
+  });
+
+  // ── getGlobalData() ──────────────────────────────────────────────────
+
+  it('getGlobalData() — returns empty object when no questions configured', () => {
+    expect(new InfoGathererSkill().getGlobalData()).toEqual({});
+  });
+
+  it('getGlobalData() — seeds question state after setup() with questions', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const globalData = skill.getGlobalData();
+    const namespace = skill.getSkillNamespace();
+    expect(globalData).toHaveProperty(namespace);
+    const state = globalData[namespace] as Record<string, unknown>;
+    expect(state['question_index']).toBe(0);
+    expect(state['answers']).toEqual([]);
+    expect(Array.isArray(state['questions'])).toBe(true);
+    expect((state['questions'] as unknown[]).length).toBe(QUESTIONS.length);
+  });
+
+  it('getGlobalData() — uses prefix in namespace key', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS, prefix: 'survey' });
+    await skill.setup();
+    const globalData = skill.getGlobalData();
+    // With prefix, namespace is "skill:survey" (config['prefix'] takes priority in getSkillNamespace)
+    expect(globalData).toHaveProperty('skill:survey');
+  });
+
+  // ── SUPPORTS_MULTIPLE_INSTANCES ──────────────────────────────────────
+
+  it('SUPPORTS_MULTIPLE_INSTANCES is true', () => {
+    expect(InfoGathererSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
+  });
+
+  // ── start_questions tool ─────────────────────────────────────────────
+
+  it('start_questions — returns first question instruction when state is fresh', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const startTool = skill.getTools()[0];
+    expect(startTool.name).toBe('start_questions');
+
+    const namespace = skill.getSkillNamespace();
+    const state = { questions: QUESTIONS, question_index: 0, answers: [] };
+    const rawData = makeRawData(namespace, state);
+
+    const result = startTool.handler({}, rawData) as { response: string };
+    expect(result.response).toContain(QUESTIONS[0].question_text);
+    expect(result.response).toContain('Question 1 of 3');
+  });
+
+  it('start_questions — includes submit tool name in instruction', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS, prefix: 'q' });
+    await skill.setup();
+    const startTool = skill.getTools()[0];
+    const namespace = skill.getSkillNamespace();
+    const rawData = makeRawData(namespace, { questions: QUESTIONS, question_index: 0, answers: [] });
+    const result = startTool.handler({}, rawData) as { response: string };
+    expect(result.response).toContain('q_submit_answer');
+  });
+
+  it('start_questions — returns no-questions message when questions array is empty in state', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const startTool = skill.getTools()[0];
+    const namespace = skill.getSkillNamespace();
+    // State has empty questions array
+    const rawData = makeRawData(namespace, { questions: [], question_index: 0, answers: [] });
+    const result = startTool.handler({}, rawData) as { response: string };
+    expect(result.response).toContain("don't have any questions");
+  });
+
+  // ── submit_answer tool ───────────────────────────────────────────────
+
+  it('submit_answer — valid answer advances to next question', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    const state = { questions: QUESTIONS, question_index: 0, answers: [] };
+    const rawData = makeRawData(namespace, state);
+
+    const result = submitTool.handler({ answer: 'Alice', confirmed_by_user: false }, rawData) as { response: string; action: Record<string, unknown>[] };
+    // Should return the second question instruction
+    expect(result.response).toContain(QUESTIONS[1].question_text);
+    expect(result.response).toContain('Question 2 of 3');
+  });
+
+  it('submit_answer — confirm=true question is rejected without confirmed_by_user flag', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    // question_index=1 is the confirm:true question
+    const state = {
+      questions: QUESTIONS,
+      question_index: 1,
+      answers: [{ key_name: 'first_name', answer: 'Alice' }],
+    };
+    const rawData = makeRawData(namespace, state);
+
+    const result = submitTool.handler({ answer: 'Smith', confirmed_by_user: false }, rawData) as { response: string };
+    expect(result.response).toContain('must read the answer');
+    expect(result.response).toContain('"Smith"');
+  });
+
+  it('submit_answer — confirm=true question succeeds with confirmed_by_user=true', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    const state = {
+      questions: QUESTIONS,
+      question_index: 1,
+      answers: [{ key_name: 'first_name', answer: 'Alice' }],
+    };
+    const rawData = makeRawData(namespace, state);
+
+    const result = submitTool.handler({ answer: 'Smith', confirmed_by_user: true }, rawData) as { response: string };
+    // Should proceed to question 3
+    expect(result.response).toContain(QUESTIONS[2].question_text);
+    expect(result.response).toContain('Question 3 of 3');
+  });
+
+  it('submit_answer — prompt_add text is included in the next question instruction', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    // Advance past questions 1 and 2 (confirm) to reach question 3 (city, has prompt_add)
+    const state = {
+      questions: QUESTIONS,
+      question_index: 1,
+      answers: [{ key_name: 'first_name', answer: 'Alice' }],
+    };
+    const rawData = makeRawData(namespace, state);
+    // Answer q2 with confirmation
+    const result = submitTool.handler({ answer: 'Smith', confirmed_by_user: true }, rawData) as { response: string };
+    expect(result.response).toContain('City only, please.');
+  });
+
+  it('submit_answer — last question triggers completion and disables tools', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    const state = {
+      questions: QUESTIONS,
+      question_index: 2,
+      answers: [
+        { key_name: 'first_name', answer: 'Alice' },
+        { key_name: 'last_name', answer: 'Smith' },
+      ],
+    };
+    const rawData = makeRawData(namespace, state);
+
+    const result = submitTool.handler({ answer: 'Portland', confirmed_by_user: false }, rawData) as { response: string; action: Record<string, unknown>[] };
+    // Response should be the completion message
+    expect(result.response).toContain('Thank you! All questions have been answered');
+    // Action should include toggle_functions to disable both tools
+    const toggleAction = result.action.find((a) => 'toggle_functions' in a);
+    expect(toggleAction).toBeDefined();
+    const toggles = toggleAction!['toggle_functions'] as Array<{ function: string; active: boolean }>;
+    const startToggle = toggles.find((t) => t.function === 'start_questions');
+    const submitToggle = toggles.find((t) => t.function === 'submit_answer');
+    expect(startToggle?.active).toBe(false);
+    expect(submitToggle?.active).toBe(false);
+  });
+
+  it('submit_answer — last question also writes updated state via set_global_data', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    const state = {
+      questions: QUESTIONS,
+      question_index: 2,
+      answers: [
+        { key_name: 'first_name', answer: 'Alice' },
+        { key_name: 'last_name', answer: 'Smith' },
+      ],
+    };
+    const rawData = makeRawData(namespace, state);
+    const result = submitTool.handler({ answer: 'Portland', confirmed_by_user: false }, rawData) as { response: string; action: Record<string, unknown>[] };
+
+    const globalDataAction = result.action.find((a) => 'set_global_data' in a);
+    expect(globalDataAction).toBeDefined();
+    const updatedData = globalDataAction!['set_global_data'] as Record<string, unknown>;
+    const newState = updatedData[namespace] as Record<string, unknown>;
+    expect(newState['question_index']).toBe(3);
+    expect((newState['answers'] as unknown[]).length).toBe(3);
+  });
+
+  it('submit_answer — returns "all answered" message when index is already at end', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const submitTool = skill.getTools()[1];
+    const namespace = skill.getSkillNamespace();
+
+    const state = {
+      questions: QUESTIONS,
+      question_index: 3, // past the end
+      answers: [
+        { key_name: 'first_name', answer: 'Alice' },
+        { key_name: 'last_name', answer: 'Smith' },
+        { key_name: 'city', answer: 'Portland' },
+      ],
+    };
+    const rawData = makeRawData(namespace, state);
+    const result = submitTool.handler({ answer: 'extra', confirmed_by_user: false }, rawData) as { response: string };
+    expect(result.response).toBe('All questions have already been answered.');
+  });
+
+  // ── Prompt sections ──────────────────────────────────────────────────
+
+  it('provides sequential prompt section when questions are configured', async () => {
+    const skill = new InfoGathererSkill({ questions: QUESTIONS });
+    await skill.setup();
+    const sections = skill.getPromptSections();
+    expect(sections.length).toBeGreaterThan(0);
+    expect(sections[0].body).toContain('start_questions');
+    expect(sections[0].body).toContain('submit_answer');
   });
 });

--- a/tests/skills/web-search.test.ts
+++ b/tests/skills/web-search.test.ts
@@ -30,28 +30,35 @@ describe('WebSearchSkill', () => {
   it('should provide prompt sections', () => {
     const sections = new WebSearchSkill().getPromptSections();
     expect(sections.length).toBeGreaterThan(0);
-    expect(sections[0].title).toBe('Web Search');
+    expect(sections[0].title).toContain('Web Search');
   });
 
   it('should skip prompt sections when skip_prompt is set', () => {
     expect(new WebSearchSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
+  it('should return empty hints', () => {
     const skill = new WebSearchSkill();
     expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  });
+
+  it('should expose web search metadata via global data', () => {
+    const globalData = new WebSearchSkill().getGlobalData();
+    expect(globalData['web_search_enabled']).toBe(true);
+    expect(globalData['search_provider']).toBe('Google Custom Search');
   });
 
   it('should return correct manifest with required env vars', () => {
     const manifest = new WebSearchSkill().getManifest();
     expect(manifest.name).toBe('web_search');
+    expect(manifest.version).toBe('2.0.0');
     expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_API_KEY');
-    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_CX');
+    expect(manifest.requiredEnvVars).toContain('GOOGLE_SEARCH_ENGINE_ID');
   });
 
   it('should return error when API keys are missing', async () => {
     delete process.env['GOOGLE_SEARCH_API_KEY'];
+    delete process.env['GOOGLE_SEARCH_ENGINE_ID'];
     delete process.env['GOOGLE_SEARCH_CX'];
     const handler = new WebSearchSkill().getTools()[0].handler;
     const result = await handler({ query: 'test' }, {}) as FunctionResult;
@@ -64,9 +71,24 @@ describe('WebSearchSkill', () => {
     expect(result.response).toContain('provide a search query');
   });
 
+  it('should support multiple instances', () => {
+    expect(WebSearchSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
+  });
+
+  it('should compute instance key from search_engine_id and tool_name', () => {
+    const skill = new WebSearchSkill({ search_engine_id: 'cx-1', tool_name: 'custom' });
+    expect(skill.getInstanceKey()).toBe('web_search_cx-1_custom');
+  });
+
   it('should have a parameter schema', () => {
     const schema = WebSearchSkill.getParameterSchema();
-    expect(schema['max_results']).toBeDefined();
+    expect(schema['num_results']).toBeDefined();
+    expect(schema['tool_name']).toBeDefined();
+    expect(schema['no_results_message']).toBeDefined();
     expect(schema['safe_search']).toBeDefined();
+    expect(schema['delay']).toBeDefined();
+    expect(schema['max_content_length']).toBeDefined();
+    expect(schema['oversample_factor']).toBeDefined();
+    expect(schema['min_quality_score']).toBeDefined();
   });
 });

--- a/tests/skills/wikipedia.test.ts
+++ b/tests/skills/wikipedia.test.ts
@@ -20,10 +20,10 @@ describe('WikipediaSearchSkill', () => {
     await expect(new WikipediaSearchSkill().setup()).resolves.toBeUndefined();
   });
 
-  it('should register a search_wikipedia tool', () => {
+  it('should register a search_wiki tool', () => {
     const tools = new WikipediaSearchSkill().getTools();
     expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('search_wikipedia');
+    expect(tools[0].name).toBe('search_wiki');
     expect(tools[0].required).toContain('query');
   });
 
@@ -52,12 +52,14 @@ describe('WikipediaSearchSkill', () => {
   it('should reject empty query', async () => {
     const handler = new WikipediaSearchSkill().getTools()[0].handler;
     const result = await handler({ query: '' }, {}) as FunctionResult;
-    expect(result.response).toContain('provide a topic');
+    expect(result.response).toContain('provide a search query');
   });
 
   it('should have a parameter schema', () => {
     const schema = WikipediaSearchSkill.getParameterSchema();
+    expect(schema['num_results']).toBeDefined();
+    expect(schema['no_results_message']).toBeDefined();
     expect(schema['language']).toBeDefined();
-    expect(schema['max_results']).toBeDefined();
+    expect(schema['max_content_length']).toBeDefined();
   });
 });


### PR DESCRIPTION
## What this PR does

Aligns 5 medium-gap skills with Python — 57 gaps across InfoGatherer, DataSphere (2), WebSearch, Wikipedia.

## Changes

**InfoGathererSkill (15 gaps):** Sequential question flow — `start_questions`/`submit_answer` tools, state seeding via global_data, prefix-based instance key, validation.

**DataSphereServerlessSkill (11 gaps):** Added `tags`/`language`/`pos_to_expand`/`max_synonyms`/`no_results_message` params, `getGlobalData` override, aligned `count`/`distance` naming, removed required env vars.

**DataSphereSkill (11 gaps):** Same schema additions plus response key fix (`chunks` instead of `results`), new formatter matching Python's `_format_search_results`.

**WebSearchSkill (11 gaps):** `SUPPORTS_MULTIPLE_INSTANCES=true`, `getGlobalData` + `getInstanceKey` overrides, `no_results_message`/`tool_name`/`num_results` + scraping-parity params, env var renamed to `GOOGLE_SEARCH_ENGINE_ID` with CX fallback.

**WikipediaSearchSkill (9 gaps):** `setup()` override, public `searchWiki()`, wired `language`/`num_results`/`max_content_length`, tool renamed to `search_wiki`.

## Verification

- `npm run build` passes
- 1443/1443 tests pass

Closes #21
Closes #22
Closes #33
Closes #67
Closes #69