### PR TITLE
Align Skills batch 1 (high-gap skills) with Python SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "signalwire-agents",
-  "version": "0.1.0",
+  "name": "@signalwire/sdk",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "signalwire-agents",
-      "version": "0.1.0",
+      "name": "@signalwire/sdk",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.11.0",

--- a/src/AgentBase.ts
+++ b/src/AgentBase.ts
@@ -1074,10 +1074,15 @@ export class AgentBase {
     // Register skill tools, then apply any swaigFields as extraFields on the SWAIG function
     for (const toolDef of skill.getTools()) {
       this.defineTool(toolDef);
-      if (Object.keys(skill.swaigFields).length > 0) {
-        const fn = this.toolRegistry.get(toolDef.name);
-        if (fn instanceof SwaigFunction) {
+      const fn = this.toolRegistry.get(toolDef.name);
+      if (fn instanceof SwaigFunction) {
+        if (Object.keys(skill.swaigFields).length > 0) {
           safeAssign(fn.extraFields, skill.swaigFields);
+        }
+        // Propagate is_hangup_hook so the SignalWire platform auto-fires this
+        // tool on call hangup (Python equivalent: is_hangup_hook=True in define_tool).
+        if (toolDef.isHangupHook) {
+          fn.extraFields['is_hangup_hook'] = true;
         }
       }
     }
@@ -1504,10 +1509,13 @@ export class AgentBase {
 
         for (const toolDef of skill.getTools()) {
           copy.defineTool(toolDef);
-          if (Object.keys(skill.swaigFields).length > 0) {
-            const fn = copy.toolRegistry.get(toolDef.name);
-            if (fn instanceof SwaigFunction) {
+          const fn = copy.toolRegistry.get(toolDef.name);
+          if (fn instanceof SwaigFunction) {
+            if (Object.keys(skill.swaigFields).length > 0) {
               safeAssign(fn.extraFields, skill.swaigFields);
+            }
+            if (toolDef.isHangupHook) {
+              fn.extraFields['is_hangup_hook'] = true;
             }
           }
         }

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -30,6 +30,13 @@ export interface SkillToolDefinition {
   fillers?: Record<string, string[]>;
   /** List of parameter names that are required. */
   required?: string[];
+  /**
+   * When true, the SignalWire platform automatically invokes this tool when
+   * the call ends (hangup), regardless of whether the AI explicitly calls it.
+   * Equivalent to Python's `is_hangup_hook=True` in `define_tool()`.
+   * The flag is serialised as `"is_hangup_hook": true` in the SWAIG JSON.
+   */
+  isHangupHook?: boolean;
 }
 
 /** A section of prompt content injected into the agent's system prompt by a skill. */

--- a/src/skills/builtin/mcp_gateway.ts
+++ b/src/skills/builtin/mcp_gateway.ts
@@ -1,10 +1,13 @@
 /**
- * MCP Gateway Skill - Placeholder for Model Context Protocol integration.
+ * MCP Gateway Skill - Bridge MCP servers with SWAIG functions.
  *
- * Tier 3 built-in skill: stub implementation for future MCP server gateway.
- * This skill will eventually allow agents to invoke tools exposed by MCP
- * (Model Context Protocol) servers, enabling integration with external
- * tool providers via the MCP standard.
+ * Port of the Python `MCPGatewaySkill`. Connects SignalWire agents to a
+ * Model Context Protocol gateway HTTP service and dynamically registers
+ * SWAIG tools for every MCP tool exposed by the configured services.
+ *
+ * Authentication: Bearer token (via `auth_token`) or HTTP Basic auth
+ * (via `auth_user` + `auth_password`). Supports configurable timeouts,
+ * retry attempts, and SSL verification.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -16,13 +19,35 @@ import type {
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
+import { getLogger } from '../../Logger.js';
+
+const log = getLogger('McpGatewaySkill');
+
+/** Configuration entry for a single MCP service to expose. */
+interface McpServiceConfig {
+  /** Service name as registered on the gateway. */
+  name: string;
+  /** Tools to expose: '*' for all, array of names to filter, or undefined. */
+  tools?: string | string[];
+}
+
+/** MCP tool definition returned by the gateway's /services/<name>/tools endpoint. */
+interface McpToolDefinition {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    properties?: Record<string, { type?: string; description?: string; enum?: unknown[]; default?: unknown }>;
+    required?: string[];
+  };
+}
 
 /**
- * Placeholder skill for future Model Context Protocol (MCP) server integration.
+ * Bridge MCP (Model Context Protocol) servers with SWAIG functions.
  *
- * Tier 3 stub implementation. When fully implemented, this skill will allow
- * agents to invoke tools exposed by external MCP servers. Currently provides
- * a non-functional `mcp_invoke` tool that returns a "not yet implemented" message.
+ * When configured, calls a gateway's `/services` endpoint to discover MCP
+ * services, enumerates each service's tools, and registers them as SWAIG
+ * tools prefixed with `tool_prefix` (default `mcp_`). A hidden hangup hook
+ * tool cleans up MCP sessions when the call ends.
  */
 export class McpGatewaySkill extends SkillBase {
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
@@ -30,82 +55,545 @@ export class McpGatewaySkill extends SkillBase {
       ...super.getParameterSchema(),
       gateway_url: {
         type: 'string',
-        description: 'URL of the MCP gateway server.',
-      },
-      tool_prefix: {
-        type: 'string',
-        description: 'Prefix for tool names from this gateway.',
+        description: 'URL of the MCP Gateway service',
+        required: true,
       },
       auth_token: {
         type: 'string',
-        description: 'Authentication token for the MCP gateway.',
+        description:
+          'Bearer token for authentication (alternative to basic auth)',
+        required: false,
         hidden: true,
+        env_var: 'MCP_GATEWAY_AUTH_TOKEN',
+      },
+      auth_user: {
+        type: 'string',
+        description:
+          'Username for basic authentication (required if auth_token not provided)',
+        required: false,
+        env_var: 'MCP_GATEWAY_AUTH_USER',
+      },
+      auth_password: {
+        type: 'string',
+        description:
+          'Password for basic authentication (required if auth_token not provided)',
+        required: false,
+        hidden: true,
+        env_var: 'MCP_GATEWAY_AUTH_PASSWORD',
+      },
+      services: {
+        type: 'array',
+        description:
+          'List of MCP services to connect to (empty for all available)',
+        default: [],
+        required: false,
+        items: { type: 'object' },
+      },
+      session_timeout: {
+        type: 'integer',
+        description: 'Session timeout in seconds',
+        default: 300,
+        required: false,
+      },
+      tool_prefix: {
+        type: 'string',
+        description: 'Prefix for registered SWAIG function names',
+        default: 'mcp_',
+        required: false,
+      },
+      retry_attempts: {
+        type: 'integer',
+        description: 'Number of retry attempts for failed requests',
+        default: 3,
+        required: false,
+      },
+      request_timeout: {
+        type: 'integer',
+        description: 'Request timeout in seconds',
+        default: 30,
+        required: false,
+      },
+      verify_ssl: {
+        type: 'boolean',
+        description: 'Verify SSL certificates',
+        default: true,
+        required: false,
       },
     };
   }
 
+  // Runtime state populated in setup()
+  private gatewayUrl = '';
+  private authToken: string | undefined;
+  private authUser: string | undefined;
+  private authPassword: string | undefined;
+  private services: McpServiceConfig[] = [];
+  private sessionTimeout = 300;
+  private toolPrefix = 'mcp_';
+  private retryAttempts = 3;
+  private requestTimeout = 30;
+  private verifySsl = true;
+  private sessionId: string | undefined;
+  private _discoveredTools: SkillToolDefinition[] = [];
+  private _ready = false;
+
   /**
-   * @param config - Optional configuration (reserved for future MCP server settings).
+   * @param config - Optional configuration (see `getParameterSchema()`).
    */
   constructor(config?: SkillConfig) {
     super('mcp_gateway', config);
   }
 
-  /** @returns Manifest with placeholder metadata for the MCP gateway. */
+  /** @returns Manifest for the MCP gateway skill. */
   getManifest(): SkillManifest {
     return {
       name: 'mcp_gateway',
-      description: 'MCP protocol gateway (placeholder). Will provide integration with Model Context Protocol servers for external tool invocation.',
-      version: '0.1.0',
+      description: 'Bridge MCP servers with SWAIG functions',
+      version: '1.0.0',
       author: 'SignalWire',
-      tags: ['mcp', 'gateway', 'protocol', 'tools', 'integration', 'placeholder'],
+      tags: ['mcp', 'gateway', 'protocol', 'tools', 'integration'],
+      requiredEnvVars: [],
     };
   }
 
-  /** @returns A single placeholder `mcp_invoke` tool (not yet functional). */
+  override async setup(): Promise<void> {
+    this.authToken =
+      this.getConfig<string | undefined>('auth_token', undefined) ??
+      process.env['MCP_GATEWAY_AUTH_TOKEN'];
+
+    const gatewayUrl = this.getConfig<string | undefined>('gateway_url', undefined);
+    if (!gatewayUrl) {
+      log.error('mcp_gateway: missing required parameter: gateway_url');
+      return;
+    }
+
+    if (!this.authToken) {
+      this.authUser =
+        this.getConfig<string | undefined>('auth_user', undefined) ??
+        process.env['MCP_GATEWAY_AUTH_USER'];
+      this.authPassword =
+        this.getConfig<string | undefined>('auth_password', undefined) ??
+        process.env['MCP_GATEWAY_AUTH_PASSWORD'];
+      if (!this.authUser || !this.authPassword) {
+        log.error(
+          'mcp_gateway: missing required parameters: auth_token or (auth_user + auth_password)',
+        );
+        return;
+      }
+    }
+
+    this.gatewayUrl = gatewayUrl.replace(/\/+$/, '');
+    this.services =
+      this.getConfig<McpServiceConfig[]>('services', []) ?? [];
+    this.sessionTimeout = this.getConfig<number>('session_timeout', 300);
+    this.toolPrefix = this.getConfig<string>('tool_prefix', 'mcp_');
+    this.retryAttempts = this.getConfig<number>('retry_attempts', 3);
+    this.requestTimeout = this.getConfig<number>('request_timeout', 30);
+    this.verifySsl = this.getConfig<boolean>('verify_ssl', true);
+
+    this.sessionId = undefined;
+
+    // Validate gateway connectivity
+    try {
+      const health = await this._makeRequest('GET', `${this.gatewayUrl}/health`);
+      if (!health.ok) {
+        log.error('mcp_gateway: gateway health check failed', {
+          status: health.status,
+        });
+        return;
+      }
+      log.info('mcp_gateway: connected', { url: this.gatewayUrl });
+    } catch (err) {
+      log.error('mcp_gateway: failed to connect to gateway', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    // Discover tools (equivalent of Python register_tools())
+    try {
+      await this._discoverTools();
+      this._ready = true;
+    } catch (err) {
+      log.error('mcp_gateway: tool discovery failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  override getHints(): string[] {
+    const hints = ['MCP', 'gateway'];
+    const services =
+      this.services.length > 0
+        ? this.services
+        : (this.getConfig<McpServiceConfig[]>('services', []) ?? []);
+    for (const service of services) {
+      if (service && typeof service === 'object' && service.name) {
+        hints.push(service.name);
+      }
+    }
+    return hints;
+  }
+
+  override getGlobalData(): Record<string, unknown> {
+    if (!this._ready) return {};
+    return {
+      mcp_gateway_url: this.gatewayUrl,
+      mcp_session_id: this.sessionId ?? null,
+      mcp_services: this.services
+        .map((s) => (typeof s === 'object' && s !== null ? s.name : String(s)))
+        .filter(Boolean),
+    };
+  }
+
+  /**
+   * @returns Dynamically discovered MCP tools plus an internal hangup-cleanup
+   *          tool. If discovery has not completed, returns a single fallback
+   *          `mcp_invoke` tool that explains configuration is missing.
+   */
   getTools(): SkillToolDefinition[] {
+    if (!this._ready || this._discoveredTools.length === 0) {
+      return [
+        {
+          name: 'mcp_invoke',
+          description:
+            'MCP gateway is not configured. Provide gateway_url and credentials to enable this skill.',
+          parameters: {
+            server: {
+              type: 'string',
+              description: 'The MCP server/service name.',
+            },
+            method: {
+              type: 'string',
+              description: 'The method/tool name to invoke.',
+            },
+            params: {
+              type: 'object',
+              description: 'Parameters to pass to the MCP method.',
+            },
+          },
+          required: ['server', 'method'],
+          handler: () =>
+            new FunctionResult(
+              'MCP gateway is not configured. Set gateway_url and an auth method (auth_token or auth_user/auth_password) on the skill config.',
+            ),
+        },
+      ];
+    }
+
+    // Append hangup hook tool
+    const tools = [...this._discoveredTools];
+    tools.push({
+      name: '_mcp_gateway_hangup',
+      description: 'Internal cleanup function for MCP sessions',
+      parameters: {},
+      handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) =>
+        this._hangupHandler(args, rawData),
+    });
+    return tools;
+  }
+
+  /** @returns Prompt section listing configured MCP services. */
+  protected override _getPromptSections(): SkillPromptSection[] {
+    // Prefer runtime-resolved services (after setup); fall back to config.
+    const services =
+      this.services.length > 0
+        ? this.services
+        : (this.getConfig<McpServiceConfig[]>('services', []) ?? []);
+    const gatewayUrl = this.gatewayUrl || this.getConfig<string>('gateway_url', '');
+    const toolPrefix = this.toolPrefix || this.getConfig<string>('tool_prefix', 'mcp_');
+    const serviceDescriptions: string[] = [];
+    for (const service of services) {
+      if (typeof service !== 'object' || service === null) continue;
+      const name = service.name ?? 'Unknown';
+      const tools = service.tools ?? '*';
+      if (tools === '*') {
+        serviceDescriptions.push(`${name} (all tools)`);
+      } else if (Array.isArray(tools)) {
+        serviceDescriptions.push(`${name} (${tools.length} tools)`);
+      } else {
+        serviceDescriptions.push(String(name));
+      }
+    }
+
+    if (serviceDescriptions.length === 0) {
+      return [];
+    }
+
     return [
       {
-        name: 'mcp_invoke',
-        description:
-          'Invoke a method on an MCP (Model Context Protocol) server. Currently a placeholder for future implementation.',
-        parameters: {
-          server: {
-            type: 'string',
-            description: 'The MCP server name or URL to connect to.',
-          },
-          method: {
-            type: 'string',
-            description: 'The method/tool name to invoke on the MCP server.',
-          },
-          params: {
-            type: 'object',
-            description: 'Parameters to pass to the MCP method.',
-          },
-        },
-        required: ['server', 'method'],
-        handler: () => {
-          return new FunctionResult(
-            'MCP gateway is not yet implemented. Configure MCP servers to use this skill.',
-          );
-        },
+        title: 'MCP Gateway Integration',
+        body: 'You have access to external MCP (Model Context Protocol) services through a gateway.',
+        bullets: [
+          `Connected to gateway at ${gatewayUrl}`,
+          `Available services: ${serviceDescriptions.join(', ')}`,
+          `Functions are prefixed with '${toolPrefix}' followed by service name`,
+          'Each service maintains its own session state throughout the call',
+        ],
       },
     ];
   }
 
-  /** @returns Prompt section explaining the MCP gateway placeholder status. */
-  protected override _getPromptSections(): SkillPromptSection[] {
-    return [
-      {
-        title: 'MCP Gateway (Placeholder)',
-        body: 'The MCP gateway skill is available but not yet fully implemented.',
-        bullets: [
-          'The mcp_invoke tool is a placeholder for future MCP (Model Context Protocol) integration.',
-          'When implemented, it will allow you to invoke tools from external MCP servers.',
-          'If a user asks about MCP functionality, let them know it is planned for a future release.',
-        ],
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Build auth + timeout-bearing fetch request to the gateway. */
+  private async _makeRequest(
+    method: string,
+    url: string,
+    options: { body?: unknown; headers?: Record<string, string> } = {},
+  ): Promise<Response> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...(options.headers ?? {}),
+    };
+
+    if (this.authToken) {
+      headers['Authorization'] = `Bearer ${this.authToken}`;
+    } else if (this.authUser && this.authPassword) {
+      const creds = Buffer.from(`${this.authUser}:${this.authPassword}`).toString(
+        'base64',
+      );
+      headers['Authorization'] = `Basic ${creds}`;
+    }
+
+    const init: RequestInit = { method, headers };
+    if (options.body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      init.body = JSON.stringify(options.body);
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      this.requestTimeout * 1000,
+    );
+    init.signal = controller.signal;
+
+    try {
+      return await fetch(url, init);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Discover available services and register each MCP tool as a SWAIG tool. */
+  private async _discoverTools(): Promise<void> {
+    this._discoveredTools = [];
+
+    // If no services configured, fetch all available
+    let services = this.services;
+    if (services.length === 0) {
+      const response = await this._makeRequest(
+        'GET',
+        `${this.gatewayUrl}/services`,
+      );
+      if (!response.ok) {
+        log.error('mcp_gateway: failed to list services', {
+          status: response.status,
+        });
+        return;
+      }
+      const allServices = (await response.json()) as Record<string, unknown>;
+      services = Object.keys(allServices).map((name) => ({ name }));
+      this.services = services;
+    }
+
+    for (const serviceConfig of services) {
+      const serviceName = serviceConfig?.name;
+      if (!serviceName) continue;
+
+      try {
+        const response = await this._makeRequest(
+          'GET',
+          `${this.gatewayUrl}/services/${encodeURIComponent(serviceName)}/tools`,
+        );
+        if (!response.ok) {
+          log.error('mcp_gateway: failed to get tools for service', {
+            service: serviceName,
+            status: response.status,
+          });
+          continue;
+        }
+        const data = (await response.json()) as { tools?: McpToolDefinition[] };
+        let tools = data.tools ?? [];
+
+        // Filter tools if specified
+        const toolFilter = serviceConfig.tools ?? '*';
+        if (toolFilter !== '*' && Array.isArray(toolFilter)) {
+          tools = tools.filter((t) => toolFilter.includes(t.name));
+        }
+
+        for (const toolDef of tools) {
+          const registered = this._registerMcpTool(serviceName, toolDef);
+          if (registered) this._discoveredTools.push(registered);
+        }
+      } catch (err) {
+        log.error('mcp_gateway: error fetching tools for service', {
+          service: serviceName,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  /** Convert an MCP tool definition into a SWAIG-compatible `SkillToolDefinition`. */
+  private _registerMcpTool(
+    serviceName: string,
+    toolDef: McpToolDefinition,
+  ): SkillToolDefinition | null {
+    const toolName = toolDef.name;
+    if (!toolName) return null;
+
+    const swaigName = `${this.toolPrefix}${serviceName}_${toolName}`;
+
+    const inputSchema = toolDef.inputSchema ?? {};
+    const properties = inputSchema.properties ?? {};
+    const required = inputSchema.required ?? [];
+
+    const swaigParams: Record<string, Record<string, unknown>> = {};
+    for (const [propName, propDef] of Object.entries(properties)) {
+      const paramDef: Record<string, unknown> = {
+        type: propDef.type ?? 'string',
+        description: propDef.description ?? '',
+      };
+      if (propDef.enum !== undefined) paramDef['enum'] = propDef.enum;
+      if (propDef.default !== undefined && !required.includes(propName)) {
+        paramDef['default'] = propDef.default;
+      }
+      swaigParams[propName] = paramDef;
+    }
+
+    log.info('mcp_gateway: registering SWAIG tool', { name: swaigName });
+
+    return {
+      name: swaigName,
+      description: `[${serviceName}] ${toolDef.description ?? toolName}`,
+      parameters: swaigParams,
+      required,
+      handler: async (
+        args: Record<string, unknown>,
+        rawData: Record<string, unknown>,
+      ) => this._callMcpTool(serviceName, toolName, args, rawData),
+    };
+  }
+
+  /** Call an MCP tool through the gateway, with retries. */
+  private async _callMcpTool(
+    serviceName: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    rawData: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    const globalData = (rawData['global_data'] as Record<string, unknown>) ?? {};
+    let sessionId: string;
+    if (typeof globalData['mcp_call_id'] === 'string') {
+      sessionId = globalData['mcp_call_id'] as string;
+      log.info('mcp_gateway: using session ID from global_data.mcp_call_id', {
+        sessionId,
+      });
+    } else {
+      sessionId = (rawData['call_id'] as string) ?? 'unknown';
+      log.info('mcp_gateway: using session ID from call_id', { sessionId });
+    }
+    this.sessionId = sessionId;
+
+    const requestData: Record<string, unknown> = {
+      tool: toolName,
+      arguments: args,
+      session_id: sessionId,
+      timeout: this.sessionTimeout,
+      metadata: {
+        agent_id: 'signalwire-typescript',
+        timestamp: rawData['timestamp'],
+        call_id: rawData['call_id'],
       },
-    ];
+    };
+
+    let lastError: string | undefined;
+    for (let attempt = 0; attempt < this.retryAttempts; attempt++) {
+      try {
+        const response = await this._makeRequest(
+          'POST',
+          `${this.gatewayUrl}/services/${encodeURIComponent(serviceName)}/call`,
+          { body: requestData },
+        );
+
+        if (response.status === 200) {
+          const resultData = (await response.json()) as {
+            result?: unknown;
+          };
+          const resultText =
+            typeof resultData.result === 'string'
+              ? resultData.result
+              : JSON.stringify(resultData.result ?? 'No response');
+          return new FunctionResult(resultText);
+        }
+
+        let errorMsg: string;
+        try {
+          const errorData = (await response.json()) as { error?: string };
+          errorMsg = errorData.error ?? `HTTP ${response.status}`;
+        } catch {
+          errorMsg = `HTTP ${response.status}`;
+        }
+        lastError = errorMsg;
+
+        if (response.status >= 500) {
+          log.warn('mcp_gateway: server error, retrying', {
+            attempt: attempt + 1,
+            error: errorMsg,
+          });
+          continue;
+        }
+        // Client error — don't retry
+        break;
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+        log.warn('mcp_gateway: request error', {
+          attempt: attempt + 1,
+          error: lastError,
+        });
+      }
+    }
+
+    const errorMsg = `Failed to call ${serviceName}.${toolName}: ${lastError ?? 'unknown error'}`;
+    log.error('mcp_gateway: call failed', { error: errorMsg });
+    return new FunctionResult(errorMsg);
+  }
+
+  /** Handle call hangup — clean up any MCP session on the gateway. */
+  private async _hangupHandler(
+    _args: Record<string, unknown>,
+    rawData: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    const globalData = (rawData['global_data'] as Record<string, unknown>) ?? {};
+    const sessionId =
+      (globalData['mcp_call_id'] as string | undefined) ??
+      (rawData['call_id'] as string | undefined) ??
+      'unknown';
+
+    try {
+      const response = await this._makeRequest(
+        'DELETE',
+        `${this.gatewayUrl}/sessions/${encodeURIComponent(sessionId)}`,
+      );
+
+      if (response.status === 200 || response.status === 404) {
+        log.info('mcp_gateway: cleaned up MCP session', { sessionId });
+      } else {
+        log.warn('mcp_gateway: session cleanup returned non-ok status', {
+          status: response.status,
+        });
+      }
+    } catch (err) {
+      log.error('mcp_gateway: error cleaning up session', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    return new FunctionResult('Session cleanup complete');
   }
 }
 

--- a/src/skills/builtin/mcp_gateway.ts
+++ b/src/skills/builtin/mcp_gateway.ts
@@ -281,7 +281,8 @@ export class McpGatewaySkill extends SkillBase {
       ];
     }
 
-    // Append hangup hook tool
+    // Append hangup hook tool — isHangupHook causes the platform to auto-fire
+    // this on call hangup (Python: is_hangup_hook=True in define_tool).
     const tools = [...this._discoveredTools];
     tools.push({
       name: '_mcp_gateway_hangup',
@@ -289,6 +290,7 @@ export class McpGatewaySkill extends SkillBase {
       parameters: {},
       handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) =>
         this._hangupHandler(args, rawData),
+      isHangupHook: true,
     });
     return tools;
   }

--- a/src/skills/builtin/native_vector_search.ts
+++ b/src/skills/builtin/native_vector_search.ts
@@ -1,10 +1,18 @@
 /**
- * Native Vector Search Skill - In-memory document search using TF-IDF-like scoring.
+ * Native Vector Search Skill - Document search over a local or remote index.
  *
- * Tier 3 built-in skill: no external dependencies or API keys required.
- * Implements a simple text-matching algorithm based on word overlap scoring
- * (TF-IDF inspired) to search through a set of in-memory documents.
- * Suitable for small to medium document collections.
+ * Port of the Python `NativeVectorSearchSkill`. Supports three backends in
+ * Python (SQLite `.swsearch`, PostgreSQL `pgvector`, and a remote HTTP
+ * search server). This TypeScript implementation provides:
+ *
+ * - In-memory TF-IDF search over `documents` passed via config (fast path
+ *   that needs no additional deps), and
+ * - Remote HTTP search via a configured `remote_url` (compatible with the
+ *   Python SDK's `sw-search` remote protocol).
+ *
+ * The SQLite/pgvector backends require native Python dependencies and are
+ * not available here; their schema entries are preserved so configuration
+ * written for the Python SDK remains valid.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -16,6 +24,19 @@ import type {
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
+import { getLogger } from '../../Logger.js';
+
+const log = getLogger('NativeVectorSearchSkill');
+
+/** Callback signature for customizing the formatted search response. */
+export type ResponseFormatCallback = (ctx: {
+  response: string;
+  query: string;
+  results: Array<{ content: string; score: number; metadata: Record<string, unknown>; tags?: string[] }>;
+  args: Record<string, unknown>;
+  count: number;
+  skill: NativeVectorSearchSkill;
+}) => string;
 
 /** A document entry in the in-memory search index. */
 interface DocumentEntry {
@@ -25,20 +46,20 @@ interface DocumentEntry {
   text: string;
   /** Optional metadata associated with the document. */
   metadata?: Record<string, unknown>;
+  /** Optional tags for filtering. */
+  tags?: string[];
 }
 
-/** A document paired with its relevance score from a search query. */
-interface ScoredDocument {
-  /** The matched document entry. */
-  document: DocumentEntry;
-  /** TF-IDF relevance score (higher is more relevant). */
+/** A single search result in normalized form. */
+interface SearchResult {
+  content: string;
   score: number;
+  metadata: Record<string, unknown>;
+  tags?: string[];
 }
 
 /**
  * Tokenize text into lowercase words, removing punctuation and common stop words.
- * @param text - Raw text to tokenize.
- * @returns Array of meaningful word tokens.
  */
 function tokenize(text: string): string[] {
   const stopWords = new Set([
@@ -63,17 +84,11 @@ function tokenize(text: string): string[] {
     .filter((word) => word.length > 1 && !stopWords.has(word));
 }
 
-/**
- * Compute normalized term frequency for a list of tokens.
- * @param tokens - Array of tokenized words.
- * @returns Map from token to its normalized frequency.
- */
 function termFrequency(tokens: string[]): Map<string, number> {
   const tf = new Map<string, number>();
   for (const token of tokens) {
     tf.set(token, (tf.get(token) ?? 0) + 1);
   }
-  // Normalize by document length
   const len = tokens.length || 1;
   for (const [term, count] of tf) {
     tf.set(term, count / len);
@@ -81,65 +96,40 @@ function termFrequency(tokens: string[]): Map<string, number> {
   return tf;
 }
 
-/**
- * Compute inverse document frequency weights for a tokenized corpus.
- * @param corpus - Array of token arrays, one per document.
- * @returns Map from token to its IDF weight.
- */
-function inverseDocumentFrequency(
-  corpus: string[][],
-): Map<string, number> {
+function inverseDocumentFrequency(corpus: string[][]): Map<string, number> {
   const idf = new Map<string, number>();
   const numDocs = corpus.length || 1;
-
-  // Count how many documents contain each term
   const docFreq = new Map<string, number>();
   for (const tokens of corpus) {
-    const uniqueTokens = new Set(tokens);
-    for (const token of uniqueTokens) {
-      docFreq.set(token, (docFreq.get(token) ?? 0) + 1);
-    }
+    const unique = new Set(tokens);
+    for (const t of unique) docFreq.set(t, (docFreq.get(t) ?? 0) + 1);
   }
-
   for (const [term, freq] of docFreq) {
     idf.set(term, Math.log((numDocs + 1) / (freq + 1)) + 1);
   }
-
   return idf;
 }
 
-/**
- * Score a query against a document using TF-IDF cosine-like similarity.
- * @param queryTokens - Tokenized query words.
- * @param docTf - Pre-computed term frequency map for the document.
- * @param idf - Pre-computed inverse document frequency map.
- * @returns Similarity score (higher is more relevant).
- */
 function scoreTfIdf(
   queryTokens: string[],
   docTf: Map<string, number>,
   idf: Map<string, number>,
 ): number {
   if (queryTokens.length === 0) return 0;
-
   let score = 0;
   const queryTf = termFrequency(queryTokens);
-
   for (const [term, qWeight] of queryTf) {
     const docWeight = docTf.get(term) ?? 0;
     const idfWeight = idf.get(term) ?? 1;
     score += qWeight * docWeight * idfWeight * idfWeight;
   }
-
   return score;
 }
 
 /**
- * In-memory document search using TF-IDF-like word overlap scoring.
+ * Document search using TF-IDF in-memory scoring or a remote search server.
  *
- * Tier 3 built-in skill with no external dependencies or API keys required.
- * Documents are provided via the `documents` config array and indexed at
- * construction time. Suitable for small to medium document collections.
+ * Multi-instance capable (distinguished by `tool_name` + `index_file`).
  */
 export class NativeVectorSearchSkill extends SkillBase {
   static override SUPPORTS_MULTIPLE_INSTANCES = true;
@@ -150,25 +140,230 @@ export class NativeVectorSearchSkill extends SkillBase {
       tool_name: {
         type: 'string',
         description: 'Custom tool name for this vector search instance.',
+        default: 'search_knowledge',
+        required: false,
+      },
+      index_file: {
+        type: 'string',
+        description:
+          'Path to .swsearch index file (SQLite backend only). Use this for local file-based search',
+        required: false,
+      },
+      build_index: {
+        type: 'boolean',
+        description: 'Whether to build index from source files',
+        default: false,
+        required: false,
+      },
+      source_dir: {
+        type: 'string',
+        description:
+          'Directory containing documents to index (required if build_index=True)',
+        required: false,
+      },
+      remote_url: {
+        type: 'string',
+        description:
+          'URL of remote search server for network mode (e.g., http://localhost:8001)',
+        required: false,
+      },
+      index_name: {
+        type: 'string',
+        description:
+          'Name of index on remote server (network mode only, used with remote_url)',
+        default: 'default',
+        required: false,
+      },
+      count: {
+        type: 'integer',
+        description: 'Number of search results to return',
+        default: 5,
+        required: false,
+        min: 1,
+        max: 20,
+      },
+      similarity_threshold: {
+        type: 'number',
+        description:
+          'Minimum similarity score for results (0.0 = no limit, 1.0 = exact match)',
+        default: 0.0,
+        required: false,
+        min: 0.0,
+        max: 1.0,
+      },
+      tags: {
+        type: 'array',
+        description: 'Tags to filter search results',
+        default: [],
+        required: false,
+        items: { type: 'string' },
+      },
+      global_tags: {
+        type: 'array',
+        description: 'Tags to apply to all indexed documents',
+        default: [],
+        required: false,
+        items: { type: 'string' },
+      },
+      file_types: {
+        type: 'array',
+        description: 'File extensions to include when building index',
+        default: ['md', 'txt', 'pdf', 'docx', 'html'],
+        required: false,
+        items: { type: 'string' },
+      },
+      exclude_patterns: {
+        type: 'array',
+        description: 'Patterns to exclude when building index',
+        default: [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/dist/**',
+          '**/build/**',
+        ],
+        required: false,
+        items: { type: 'string' },
+      },
+      no_results_message: {
+        type: 'string',
+        description: 'Message when no results are found',
+        default: "No information found for '{query}'",
+        required: false,
+      },
+      response_prefix: {
+        type: 'string',
+        description: 'Prefix to add to search results',
+        default: '',
+        required: false,
+      },
+      response_postfix: {
+        type: 'string',
+        description: 'Postfix to add to search results',
+        default: '',
+        required: false,
+      },
+      max_content_length: {
+        type: 'integer',
+        description:
+          'Maximum total response size in characters (distributed across all results)',
+        default: 32768,
+        required: false,
+        min: 1000,
+      },
+      response_format_callback: {
+        type: 'object',
+        description:
+          'Optional callback function to format/transform the response.',
+        required: false,
+      },
+      description: {
+        type: 'string',
+        description: 'Tool description',
+        default: 'Search the knowledge base for information',
+        required: false,
+      },
+      hints: {
+        type: 'array',
+        description: 'Speech recognition hints',
+        default: [],
+        required: false,
+        items: { type: 'string' },
+      },
+      nlp_backend: {
+        type: 'string',
+        description: 'NLP backend for query processing (deprecated)',
+        default: 'basic',
+        required: false,
+        enum: ['basic', 'spacy', 'nltk'],
+      },
+      query_nlp_backend: {
+        type: 'string',
+        description: 'NLP backend for query expansion',
+        required: false,
+        enum: ['basic', 'spacy', 'nltk'],
+      },
+      index_nlp_backend: {
+        type: 'string',
+        description: 'NLP backend for indexing',
+        required: false,
+        enum: ['basic', 'spacy', 'nltk'],
+      },
+      backend: {
+        type: 'string',
+        description:
+          "Storage backend for local database mode: 'sqlite' or 'pgvector'. Ignored if remote_url is set",
+        default: 'sqlite',
+        required: false,
+        enum: ['sqlite', 'pgvector'],
+      },
+      connection_string: {
+        type: 'string',
+        description: 'PostgreSQL connection string (pgvector backend only)',
+        required: false,
+      },
+      collection_name: {
+        type: 'string',
+        description: 'Collection/table name in PostgreSQL (pgvector backend only)',
+        required: false,
+      },
+      verbose: {
+        type: 'boolean',
+        description: 'Enable verbose logging',
+        default: false,
+        required: false,
+      },
+      keyword_weight: {
+        type: 'number',
+        description:
+          'Manual keyword weight (0.0-1.0). Overrides automatic weight detection',
+        required: false,
+        min: 0.0,
+        max: 1.0,
+      },
+      model_name: {
+        type: 'string',
+        description: 'Embedding model to use',
+        default: 'mini',
+        required: false,
+      },
+      overwrite: {
+        type: 'boolean',
+        description: 'Overwrite existing pgvector collection when building index',
+        default: false,
+        required: false,
       },
       documents: {
         type: 'array',
-        description: 'Array of documents to index: [{ id, text, metadata? }].',
+        description:
+          'In-memory array of documents to index: [{ id, text, metadata?, tags? }] (TS-specific)',
+        required: false,
         items: { type: 'object' },
-      },
-      num_results: {
-        type: 'number',
-        description: 'Default number of top results to return.',
-        default: 3,
-      },
-      distance_threshold: {
-        type: 'number',
-        description: 'Minimum relevance score threshold.',
-        default: 0,
       },
     };
   }
 
+  // Runtime state
+  private toolName = 'search_knowledge';
+  private backend = 'sqlite';
+  private indexFile: string | undefined;
+  private remoteUrl: string | undefined;
+  private indexName = 'default';
+  private count = 5;
+  private similarityThreshold = 0.0;
+  private filterTags: string[] = [];
+  private noResultsMessage = "No information found for '{query}'";
+  private responsePrefix = '';
+  private responsePostfix = '';
+  private maxContentLength = 32768;
+  private responseFormatCallback: ResponseFormatCallback | undefined;
+  private description = 'Search the knowledge base for information';
+  private verbose = false;
+  private searchAvailable = false;
+  private useRemote = false;
+  private remoteBaseUrl: string | undefined;
+  private remoteAuth: { user: string; pass: string } | undefined;
+
+  // In-memory index state
   private _documents: DocumentEntry[] = [];
   private _tokenizedDocs: string[][] = [];
   private _docTfs: Map<string, number>[] = [];
@@ -176,42 +371,156 @@ export class NativeVectorSearchSkill extends SkillBase {
   private _indexed = false;
 
   /**
-   * @param config - Optional configuration; supports `documents` array of {id, text, metadata?}.
+   * @param config - Optional configuration (see `getParameterSchema()`).
    */
   constructor(config?: SkillConfig) {
     super('native_vector_search', config);
-    this._loadDocuments();
   }
 
   override getInstanceKey(): string {
-    const toolName = this.getConfig<string | undefined>('tool_name', undefined);
-    return toolName ? `${this.skillName}_${toolName}` : this.skillName;
+    const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
+    const indexFile = this.getConfig<string>('index_file', 'default');
+    return `${this.skillName}_${toolName}_${indexFile}`;
   }
 
-  /** @returns Manifest with config schema for the documents array. */
+  override async setup(): Promise<void> {
+    // Config
+    this.toolName = this.getConfig<string>('tool_name', 'search_knowledge');
+    this.backend = this.getConfig<string>('backend', 'sqlite');
+    this.indexFile = this.getConfig<string | undefined>('index_file', undefined);
+    this.count = this.getConfig<number>('count', 5);
+    this.similarityThreshold = this.getConfig<number>('similarity_threshold', 0.0);
+    this.filterTags = this.getConfig<string[]>('tags', []) ?? [];
+    this.noResultsMessage = this.getConfig<string>(
+      'no_results_message',
+      "No information found for '{query}'",
+    );
+    this.responsePrefix = this.getConfig<string>('response_prefix', '');
+    this.responsePostfix = this.getConfig<string>('response_postfix', '');
+    this.maxContentLength = this.getConfig<number>('max_content_length', 32768);
+    this.responseFormatCallback = this.getConfig<ResponseFormatCallback | undefined>(
+      'response_format_callback',
+      undefined,
+    );
+    this.description = this.getConfig<string>(
+      'description',
+      'Search the knowledge base for information',
+    );
+    this.verbose = this.getConfig<boolean>('verbose', false);
+
+    // Remote search configuration
+    this.remoteUrl = this.getConfig<string | undefined>('remote_url', undefined);
+    this.indexName = this.getConfig<string>('index_name', 'default');
+
+    // Parse auth from URL if present
+    if (this.remoteUrl) {
+      try {
+        const parsed = new URL(this.remoteUrl);
+        if (parsed.username && parsed.password) {
+          this.remoteAuth = {
+            user: decodeURIComponent(parsed.username),
+            pass: decodeURIComponent(parsed.password),
+          };
+          parsed.username = '';
+          parsed.password = '';
+          this.remoteBaseUrl = parsed.toString().replace(/\/+$/, '');
+        } else {
+          this.remoteBaseUrl = this.remoteUrl.replace(/\/+$/, '');
+        }
+      } catch {
+        this.remoteBaseUrl = this.remoteUrl;
+      }
+    }
+
+    // Remote mode — validate and skip heavy local setup
+    if (this.remoteUrl) {
+      this.useRemote = true;
+      try {
+        const response = await this._fetchWithAuth(
+          `${this.remoteBaseUrl}/health`,
+          { method: 'GET' },
+        );
+        if (response.status === 200) {
+          log.info('native_vector_search: remote server available', {
+            url: this.remoteBaseUrl,
+          });
+          this.searchAvailable = true;
+          return;
+        }
+        if (response.status === 401) {
+          log.error('native_vector_search: remote auth failed');
+        } else {
+          log.error('native_vector_search: remote server returned non-200', {
+            status: response.status,
+          });
+        }
+        this.searchAvailable = false;
+      } catch (err) {
+        log.error('native_vector_search: failed to connect to remote', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        this.searchAvailable = false;
+      }
+      return;
+    }
+
+    // Local / in-memory mode
+    this.useRemote = false;
+    this._loadDocuments();
+    this.searchAvailable = this._indexed;
+
+    if (this.verbose) {
+      log.info('native_vector_search: local index loaded', {
+        docCount: this._documents.length,
+        indexed: this._indexed,
+      });
+    }
+  }
+
+  override getHints(): string[] {
+    const hints = ['search', 'find', 'look up', 'documentation', 'knowledge base'];
+    const extra = this.getConfig<string[]>('hints', []) ?? [];
+    return [...hints, ...extra];
+  }
+
+  override getGlobalData(): Record<string, unknown> {
+    const globalData: Record<string, unknown> = {};
+    if (this._indexed) {
+      globalData['search_stats'] = {
+        doc_count: this._documents.length,
+        backend: this.useRemote ? 'remote' : this.backend,
+      };
+    }
+    return globalData;
+  }
+
+  override async cleanup(): Promise<void> {
+    this._documents = [];
+    this._tokenizedDocs = [];
+    this._docTfs = [];
+    this._idf = new Map();
+    this._indexed = false;
+  }
+
+  /** @returns Manifest for the native vector search skill. */
   getManifest(): SkillManifest {
     return {
       name: 'native_vector_search',
       description:
-        'In-memory document search using TF-IDF-like word overlap scoring. No external dependencies or API keys required.',
+        'Search document indexes using vector similarity and keyword search (local or remote)',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['search', 'vector', 'tfidf', 'documents', 'local', 'knowledge'],
-      configSchema: {
-        documents: {
-          type: 'array',
-          description:
-            'Array of documents to index: [{ id: string, text: string, metadata?: object }].',
-        },
-      },
     };
   }
 
   /**
-   * Load and index documents from configuration.
+   * Load and TF-IDF-index documents from config.
+   * Applies `global_tags` to every document's tag list.
    */
   private _loadDocuments(): void {
-    const docs = this.getConfig<DocumentEntry[]>('documents', []);
+    const docs = this.getConfig<DocumentEntry[]>('documents', []) ?? [];
+    const globalTags = this.getConfig<string[]>('global_tags', []) ?? [];
 
     if (!Array.isArray(docs) || docs.length === 0) {
       this._documents = [];
@@ -219,134 +528,320 @@ export class NativeVectorSearchSkill extends SkillBase {
       return;
     }
 
-    this._documents = docs.filter(
-      (d) => d && typeof d.id === 'string' && typeof d.text === 'string' && d.text.trim().length > 0,
-    );
+    this._documents = docs
+      .filter(
+        (d) =>
+          d &&
+          typeof d.id === 'string' &&
+          typeof d.text === 'string' &&
+          d.text.trim().length > 0,
+      )
+      .map((d) => ({
+        ...d,
+        tags: Array.from(new Set([...(d.tags ?? []), ...globalTags])),
+      }));
 
-    // Tokenize all documents
     this._tokenizedDocs = this._documents.map((doc) => tokenize(doc.text));
-
-    // Compute TF for each document
     this._docTfs = this._tokenizedDocs.map((tokens) => termFrequency(tokens));
-
-    // Compute IDF across the corpus
     this._idf = inverseDocumentFrequency(this._tokenizedDocs);
-
-    this._indexed = true;
+    this._indexed = this._documents.length > 0;
   }
 
-  /** @returns A single `search_documents` tool that searches indexed documents by text similarity. */
+  /** @returns A single search tool using the configured `tool_name` (default `search_knowledge`). */
   getTools(): SkillToolDefinition[] {
+    const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
+    const defaultCount = this.getConfig<number>('count', 5);
+    const description = this.getConfig<string>(
+      'description',
+      'Search the knowledge base for information',
+    );
+
     return [
       {
-        name: 'search_documents',
-        description:
-          'Search through the indexed documents for the most relevant results matching your query. Uses text similarity scoring to rank results.',
+        name: toolName,
+        description,
         parameters: {
           query: {
             type: 'string',
-            description: 'The search query or question.',
+            description: 'Search query or question',
           },
-          top_k: {
-            type: 'number',
-            description: 'Number of top results to return (1-20). Defaults to 3.',
+          count: {
+            type: 'integer',
+            description: `Number of results to return (default: ${defaultCount})`,
+            default: defaultCount,
           },
         },
         required: ['query'],
-        handler: (args: Record<string, unknown>) => {
-          const query = args.query as string | undefined;
-          const topK = args.top_k as number | undefined;
-
-          if (!query || typeof query !== 'string' || query.trim().length === 0) {
-            return new FunctionResult('Please provide a search query.');
-          }
-
-          if (!this._indexed || this._documents.length === 0) {
-            return new FunctionResult(
-              'No documents are loaded for searching. Configure the skill with a "documents" array.',
-            );
-          }
-
-          const k = Math.max(1, Math.min(20, topK ?? 3));
-          const queryTokens = tokenize(query);
-
-          if (queryTokens.length === 0) {
-            return new FunctionResult(
-              'The search query did not contain any meaningful search terms. Please try a more specific query.',
-            );
-          }
-
-          // Score all documents
-          const scored: ScoredDocument[] = this._documents.map((doc, i) => ({
-            document: doc,
-            score: scoreTfIdf(queryTokens, this._docTfs[i], this._idf),
-          }));
-
-          // Sort by score descending
-          scored.sort((a, b) => b.score - a.score);
-
-          // Filter out zero-score results and take top k
-          const results = scored.filter((s) => s.score > 0).slice(0, k);
-
-          if (results.length === 0) {
-            return new FunctionResult(
-              `No relevant documents found for "${query}". Try different search terms.`,
-            );
-          }
-
-          const parts: string[] = [
-            `Found ${results.length} relevant document(s) for "${query}":`,
-            '',
-          ];
-
-          for (let i = 0; i < results.length; i++) {
-            const { document, score } = results[i];
-            const relevance = score.toFixed(4);
-
-            parts.push(`--- Result ${i + 1} (ID: ${document.id}, relevance: ${relevance}) ---`);
-
-            // Truncate long texts for readability
-            const maxLen = 500;
-            const text = document.text.trim();
-            if (text.length > maxLen) {
-              parts.push(text.slice(0, maxLen) + '...');
-            } else {
-              parts.push(text);
-            }
-
-            if (document.metadata && Object.keys(document.metadata).length > 0) {
-              const metaStr = Object.entries(document.metadata)
-                .map(([k, v]) => `${k}: ${String(v)}`)
-                .join(', ');
-              parts.push(`[Metadata: ${metaStr}]`);
-            }
-
-            parts.push('');
-          }
-
-          return new FunctionResult(parts.join('\n').trim());
-        },
+        handler: async (
+          args: Record<string, unknown>,
+          rawData: Record<string, unknown>,
+        ) => this._searchHandler(args, rawData),
       },
     ];
   }
 
   /** @returns Prompt section describing the local document search capabilities. */
   protected override _getPromptSections(): SkillPromptSection[] {
+    const toolName = this.getConfig<string>('tool_name', 'search_knowledge');
     const docCount = this._documents.length;
+    const mode = this.useRemote ? 'remote search server' : 'local document indexes';
 
     return [
       {
-        title: 'Document Search',
-        body: `You have access to a local collection of ${docCount} document(s) that can be searched for relevant information.`,
+        title: 'Knowledge Search',
+        body: `You can search ${mode} using the ${toolName} tool${docCount > 0 ? ` over ${docCount} indexed document(s)` : ''}.`,
         bullets: [
-          'Use the search_documents tool when the user asks about topics that may be covered in the indexed documents.',
-          'You can specify how many results to return with the top_k parameter.',
-          'Results are ranked by text relevance using word overlap scoring.',
-          'Synthesize information from multiple results when appropriate.',
-          'If no results are found, the query terms may not match the document content. Try different wording.',
+          `Use the ${toolName} tool when users ask questions about topics that might be in the indexed documents`,
+          'Search for relevant information using clear, specific queries',
+          'Provide helpful summaries of the search results',
+          'If no results are found, suggest the user try rephrasing their question or try another knowledge source',
         ],
       },
     ];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Search
+  // ---------------------------------------------------------------------------
+
+  private async _searchHandler(
+    args: Record<string, unknown>,
+    _rawData: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    if (!this.searchAvailable && !this.useRemote) {
+      // In-memory path — we should still be usable if docs were loaded synchronously
+      // (constructor path); otherwise report unavailability.
+      if (!this._indexed || this._documents.length === 0) {
+        return new FunctionResult(
+          'No documents are loaded for searching. Configure the skill with a "documents" array or a "remote_url".',
+        );
+      }
+    }
+
+    const query =
+      typeof args['query'] === 'string' ? (args['query'] as string).trim() : '';
+    if (!query) {
+      return new FunctionResult('Please provide a search query.');
+    }
+
+    const count = Math.max(
+      1,
+      Math.min(20, (args['count'] as number | undefined) ?? this.count),
+    );
+
+    let results: SearchResult[] = [];
+    try {
+      if (this.useRemote) {
+        results = await this._searchRemote(query, count);
+      } else {
+        results = this._searchLocal(query, count);
+      }
+    } catch (err) {
+      log.error('native_vector_search: search error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return new FunctionResult(
+        "I'm sorry, I encountered an issue while searching. Please try rephrasing your question.",
+      );
+    }
+
+    if (results.length === 0) {
+      let msg = this.noResultsMessage.replace('{query}', query);
+      if (this.responsePrefix) msg = `${this.responsePrefix} ${msg}`;
+      if (this.responsePostfix) msg = `${msg} ${this.responsePostfix}`;
+
+      if (typeof this.responseFormatCallback === 'function') {
+        try {
+          const formatted = this.responseFormatCallback({
+            response: msg,
+            query,
+            results: [],
+            args,
+            count,
+            skill: this,
+          });
+          if (typeof formatted === 'string') msg = formatted;
+        } catch (err) {
+          log.error(
+            'native_vector_search: response_format_callback error (no results)',
+            { error: err instanceof Error ? err.message : String(err) },
+          );
+        }
+      }
+      return new FunctionResult(msg);
+    }
+
+    // Compose formatted response with per-result truncation
+    const responseParts: string[] = [];
+    if (this.responsePrefix) responseParts.push(this.responsePrefix);
+    responseParts.push(`Found ${results.length} relevant results for '${query}':\n`);
+
+    const estimatedOverheadPerResult = 300;
+    const prefixPostfixOverhead =
+      this.responsePrefix.length + this.responsePostfix.length + 100;
+    const totalOverhead =
+      results.length * estimatedOverheadPerResult + prefixPostfixOverhead;
+    const available = this.maxContentLength - totalOverhead;
+    const perResultLimit =
+      results.length > 0
+        ? Math.max(500, Math.floor(available / results.length))
+        : 1000;
+
+    results.forEach((r, i) => {
+      const filename =
+        (r.metadata['filename'] as string | undefined) ?? `result-${i + 1}`;
+      const section = (r.metadata['section'] as string | undefined) ?? '';
+      const score = r.score;
+      let content = r.content;
+      if (content.length > perResultLimit) {
+        content = content.slice(0, perResultLimit) + '...';
+      }
+      const tags = r.tags ?? (r.metadata['tags'] as string[] | undefined) ?? [];
+
+      let text = `**Result ${i + 1}** (from ${filename}`;
+      if (section) text += `, section: ${section}`;
+      if (tags.length > 0) text += `, tags: ${tags.join(', ')}`;
+      text += `, relevance: ${score.toFixed(2)})\n${content}\n`;
+      responseParts.push(text);
+    });
+
+    if (this.responsePostfix) responseParts.push(this.responsePostfix);
+
+    let response = responseParts.join('\n');
+
+    if (typeof this.responseFormatCallback === 'function') {
+      try {
+        const formatted = this.responseFormatCallback({
+          response,
+          query,
+          results,
+          args,
+          count,
+          skill: this,
+        });
+        if (typeof formatted === 'string') {
+          response = formatted;
+        } else {
+          log.warn(
+            'native_vector_search: response_format_callback returned non-string',
+          );
+        }
+      } catch (err) {
+        log.error('native_vector_search: response_format_callback error', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return new FunctionResult(response);
+  }
+
+  private _searchLocal(query: string, count: number): SearchResult[] {
+    const queryTokens = tokenize(query);
+    if (queryTokens.length === 0) return [];
+
+    const scored = this._documents.map((doc, i) => ({
+      doc,
+      score: scoreTfIdf(queryTokens, this._docTfs[i], this._idf),
+    }));
+
+    const filtered = scored
+      .filter((s) => s.score > this.similarityThreshold)
+      .filter((s) => {
+        if (this.filterTags.length === 0) return true;
+        const docTags = s.doc.tags ?? [];
+        return this.filterTags.some((t) => docTags.includes(t));
+      });
+
+    filtered.sort((a, b) => b.score - a.score);
+
+    return filtered.slice(0, count).map(({ doc, score }) => ({
+      content: doc.text,
+      score,
+      metadata: {
+        filename: doc.id,
+        ...(doc.metadata ?? {}),
+        tags: doc.tags ?? [],
+      },
+      tags: doc.tags ?? [],
+    }));
+  }
+
+  /** Perform search against a remote search server. */
+  private async _searchRemote(
+    query: string,
+    count: number,
+  ): Promise<SearchResult[]> {
+    if (!this.remoteBaseUrl) return [];
+
+    try {
+      const body = {
+        query,
+        index_name: this.indexName,
+        count,
+        similarity_threshold: this.similarityThreshold,
+        tags: this.filterTags,
+      };
+
+      const response = await this._fetchWithAuth(
+        `${this.remoteBaseUrl}/search`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      );
+
+      if (response.status !== 200) {
+        log.error('native_vector_search: remote search failed', {
+          status: response.status,
+        });
+        return [];
+      }
+      const data = (await response.json()) as {
+        results?: Array<{
+          content: string;
+          score: number;
+          metadata: Record<string, unknown>;
+          tags?: string[];
+        }>;
+      };
+      return (data.results ?? []).map((r) => ({
+        content: r.content,
+        score: r.score,
+        metadata: r.metadata,
+        tags: r.tags,
+      }));
+    } catch (err) {
+      log.error('native_vector_search: remote search error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+  }
+
+  /** Fetch wrapper that injects Basic auth if configured. */
+  private async _fetchWithAuth(
+    url: string,
+    init: RequestInit = {},
+  ): Promise<Response> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...((init.headers as Record<string, string>) ?? {}),
+    };
+    if (this.remoteAuth) {
+      const creds = Buffer.from(
+        `${this.remoteAuth.user}:${this.remoteAuth.pass}`,
+      ).toString('base64');
+      headers['Authorization'] = `Basic ${creds}`;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30_000);
+    try {
+      return await fetch(url, { ...init, headers, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
   }
 }
 

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -1,9 +1,15 @@
 /**
- * Spider Skill - Scrapes webpage content using the Spider API.
+ * Spider Skill - Fast web scraping and crawling capabilities.
  *
- * Tier 3 built-in skill: requires SPIDER_API_KEY environment variable.
- * Uses the Spider API to fetch and extract content from web pages,
- * optionally filtering by CSS selector.
+ * Tier 2 built-in skill. Port of the Python `SpiderSkill` that performs
+ * HTTP scraping via `fetch`, lightweight HTML-to-text extraction, and
+ * breadth-first crawling with configurable limits. Supports three tools:
+ *
+ * - `scrape_url` — single-page text/markdown extraction
+ * - `crawl_site` — breadth-first crawl from a start URL
+ * - `extract_structured_data` — CSS/XPath-like structured extraction
+ *
+ * Multiple instances are supported; use `tool_name` in config to differentiate.
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -20,232 +26,329 @@ import { getLogger } from '../../Logger.js';
 
 const log = getLogger('SpiderSkill');
 
-/** A single crawl result from the Spider API. */
-interface SpiderResult {
-  /** Raw HTML content of the page. */
-  content?: string;
-  /** Markdown-formatted content. */
-  markdown?: string;
-  /** Plain text content. */
-  text?: string;
-  /** Resolved URL of the crawled page. */
-  url?: string;
-  /** HTTP status code of the crawl. */
-  status?: number;
-  /** Error message if the crawl failed. */
-  error?: string;
+/** Cached response entry used by the internal LRU cache. */
+interface CachedResponse {
+  /** Resolved URL (after redirects). */
+  url: string;
+  /** HTTP status code. */
+  status: number;
+  /** Raw HTML body (or best-effort text for non-HTML). */
+  body: string;
 }
 
-/** Response from the Spider API, which may be an array, single result, or error object. */
-type SpiderResponse = SpiderResult[] | SpiderResult | { error: string; message?: string };
+const WHITESPACE_REGEX = /\s+/g;
+
+/** Tags stripped from HTML before text extraction. */
+const STRIP_TAG_REGEXES: RegExp[] = [
+  /<script\b[^>]*>[\s\S]*?<\/script>/gi,
+  /<style\b[^>]*>[\s\S]*?<\/style>/gi,
+  /<nav\b[^>]*>[\s\S]*?<\/nav>/gi,
+  /<header\b[^>]*>[\s\S]*?<\/header>/gi,
+  /<footer\b[^>]*>[\s\S]*?<\/footer>/gi,
+  /<aside\b[^>]*>[\s\S]*?<\/aside>/gi,
+  /<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi,
+];
 
 /**
- * Scrapes webpage content using the Spider API.
+ * Fast web scraping skill optimized for speed and token efficiency.
  *
- * Tier 3 built-in skill. Requires the `SPIDER_API_KEY` environment variable.
- * Extracts text, markdown, or HTML from any public URL, with optional CSS
- * selector filtering. Supports `max_content_length` config option.
+ * Multi-instance capable. Port of the Python `SpiderSkill` with three tools:
+ * `scrape_url`, `crawl_site`, and `extract_structured_data`. Configuration
+ * mirrors the Python schema (delay, concurrent_requests, timeout, max_pages,
+ * max_depth, extract_type, max_text_length, clean_text, selectors,
+ * follow_patterns, user_agent, headers, follow_robots_txt, cache_enabled).
  */
 export class SpiderSkill extends SkillBase {
+  static override SUPPORTS_MULTIPLE_INSTANCES = true;
+
   static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
     return {
       ...super.getParameterSchema(),
       api_key: {
         type: 'string',
-        description: 'Spider API key.',
+        description: 'Spider API key (optional; empowers future hosted-Spider backend).',
         hidden: true,
         env_var: 'SPIDER_API_KEY',
-        required: true,
       },
-      max_content_length: {
+      delay: {
         type: 'number',
-        description: 'Maximum length of returned content in characters.',
-        default: 5000,
+        description: 'Delay between requests in seconds',
+        default: 0.1,
+        required: false,
+        min: 0,
+      },
+      concurrent_requests: {
+        type: 'integer',
+        description: 'Number of concurrent requests allowed',
+        default: 5,
+        required: false,
+        min: 1,
+        max: 20,
+      },
+      timeout: {
+        type: 'integer',
+        description: 'Request timeout in seconds',
+        default: 5,
+        required: false,
+        min: 1,
+        max: 60,
+      },
+      max_pages: {
+        type: 'integer',
+        description: 'Maximum number of pages to scrape',
+        default: 1,
+        required: false,
+        min: 1,
+        max: 100,
+      },
+      max_depth: {
+        type: 'integer',
+        description: 'Maximum crawl depth (0 = single page only)',
+        default: 0,
+        required: false,
+        min: 0,
+        max: 5,
+      },
+      extract_type: {
+        type: 'string',
+        description: 'Content extraction method',
+        default: 'fast_text',
+        required: false,
+        enum: ['fast_text', 'clean_text', 'full_text', 'html', 'custom'],
+      },
+      max_text_length: {
+        type: 'integer',
+        description: 'Maximum text length to return',
+        default: 10000,
+        required: false,
+        min: 100,
+        max: 100000,
+      },
+      clean_text: {
+        type: 'boolean',
+        description: 'Whether to clean extracted text',
+        default: true,
+        required: false,
+      },
+      selectors: {
+        type: 'object',
+        description: 'Custom CSS/XPath selectors for structured extraction',
+        default: {},
+        required: false,
+      },
+      follow_patterns: {
+        type: 'array',
+        description: 'URL patterns to follow when crawling',
+        default: [],
+        required: false,
+        items: { type: 'string' },
+      },
+      user_agent: {
+        type: 'string',
+        description: 'User agent string for requests',
+        default: 'Spider/1.0 (SignalWire AI Agent)',
+        required: false,
+      },
+      headers: {
+        type: 'object',
+        description: 'Additional HTTP headers',
+        default: {},
+        required: false,
+      },
+      follow_robots_txt: {
+        type: 'boolean',
+        description: 'Whether to respect robots.txt',
+        default: true,
+        required: false,
+      },
+      cache_enabled: {
+        type: 'boolean',
+        description: 'Whether to cache scraped pages',
+        default: true,
+        required: false,
       },
     };
   }
 
+  // Runtime state, populated in setup()
+  private delay = 0.1;
+  private concurrentRequests = 5;
+  private timeoutSec = 5;
+  private maxPages = 1;
+  private maxDepth = 0;
+  private extractType = 'fast_text';
+  private maxTextLength = 10000;
+  private cleanText = true;
+  private cacheEnabled = true;
+  private followRobotsTxt = true;
+  private userAgent = 'Spider/1.0 (SignalWire AI Agent)';
+  private extraHeaders: Record<string, string> = {};
+  private selectors: Record<string, string> = {};
+  private compiledFollowPatterns: RegExp[] = [];
+  private cache: Map<string, CachedResponse> | null = null;
+  private readonly cacheMaxSize = 100;
+
   /**
-   * @param config - Optional configuration; supports `max_content_length`.
+   * @param config - Optional configuration; see `getParameterSchema()` for accepted keys.
    */
   constructor(config?: SkillConfig) {
     super('spider', config);
   }
 
-  /** @returns Manifest declaring SPIDER_API_KEY as required and config schema for max_content_length. */
+  override getInstanceKey(): string {
+    const toolName = this.getConfig<string>('tool_name', this.skillName);
+    return `${this.skillName}_${toolName}`;
+  }
+
+  override async setup(): Promise<void> {
+    // Performance
+    this.delay = this.getConfig<number>('delay', 0.1);
+    this.concurrentRequests = this.getConfig<number>('concurrent_requests', 5);
+    this.timeoutSec = this.getConfig<number>('timeout', 5);
+
+    // Crawl limits
+    this.maxPages = this.getConfig<number>('max_pages', 1);
+    this.maxDepth = this.getConfig<number>('max_depth', 0);
+
+    // Content processing
+    this.extractType = this.getConfig<string>('extract_type', 'fast_text');
+    // Match Python __init__ fallback (3000) even though schema default is 10000
+    this.maxTextLength = this.getConfig<number>('max_text_length', 3000);
+    this.cleanText = this.getConfig<boolean>('clean_text', true);
+
+    // Features
+    this.cacheEnabled = this.getConfig<boolean>('cache_enabled', true);
+    this.followRobotsTxt = this.getConfig<boolean>('follow_robots_txt', false);
+    this.userAgent = this.getConfig<string>(
+      'user_agent',
+      'Spider/1.0 (SignalWire AI Agent)',
+    );
+
+    // Optional headers + user-agent merge
+    const headers = this.getConfig<Record<string, string>>('headers', {}) ?? {};
+    this.extraHeaders = { ...headers, 'User-Agent': this.userAgent };
+
+    // Selectors for structured extraction
+    this.selectors = this.getConfig<Record<string, string>>('selectors', {}) ?? {};
+
+    // Setup cache
+    this.cache = this.cacheEnabled ? new Map() : null;
+
+    // Validate numeric ranges
+    if (this.delay < 0) {
+      log.error('spider: delay cannot be negative', { delay: this.delay });
+      return;
+    }
+    if (this.concurrentRequests < 1 || this.concurrentRequests > 20) {
+      log.error(
+        'spider: concurrent_requests must be between 1 and 20',
+        { concurrent_requests: this.concurrentRequests },
+      );
+      return;
+    }
+    if (this.maxPages < 1) {
+      log.error('spider: max_pages must be at least 1', { max_pages: this.maxPages });
+      return;
+    }
+    if (this.maxDepth < 0) {
+      log.error('spider: max_depth cannot be negative', { max_depth: this.maxDepth });
+      return;
+    }
+
+    // Pre-compile follow patterns
+    this.compiledFollowPatterns = [];
+    const patterns = this.getConfig<string[]>('follow_patterns', []) ?? [];
+    for (const pattern of patterns) {
+      try {
+        this.compiledFollowPatterns.push(new RegExp(pattern));
+      } catch (err) {
+        log.error('spider: invalid follow pattern', {
+          pattern,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    log.info('spider: configured', {
+      delay: this.delay,
+      max_pages: this.maxPages,
+      max_depth: this.maxDepth,
+    });
+  }
+
+  override getHints(): string[] {
+    return [
+      'scrape',
+      'crawl',
+      'extract',
+      'web page',
+      'website',
+      'get content from',
+      'fetch data from',
+      'spider',
+    ];
+  }
+
+  override async cleanup(): Promise<void> {
+    if (this.cache) {
+      this.cache.clear();
+    }
+  }
+
+  /** @returns Manifest describing the Spider skill capabilities and config. */
   getManifest(): SkillManifest {
     return {
       name: 'spider',
-      description:
-        'Scrapes webpage content using the Spider API. Extracts text, markdown, or HTML from any public URL.',
+      description: 'Fast web scraping and crawling capabilities',
       version: '1.0.0',
       author: 'SignalWire',
-      tags: ['scraping', 'web', 'spider', 'content', 'extraction', 'external'],
-      requiredEnvVars: ['SPIDER_API_KEY'],
-      configSchema: {
-        max_content_length: {
-          type: 'number',
-          description:
-            'Maximum length of returned content in characters. Defaults to 5000.',
-          default: 5000,
-        },
-      },
+      tags: ['scraping', 'web', 'spider', 'content', 'extraction'],
+      requiredEnvVars: [],
     };
   }
 
-  /** @returns A single `scrape_url` tool that extracts content from a web page. */
+  /** @returns Three tools: `scrape_url`, `crawl_site`, and `extract_structured_data`. */
   getTools(): SkillToolDefinition[] {
-    const maxContentLength = this.getConfig<number>('max_content_length', 5000);
+    const toolPrefix = this.getConfig<string>('tool_name', '');
+    const prefix = toolPrefix ? `${toolPrefix}_` : '';
 
     return [
       {
-        name: 'scrape_url',
-        description:
-          'Scrape and extract content from a web page URL. Returns the page text or markdown content.',
+        name: `${prefix}scrape_url`,
+        description: 'Extract text content from a single web page',
         parameters: {
           url: {
             type: 'string',
-            description: 'The full URL of the web page to scrape (must start with http:// or https://).',
-          },
-          selector: {
-            type: 'string',
-            description:
-              'Optional CSS selector to extract specific content from the page (e.g., "article", ".main-content", "#body").',
+            description: 'The URL to scrape',
           },
         },
         required: ['url'],
-        handler: async (args: Record<string, unknown>) => {
-          const url = args.url as string | undefined;
-          const selector = args.selector as string | undefined;
-
-          if (!url || typeof url !== 'string' || url.trim().length === 0) {
-            return new FunctionResult('Please provide a URL to scrape.');
-          }
-
-          if (url.length > MAX_SKILL_INPUT_LENGTH) {
-            return new FunctionResult('Input URL is too long.');
-          }
-
-          const trimmedUrl = url.trim();
-          if (!trimmedUrl.startsWith('http://') && !trimmedUrl.startsWith('https://')) {
-            return new FunctionResult(
-              'Invalid URL. Please provide a full URL starting with http:// or https://.',
-            );
-          }
-
-          // SSRF protection: validate URL does not resolve to a private IP
-          const allowPrivate = process.env['SWML_ALLOW_PRIVATE_URLS'] === 'true';
-          try {
-            await resolveAndValidateUrl(trimmedUrl, allowPrivate);
-          } catch {
-            return new FunctionResult(
-              'The provided URL could not be validated. Please check the URL and try again.',
-            );
-          }
-
-          const apiKey = process.env['SPIDER_API_KEY'];
-          if (!apiKey) {
-            return new FunctionResult(
-              'Service is not configured. Please contact your administrator.',
-            );
-          }
-
-          try {
-            const requestBody: Record<string, unknown> = {
-              url: trimmedUrl,
-              return_format: 'markdown',
-            };
-
-            if (selector && typeof selector === 'string' && selector.trim().length > 0) {
-              requestBody['css_selector'] = selector.trim();
-            }
-
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), 30_000);
-            let response: Response;
-            try {
-              response = await fetch('https://api.spider.cloud/crawl', {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                  'Authorization': `Bearer ${apiKey}`,
-                },
-                body: JSON.stringify(requestBody),
-                signal: controller.signal,
-              });
-            } finally {
-              clearTimeout(timeout);
-            }
-
-            if (!response.ok) {
-              log.error('spider_api_error', { status: response.status });
-              return new FunctionResult(
-                'The web scraping service encountered an error. Please try again later.',
-              );
-            }
-
-            const data = (await response.json()) as SpiderResponse;
-
-            // Handle error responses
-            if (!Array.isArray(data) && 'error' in data) {
-              log.error('spider_scraping_failed', { error: data.error });
-              return new FunctionResult(
-                'The web scraping service could not process the request. Please try again later.',
-              );
-            }
-
-            // Extract content from result
-            let content = '';
-            const result: SpiderResult = Array.isArray(data) ? data[0] : data;
-
-            if (!result) {
-              return new FunctionResult(
-                `No content could be extracted from "${trimmedUrl}".`,
-              );
-            }
-
-            if (result.error) {
-              log.error('spider_result_error', { error: result.error });
-              return new FunctionResult(
-                `Could not extract content from the requested page. Please try again later.`,
-              );
-            }
-
-            // Prefer markdown > text > content
-            content = result.markdown ?? result.text ?? result.content ?? '';
-
-            if (content.trim().length === 0) {
-              return new FunctionResult(
-                `The page at "${trimmedUrl}" returned no extractable content.`,
-              );
-            }
-
-            // Truncate if necessary
-            let truncated = false;
-            if (content.length > maxContentLength) {
-              content = content.slice(0, maxContentLength);
-              truncated = true;
-            }
-
-            const parts: string[] = [
-              `Content from ${trimmedUrl}:`,
-              '',
-              content.trim(),
-            ];
-
-            if (truncated) {
-              parts.push('');
-              parts.push(`[Content truncated to ${maxContentLength} characters]`);
-            }
-
-            return new FunctionResult(parts.join('\n'));
-          } catch (err) {
-            log.error('scrape_url_failed', { error: err instanceof Error ? err.message : String(err) });
-            return new FunctionResult(
-              'The request could not be completed. Please try again.',
-            );
-          }
+        handler: async (args: Record<string, unknown>) => this._scrapeUrlHandler(args),
+      },
+      {
+        name: `${prefix}crawl_site`,
+        description: 'Crawl multiple pages starting from a URL',
+        parameters: {
+          start_url: {
+            type: 'string',
+            description: 'Starting URL for the crawl',
+          },
         },
+        required: ['start_url'],
+        handler: async (args: Record<string, unknown>) => this._crawlSiteHandler(args),
+      },
+      {
+        name: `${prefix}extract_structured_data`,
+        description: 'Extract specific data from a web page using selectors',
+        parameters: {
+          url: {
+            type: 'string',
+            description: 'The URL to scrape',
+          },
+        },
+        required: ['url'],
+        handler: async (args: Record<string, unknown>) =>
+          this._extractStructuredHandler(args),
       },
     ];
   }
@@ -258,14 +361,483 @@ export class SpiderSkill extends SkillBase {
         body: 'You can scrape and extract content from web pages.',
         bullets: [
           'Use the scrape_url tool to fetch content from any public web page.',
+          'Use the crawl_site tool to crawl multiple pages starting from a URL.',
+          'Use the extract_structured_data tool with configured selectors for structured data.',
           'Provide a full URL starting with http:// or https://.',
-          'Optionally specify a CSS selector to extract specific parts of the page.',
-          'Content is returned as markdown text for easy reading.',
-          `Content is limited to ${this.getConfig<number>('max_content_length', 5000)} characters.`,
+          `Text content is limited to ${this.maxTextLength} characters.`,
           'Summarize the scraped content for the user rather than reading it verbatim.',
         ],
       },
     ];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Fetch a URL with caching and timeout handling. Returns null on failure. */
+  private async _fetchUrl(url: string): Promise<CachedResponse | null> {
+    if (this.cacheEnabled && this.cache?.has(url)) {
+      log.debug('spider: cache hit', { url });
+      return this.cache.get(url)!;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutSec * 1000);
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: this.extraHeaders,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        log.error('spider: fetch failed', { url, status: response.status });
+        return null;
+      }
+
+      const body = await response.text();
+      const cached: CachedResponse = {
+        url: response.url || url,
+        status: response.status,
+        body,
+      };
+
+      if (this.cacheEnabled && this.cache) {
+        if (this.cache.size >= this.cacheMaxSize) {
+          const oldest = this.cache.keys().next().value;
+          if (oldest !== undefined) this.cache.delete(oldest);
+        }
+        this.cache.set(url, cached);
+      }
+      return cached;
+    } catch (err) {
+      log.error('spider: fetch error', {
+        url,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Extract plain text from an HTML body using simple regex stripping. */
+  private _fastTextExtract(html: string): string {
+    let stripped = html;
+    for (const re of STRIP_TAG_REGEXES) {
+      stripped = stripped.replace(re, ' ');
+    }
+    // Remove all remaining tags
+    stripped = stripped.replace(/<[^>]+>/g, ' ');
+    // HTML entity decode (basic)
+    stripped = stripped
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'");
+
+    let text = stripped;
+    if (this.cleanText) {
+      text = text.replace(WHITESPACE_REGEX, ' ').trim();
+    }
+
+    // Smart truncation
+    if (text.length > this.maxTextLength) {
+      const keepStart = Math.floor((this.maxTextLength * 2) / 3);
+      const keepEnd = Math.floor(this.maxTextLength / 3);
+      text =
+        text.slice(0, keepStart) +
+        '\n\n[...CONTENT TRUNCATED...]\n\n' +
+        text.slice(-keepEnd);
+    }
+
+    return text;
+  }
+
+  /**
+   * Extract a value for a CSS-like or XPath-like selector. Returns best-effort text
+   * from elements matched by a very small subset of selectors (tag name, `.class`,
+   * `#id`, or attribute-based `[attr="value"]`).
+   */
+  private _applySimpleSelector(html: string, selector: string): string[] {
+    // Very small CSS selector engine — tag name or tag + class/id selector
+    // Patterns like: "h1", "title", ".foo", "#id", "div.classname", "meta[name='description']"
+    const trimmedSel = selector.trim();
+    if (!trimmedSel) return [];
+
+    // Support XPath-like selectors like "//title/text()" by extracting tag names
+    if (trimmedSel.startsWith('/')) {
+      const tagMatch = /\/\/([a-zA-Z][a-zA-Z0-9]*)/.exec(trimmedSel);
+      if (tagMatch) {
+        return this._extractTagText(html, tagMatch[1]);
+      }
+      return [];
+    }
+
+    // ID selector: #id
+    const idMatch = /^#([a-zA-Z][\w-]*)$/.exec(trimmedSel);
+    if (idMatch) {
+      const id = idMatch[1];
+      const re = new RegExp(
+        `<([a-zA-Z][a-zA-Z0-9]*)[^>]*\\bid\\s*=\\s*["']${this._escapeRegex(id)}["'][^>]*>([\\s\\S]*?)</\\1>`,
+        'gi',
+      );
+      return this._collectInnerText(html, re);
+    }
+
+    // Class selector: .class
+    const classMatch = /^\.([a-zA-Z][\w-]*)$/.exec(trimmedSel);
+    if (classMatch) {
+      const cls = classMatch[1];
+      const re = new RegExp(
+        `<([a-zA-Z][a-zA-Z0-9]*)[^>]*\\bclass\\s*=\\s*["'][^"']*\\b${this._escapeRegex(cls)}\\b[^"']*["'][^>]*>([\\s\\S]*?)</\\1>`,
+        'gi',
+      );
+      return this._collectInnerText(html, re);
+    }
+
+    // Tag with attribute: tag[attr="value"]
+    const tagAttrMatch =
+      /^([a-zA-Z][a-zA-Z0-9]*)\[([a-zA-Z_][\w-]*)\s*=\s*["']([^"']*)["']\]$/.exec(
+        trimmedSel,
+      );
+    if (tagAttrMatch) {
+      const [, tag, attr, value] = tagAttrMatch;
+      const re = new RegExp(
+        `<${tag}[^>]*\\b${attr}\\s*=\\s*["']${this._escapeRegex(value)}["'][^>]*>([\\s\\S]*?)</${tag}>`,
+        'gi',
+      );
+      return this._collectInnerText(html, re, 1);
+    }
+
+    // Simple tag: h1, p, title, ...
+    const tagMatch = /^([a-zA-Z][a-zA-Z0-9]*)$/.exec(trimmedSel);
+    if (tagMatch) {
+      return this._extractTagText(html, tagMatch[1]);
+    }
+
+    return [];
+  }
+
+  private _extractTagText(html: string, tag: string): string[] {
+    const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'gi');
+    return this._collectInnerText(html, re, 1);
+  }
+
+  private _collectInnerText(
+    html: string,
+    re: RegExp,
+    groupIndex = 2,
+  ): string[] {
+    const results: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(html)) !== null) {
+      const inner = match[groupIndex] ?? match[match.length - 1] ?? '';
+      const text = inner
+        .replace(/<[^>]+>/g, ' ')
+        .replace(WHITESPACE_REGEX, ' ')
+        .trim();
+      if (text) results.push(text);
+    }
+    return results;
+  }
+
+  private _escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  private _structuredExtract(
+    cached: CachedResponse,
+    selectors: Record<string, string>,
+  ): Record<string, unknown> {
+    const result: Record<string, unknown> = {
+      url: cached.url,
+      status_code: cached.status,
+      title: '',
+      data: {},
+    };
+
+    const titleMatches = this._extractTagText(cached.body, 'title');
+    if (titleMatches.length > 0) result['title'] = titleMatches[0];
+
+    const data: Record<string, unknown> = {};
+    for (const [field, selector] of Object.entries(selectors)) {
+      try {
+        const values = this._applySimpleSelector(cached.body, selector);
+        if (values.length === 0) {
+          data[field] = null;
+        } else if (values.length === 1) {
+          data[field] = values[0];
+        } else {
+          data[field] = values;
+        }
+      } catch (err) {
+        log.warn('spider: selector error', {
+          selector,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        data[field] = null;
+      }
+    }
+    result['data'] = data;
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tool handlers
+  // ---------------------------------------------------------------------------
+
+  private async _scrapeUrlHandler(
+    args: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    const urlArg = args['url'];
+    if (typeof urlArg !== 'string' || urlArg.trim().length === 0) {
+      return new FunctionResult('Please provide a URL to scrape');
+    }
+    const url = urlArg.trim();
+
+    if (url.length > MAX_SKILL_INPUT_LENGTH) {
+      return new FunctionResult('Input URL is too long.');
+    }
+
+    if (!/^https?:\/\//.test(url)) {
+      return new FunctionResult(`Invalid URL: ${url}`);
+    }
+
+    // SSRF protection
+    const allowPrivate = process.env['SWML_ALLOW_PRIVATE_URLS'] === 'true';
+    try {
+      await resolveAndValidateUrl(url, allowPrivate);
+    } catch {
+      return new FunctionResult(
+        'URL rejected: cannot access private or internal URLs',
+      );
+    }
+
+    const cached = await this._fetchUrl(url);
+    if (!cached) {
+      return new FunctionResult(`Failed to fetch ${url}`);
+    }
+
+    try {
+      if (this.extractType === 'structured') {
+        const result = this._structuredExtract(cached, this.selectors);
+        return new FunctionResult(
+          `Extracted structured data from ${url}: ${JSON.stringify(result)}`,
+        );
+      }
+      // All other extract types fall through to fast-text-like extraction
+      const content = this._fastTextExtract(cached.body);
+
+      if (!content) {
+        return new FunctionResult(`No content extracted from ${url}`);
+      }
+
+      const charCount = content.length;
+      const header = `Content from ${url} (${charCount} characters):\n\n`;
+      return new FunctionResult(header + content);
+    } catch (err) {
+      log.error('spider: scrape_url error', {
+        url,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return new FunctionResult(
+        `Error processing ${url}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private async _crawlSiteHandler(
+    args: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    const startArg = args['start_url'];
+    if (typeof startArg !== 'string' || startArg.trim().length === 0) {
+      return new FunctionResult('Please provide a starting URL for the crawl');
+    }
+    const startUrl = startArg.trim();
+
+    if (!/^https?:\/\//.test(startUrl)) {
+      return new FunctionResult(`Invalid URL: ${startUrl}`);
+    }
+
+    const allowPrivate = process.env['SWML_ALLOW_PRIVATE_URLS'] === 'true';
+    try {
+      await resolveAndValidateUrl(startUrl, allowPrivate);
+    } catch {
+      return new FunctionResult(
+        'URL rejected: cannot access private or internal URLs',
+      );
+    }
+
+    const maxDepth = this.maxDepth;
+    const maxPages = this.maxPages;
+
+    if (maxDepth < 0) return new FunctionResult('Max depth cannot be negative');
+    if (maxPages < 1) return new FunctionResult('Max pages must be at least 1');
+
+    const visited = new Set<string>();
+    const toVisit: [string, number][] = [[startUrl, 0]];
+    const results: {
+      url: string;
+      depth: number;
+      contentLength: number;
+      summary: string;
+    }[] = [];
+
+    let startHost: string;
+    try {
+      startHost = new URL(startUrl).host;
+    } catch {
+      return new FunctionResult(`Invalid URL: ${startUrl}`);
+    }
+
+    while (toVisit.length > 0 && visited.size < maxPages) {
+      const next = toVisit.shift();
+      if (!next) break;
+      const [url, depth] = next;
+
+      if (visited.has(url) || depth > maxDepth) continue;
+
+      const cached = await this._fetchUrl(url);
+      if (!cached) continue;
+
+      visited.add(url);
+
+      const content = this._fastTextExtract(cached.body);
+      if (content) {
+        results.push({
+          url,
+          depth,
+          contentLength: content.length,
+          summary:
+            content.length > 500 ? content.slice(0, 500) + '...' : content,
+        });
+      }
+
+      // Extract links if not at max depth
+      if (depth < maxDepth) {
+        try {
+          const hrefRe = /<a\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*>/gi;
+          let match: RegExpExecArray | null;
+          while ((match = hrefRe.exec(cached.body)) !== null) {
+            let absoluteUrl: string;
+            try {
+              absoluteUrl = new URL(match[1], url).toString();
+            } catch {
+              continue;
+            }
+
+            if (this.compiledFollowPatterns.length > 0) {
+              const allowed = this.compiledFollowPatterns.some((re) =>
+                re.test(absoluteUrl),
+              );
+              if (!allowed) continue;
+            }
+
+            try {
+              const absHost = new URL(absoluteUrl).host;
+              if (absHost !== startHost) continue;
+            } catch {
+              continue;
+            }
+
+            if (!visited.has(absoluteUrl)) {
+              toVisit.push([absoluteUrl, depth + 1]);
+            }
+          }
+        } catch (err) {
+          log.warn('spider: link extraction error', {
+            url,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      if (this.delay > 0 && visited.size < maxPages) {
+        await new Promise((resolve) => setTimeout(resolve, this.delay * 1000));
+      }
+    }
+
+    if (results.length === 0) {
+      return new FunctionResult(`No pages could be crawled from ${startUrl}`);
+    }
+
+    const lines: string[] = [
+      `Crawled ${results.length} pages from ${startHost}:`,
+      '',
+    ];
+    results.forEach((r, i) => {
+      lines.push(
+        `${i + 1}. ${r.url} (depth: ${r.depth}, ${r.contentLength} chars)`,
+      );
+      lines.push(`   Summary: ${r.summary.slice(0, 100)}...`);
+      lines.push('');
+    });
+    const totalChars = results.reduce((acc, r) => acc + r.contentLength, 0);
+    lines.push('');
+    lines.push(
+      `Total content: ${totalChars.toLocaleString()} characters across ${results.length} pages`,
+    );
+
+    return new FunctionResult(lines.join('\n'));
+  }
+
+  private async _extractStructuredHandler(
+    args: Record<string, unknown>,
+  ): Promise<FunctionResult> {
+    const urlArg = args['url'];
+    if (typeof urlArg !== 'string' || urlArg.trim().length === 0) {
+      return new FunctionResult('Please provide a URL');
+    }
+    const url = urlArg.trim();
+
+    if (!/^https?:\/\//.test(url)) {
+      return new FunctionResult(`Invalid URL: ${url}`);
+    }
+
+    const allowPrivate = process.env['SWML_ALLOW_PRIVATE_URLS'] === 'true';
+    try {
+      await resolveAndValidateUrl(url, allowPrivate);
+    } catch {
+      return new FunctionResult(
+        'URL rejected: cannot access private or internal URLs',
+      );
+    }
+
+    if (!this.selectors || Object.keys(this.selectors).length === 0) {
+      return new FunctionResult(
+        'No selectors configured for structured data extraction',
+      );
+    }
+
+    const cached = await this._fetchUrl(url);
+    if (!cached) {
+      return new FunctionResult(`Failed to fetch ${url}`);
+    }
+
+    const result = this._structuredExtract(cached, this.selectors);
+    if ('error' in result) {
+      return new FunctionResult(`Error extracting data: ${result['error']}`);
+    }
+
+    const lines: string[] = [`Extracted data from ${url}:`, ''];
+    lines.push(`Title: ${(result['title'] as string) || 'N/A'}`);
+    lines.push('');
+
+    const data = result['data'] as Record<string, unknown>;
+    if (data && Object.keys(data).length > 0) {
+      lines.push('Data:');
+      for (const [field, value] of Object.entries(data)) {
+        lines.push(`- ${field}: ${String(value)}`);
+      }
+    } else {
+      lines.push('No data extracted with provided selectors');
+    }
+
+    return new FunctionResult(lines.join('\n'));
   }
 }
 

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -212,8 +212,10 @@ export class SpiderSkill extends SkillBase {
 
     // Content processing
     this.extractType = this.getConfig<string>('extract_type', 'fast_text');
-    // Match Python __init__ fallback (3000) even though schema default is 10000
-    this.maxTextLength = this.getConfig<number>('max_text_length', 3000);
+    // Use schema-authoritative default (10000). Python has an internal
+    // inconsistency (schema: 10000, __init__ fallback: 3000); the schema is
+    // the API contract per the validated findings.
+    this.maxTextLength = this.getConfig<number>('max_text_length', 10000);
     this.cleanText = this.getConfig<boolean>('clean_text', true);
 
     // Features

--- a/src/skills/builtin/swml_transfer.ts
+++ b/src/skills/builtin/swml_transfer.ts
@@ -1,10 +1,13 @@
 /**
- * SWML Transfer Skill - Transfers calls using SWML transfer actions.
+ * SWML Transfer Skill - Transfer calls between agents using SWML with pattern matching.
  *
- * Tier 2 built-in skill: no external dependencies required.
- * Supports both direct destination transfers and named pattern-based transfers.
- * Named patterns allow configuring a set of known transfer destinations
- * that the AI can use by name rather than requiring raw phone numbers or SIP URIs.
+ * Port of the Python `SWMLTransferSkill`. Supports the Python `transfers`
+ * config (regex-keyed dict of per-destination configs with url/address,
+ * message, return_message, post_process, final, from_addr) as well as the
+ * TypeScript-native `patterns` array of friendly-named destinations.
+ *
+ * Either configuration shape works; when both are provided `transfers`
+ * takes precedence (matching the Python API).
  */
 
 import { SkillBase } from '../SkillBase.js';
@@ -16,175 +19,434 @@ import type {
   ParameterSchemaEntry,
 } from '../SkillBase.js';
 import { FunctionResult } from '../../FunctionResult.js';
+import { getLogger } from '../../Logger.js';
 
-/** A named transfer destination pattern with a friendly name and underlying address. */
+const log = getLogger('SwmlTransferSkill');
+
+/** A named transfer destination pattern (TS-style). */
 interface TransferPattern {
-  /** Friendly name for the destination (used by the AI to refer to it). */
+  /** Friendly name for the destination. */
   name: string;
   /** SIP URI, phone number, or agent URL to transfer to. */
   destination: string;
-  /** Optional human-readable description of this destination. */
+  /** Optional description. */
   description?: string;
+  /** Optional pre-transfer message override. */
+  message?: string;
+  /** Optional message shown when returning from the transfer. */
+  returnMessage?: string;
+  /** Whether to AI-process the message. */
+  postProcess?: boolean;
+  /** Whether the transfer is permanent (default) or temporary. */
+  final?: boolean;
+  /** Optional caller-ID override for connect actions. */
+  fromAddr?: string;
+}
+
+/** Per-destination entry in the Python-style `transfers` map. */
+interface TransferConfig {
+  url?: string;
+  address?: string;
+  message?: string;
+  return_message?: string;
+  post_process?: boolean;
+  final?: boolean;
+  from_addr?: string;
 }
 
 /**
- * Transfers calls using SWML transfer actions.
+ * Transfer calls between agents based on pattern matching.
  *
- * Tier 2 built-in skill with no external dependencies. Supports both direct
- * destination transfers and named pattern-based transfers configured via the
- * `patterns` config array. Optionally restricts to named destinations only
- * via `allow_arbitrary`.
+ * Multi-instance capable (distinguished by `tool_name`).
+ * Accepts either Python-style `transfers` config (regex → per-entry config)
+ * or TypeScript-style `patterns` array of named destinations.
  */
 export class SwmlTransferSkill extends SkillBase {
+  static override SUPPORTS_MULTIPLE_INSTANCES = true;
+
+  static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
+    return {
+      ...super.getParameterSchema(),
+      transfers: {
+        type: 'object',
+        description:
+          'Transfer configurations mapping patterns (regex or name) to destination configs. Each value has either url or address, plus optional message/return_message/post_process/final/from_addr.',
+        required: false,
+      },
+      patterns: {
+        type: 'array',
+        description:
+          'Array of named transfer patterns: { name, destination, description?, message?, returnMessage?, postProcess?, final?, fromAddr? }.',
+        required: false,
+        items: { type: 'object' },
+      },
+      allow_arbitrary: {
+        type: 'boolean',
+        description:
+          'Whether to allow transfers to arbitrary destinations not in patterns list.',
+        required: false,
+      },
+      tool_name: {
+        type: 'string',
+        description: 'Name of the transfer tool exposed to the AI.',
+        default: 'transfer_call',
+        required: false,
+      },
+      description: {
+        type: 'string',
+        description: 'Description for the transfer tool',
+        default: 'Transfer call based on pattern matching',
+        required: false,
+      },
+      parameter_name: {
+        type: 'string',
+        description: 'Name of the parameter that accepts the transfer type',
+        default: 'destination',
+        required: false,
+      },
+      parameter_description: {
+        type: 'string',
+        description: 'Description for the transfer type parameter',
+        default: 'The type of transfer to perform',
+        required: false,
+      },
+      default_message: {
+        type: 'string',
+        description: 'Default pre-transfer message said before every transfer.',
+        default: 'Transferring your call now.',
+        required: false,
+      },
+      no_match_message: {
+        type: 'string',
+        description: 'Message returned when no transfer pattern matches.',
+        default: 'Please specify a valid transfer type.',
+        required: false,
+      },
+      default_post_process: {
+        type: 'boolean',
+        description: 'Whether to process no-match message with AI',
+        default: false,
+        required: false,
+      },
+      required_fields: {
+        type: 'object',
+        description:
+          'Additional required fields to collect before transfer (name -> description).',
+        default: {},
+        required: false,
+      },
+    };
+  }
+
+  // Runtime state
+  private transfers: Record<string, TransferConfig> = {};
+  private patterns: TransferPattern[] = [];
+  private toolName = 'transfer_call';
+  private toolDescription = 'Transfer call based on pattern matching';
+  private parameterName = 'destination';
+  private parameterDescription = 'The type of transfer to perform';
+  private defaultMessage = 'Transferring your call now.';
+  private noMatchMessage = 'Please specify a valid transfer type.';
+  private defaultPostProcess = false;
+  private requiredFields: Record<string, string> = {};
+  private allowArbitraryOverride: boolean | undefined;
+
   /**
-   * @param config - Optional configuration; supports `patterns`, `allow_arbitrary`, `default_message`.
+   * @param config - Optional configuration (see `getParameterSchema()`).
    */
   constructor(config?: SkillConfig) {
     super('swml_transfer', config);
   }
 
-  static override getParameterSchema(): Record<string, ParameterSchemaEntry> {
-    return {
-      ...super.getParameterSchema(),
-      patterns: {
-        type: 'array',
-        description: 'Array of named transfer patterns: { name, destination, description? }.',
-        items: { type: 'object', properties: { name: { type: 'string' }, destination: { type: 'string' }, description: { type: 'string' } } },
-      },
-      allow_arbitrary: {
-        type: 'boolean',
-        description: 'Whether to allow transfers to arbitrary destinations not in patterns list.',
-      },
-      default_message: {
-        type: 'string',
-        description: 'Default message to say before transferring.',
-        default: 'Transferring your call now.',
-      },
-    };
+  override getInstanceKey(): string {
+    const toolName = this.getConfig<string>('tool_name', 'transfer_call');
+    return `${this.skillName}_${toolName}`;
   }
 
-  /** @returns Manifest with config schema for patterns, allow_arbitrary, and default_message. */
+  override async setup(): Promise<void> {
+    this.toolName = this.getConfig<string>('tool_name', 'transfer_call');
+    this.toolDescription = this.getConfig<string>(
+      'description',
+      'Transfer call based on pattern matching',
+    );
+    this.parameterName = this.getConfig<string>('parameter_name', 'destination');
+    this.parameterDescription = this.getConfig<string>(
+      'parameter_description',
+      'The type of transfer to perform',
+    );
+    this.defaultMessage = this.getConfig<string>(
+      'default_message',
+      'Transferring your call now.',
+    );
+    this.noMatchMessage = this.getConfig<string>(
+      'no_match_message',
+      'Please specify a valid transfer type.',
+    );
+    this.defaultPostProcess = this.getConfig<boolean>('default_post_process', false);
+    this.requiredFields =
+      this.getConfig<Record<string, string>>('required_fields', {}) ?? {};
+    this.allowArbitraryOverride = this.getConfig<boolean | undefined>(
+      'allow_arbitrary',
+      undefined,
+    );
+
+    // Python-style `transfers` config
+    const transfers =
+      this.getConfig<Record<string, TransferConfig>>('transfers', {}) ?? {};
+    this.transfers = {};
+    for (const [pattern, rawConfig] of Object.entries(transfers)) {
+      if (!rawConfig || typeof rawConfig !== 'object') {
+        log.error('swml_transfer: transfer config is not an object', { pattern });
+        continue;
+      }
+      const config = { ...rawConfig };
+      if (!('url' in config) && !('address' in config)) {
+        log.error(
+          'swml_transfer: transfer config must include either url or address',
+          { pattern },
+        );
+        continue;
+      }
+      if ('url' in config && 'address' in config) {
+        log.error(
+          'swml_transfer: transfer config cannot have both url and address',
+          { pattern },
+        );
+        continue;
+      }
+      if (config.message === undefined) config.message = 'Transferring you now...';
+      if (config.return_message === undefined)
+        config.return_message = 'The transfer is complete. How else can I help you?';
+      if (config.post_process === undefined) config.post_process = true;
+      if (config.final === undefined) config.final = true;
+      this.transfers[pattern] = config;
+    }
+
+    // TS-style patterns array
+    this.patterns = this.getConfig<TransferPattern[]>('patterns', []) ?? [];
+  }
+
+  override getHints(): string[] {
+    const hints: string[] = [];
+
+    // Extract words from regex patterns (Python-style)
+    for (const pattern of Object.keys(this.transfers)) {
+      let clean = pattern;
+      if (clean.startsWith('/')) clean = clean.slice(1);
+      if (clean.endsWith('/')) clean = clean.slice(0, -1);
+      else if (clean.endsWith('/i')) clean = clean.slice(0, -2);
+
+      if (clean && !clean.startsWith('.')) {
+        if (clean.includes('|')) {
+          for (const part of clean.split('|')) {
+            hints.push(part.trim().toLowerCase());
+          }
+        } else {
+          hints.push(clean.toLowerCase());
+        }
+      }
+    }
+
+    // Extract friendly names from patterns
+    for (const p of this.patterns) {
+      if (p && p.name) hints.push(p.name.toLowerCase());
+    }
+
+    hints.push('transfer', 'connect', 'speak to', 'talk to');
+    return hints;
+  }
+
+  /** @returns Manifest for the SWML transfer skill. */
   getManifest(): SkillManifest {
     return {
       name: 'swml_transfer',
-      description:
-        'Transfers calls using SWML transfer actions. Supports direct destination transfers and named pattern-based routing.',
+      description: 'Transfer calls between agents based on pattern matching',
       version: '1.0.0',
       author: 'SignalWire',
       tags: ['call-control', 'transfer', 'swml', 'routing'],
-      configSchema: {
-        patterns: {
-          type: 'array',
-          description:
-            'Array of named transfer patterns: { name, destination, description? }. When configured, the AI can transfer to named destinations.',
-          items: {
-            type: 'object',
-            properties: {
-              name: { type: 'string', description: 'Friendly name for the destination.' },
-              destination: { type: 'string', description: 'SIP URI, phone number, or agent URL.' },
-              description: { type: 'string', description: 'Optional description of this destination.' },
-            },
-            required: ['name', 'destination'],
-          },
-        },
-        allow_arbitrary: {
-          type: 'boolean',
-          description:
-            'Whether to allow transfers to arbitrary destinations not in the patterns list. Defaults to true if no patterns are configured, false if patterns are configured.',
-        },
-        default_message: {
-          type: 'string',
-          description:
-            'Default message to say before transferring. Defaults to "Transferring your call now.".',
-        },
-      },
+      requiredEnvVars: [],
     };
   }
 
   /** @returns A `transfer_call` tool, plus `list_transfer_destinations` when patterns are configured. */
   getTools(): SkillToolDefinition[] {
-    const patterns = this.getConfig<TransferPattern[]>('patterns', []);
+    // Rehydrate config for cases where getTools is called without setup()
+    const toolName = this.toolName !== 'transfer_call'
+      ? this.toolName
+      : this.getConfig<string>('tool_name', 'transfer_call');
+    const toolDescription = this.getConfig<string>(
+      'description',
+      this.toolDescription,
+    );
+    const parameterName = this.getConfig<string>(
+      'parameter_name',
+      this.parameterName,
+    );
+    const parameterDescription = this.getConfig<string>(
+      'parameter_description',
+      this.parameterDescription,
+    );
     const defaultMessage = this.getConfig<string>(
       'default_message',
-      'Transferring your call now.',
+      this.defaultMessage,
     );
+    const noMatchMessage = this.getConfig<string>(
+      'no_match_message',
+      this.noMatchMessage,
+    );
+    const defaultPostProcess = this.getConfig<boolean>(
+      'default_post_process',
+      this.defaultPostProcess,
+    );
+    const requiredFields =
+      this.getConfig<Record<string, string>>('required_fields', this.requiredFields) ?? {};
+    const transfers =
+      Object.keys(this.transfers).length > 0
+        ? this.transfers
+        : this.getConfig<Record<string, TransferConfig>>('transfers', {}) ?? {};
+    const patterns =
+      this.patterns.length > 0
+        ? this.patterns
+        : this.getConfig<TransferPattern[]>('patterns', []) ?? [];
     const allowArbitrary = this.getConfig<boolean | undefined>(
       'allow_arbitrary',
-      undefined,
+      this.allowArbitraryOverride,
     );
-
-    // If patterns are defined and allow_arbitrary is not explicitly set, default to false
     const canUseArbitrary =
       allowArbitrary !== undefined
         ? allowArbitrary
-        : patterns.length === 0;
+        : patterns.length === 0 && Object.keys(transfers).length === 0;
 
-    // Build the pattern lookup map
-    const patternMap = new Map<string, TransferPattern>();
-    for (const pattern of patterns) {
-      patternMap.set(pattern.name.toLowerCase(), pattern);
+    // Build tool parameters — include required_fields + primary destination param
+    const parameters: Record<string, unknown> = {
+      [parameterName]: {
+        type: 'string',
+        description: parameterDescription,
+      },
+      message: {
+        type: 'string',
+        description:
+          'An optional message to say to the caller before the transfer. If not provided, a default transfer message is used.',
+      },
+    };
+    const required = [parameterName];
+    for (const [fieldName, fieldDescription] of Object.entries(requiredFields)) {
+      parameters[fieldName] = {
+        type: 'string',
+        description: fieldDescription,
+      };
+      required.push(fieldName);
     }
+
+    // Pattern map for TS-style destinations (friendly-name lookup)
+    const patternMap = new Map<string, TransferPattern>();
+    for (const p of patterns) {
+      patternMap.set(p.name.toLowerCase(), p);
+    }
+
+    // Compile regex entries from Python-style transfers config
+    const compiledTransfers: Array<{ regex: RegExp; raw: string; config: TransferConfig }> = [];
+    for (const [patternKey, config] of Object.entries(transfers)) {
+      // Accept /.../ /i suffix as JS-style flags
+      let body = patternKey;
+      let flags = 'i';
+      if (body.startsWith('/')) body = body.slice(1);
+      if (body.endsWith('/i')) {
+        flags = 'i';
+        body = body.slice(0, -2);
+      } else if (body.endsWith('/')) {
+        flags = 'i';
+        body = body.slice(0, -1);
+      }
+      try {
+        compiledTransfers.push({
+          regex: new RegExp(body, flags),
+          raw: patternKey,
+          config,
+        });
+      } catch (err) {
+        log.error('swml_transfer: invalid transfer pattern', {
+          pattern: patternKey,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    const description = this._buildTransferDescription(
+      toolDescription,
+      patterns,
+      transfers,
+      canUseArbitrary,
+    );
 
     const tools: SkillToolDefinition[] = [
       {
-        name: 'transfer_call',
-        description: this._buildTransferDescription(patterns, canUseArbitrary),
-        parameters: {
-          destination: {
-            type: 'string',
-            description: this._buildDestinationDescription(patterns, canUseArbitrary),
-          },
-          message: {
-            type: 'string',
-            description:
-              'An optional message to say to the caller before the transfer. If not provided, a default transfer message is used.',
-          },
-        },
-        required: ['destination'],
+        name: toolName,
+        description,
+        parameters,
+        required,
         handler: (args: Record<string, unknown>) => {
-          const destination = args.destination as string | undefined;
-          const message = (args.message as string | undefined) ?? defaultMessage;
+          const rawDest = args[parameterName];
+          const callerMessage = args['message'];
+          const messageOverride =
+            typeof callerMessage === 'string' && callerMessage.trim().length > 0
+              ? callerMessage
+              : undefined;
 
-          if (
-            !destination ||
-            typeof destination !== 'string' ||
-            destination.trim().length === 0
-          ) {
-            return new FunctionResult(
-              'Please specify a destination for the transfer.',
+          if (typeof rawDest !== 'string' || rawDest.trim().length === 0) {
+            return new FunctionResult('Please specify a destination for the transfer.');
+          }
+          const destination = rawDest.trim();
+
+          // Build call_data for required fields
+          const callData: Record<string, unknown> = {};
+          for (const fieldName of Object.keys(requiredFields)) {
+            if (fieldName in args) callData[fieldName] = args[fieldName];
+          }
+
+          // 1. Try Python-style transfers (regex match)
+          for (const entry of compiledTransfers) {
+            if (entry.regex.test(destination)) {
+              return this._buildTransferResult(
+                entry.config,
+                messageOverride,
+                callData,
+              );
+            }
+          }
+
+          // 2. Try TS-style named patterns
+          const matchedPattern = patternMap.get(destination.toLowerCase());
+          if (matchedPattern) {
+            return this._buildPatternResult(
+              matchedPattern,
+              messageOverride ?? defaultMessage,
+              callData,
             );
           }
 
-          const trimmedDest = destination.trim();
-
-          // Check if this matches a named pattern
-          const matchedPattern = patternMap.get(trimmedDest.toLowerCase());
-
-          if (matchedPattern) {
-            const result = new FunctionResult(message);
-            result.swmlTransfer(matchedPattern.destination, message);
+          // 3. Arbitrary destinations
+          if (canUseArbitrary) {
+            const msg = messageOverride ?? defaultMessage;
+            const result = new FunctionResult(msg);
+            result.swmlTransfer(destination, msg, true);
+            if (Object.keys(callData).length > 0) {
+              result.updateGlobalData({ call_data: callData });
+            }
             return result;
           }
 
-          // No matching pattern - check if arbitrary transfers are allowed
-          if (!canUseArbitrary) {
-            const availableNames = patterns
-              .map((p) => `"${p.name}"`)
-              .join(', ');
-            return new FunctionResult(
-              `Unknown transfer destination "${trimmedDest}". Available destinations: ${availableNames}.`,
-            );
+          // 4. No match — return fallback message
+          const fallback = new FunctionResult(noMatchMessage);
+          fallback.postProcess = defaultPostProcess;
+          if (Object.keys(callData).length > 0) {
+            fallback.updateGlobalData({ call_data: callData });
           }
-
-          // Arbitrary transfer
-          const result = new FunctionResult(message);
-          result.swmlTransfer(trimmedDest, message);
-          return result;
+          return fallback;
         },
       },
     ];
 
-    // Add a list_destinations tool if patterns are configured
     if (patterns.length > 0) {
       tools.push({
         name: 'list_transfer_destinations',
@@ -196,7 +458,6 @@ export class SwmlTransferSkill extends SkillBase {
             const desc = p.description ? ` - ${p.description}` : '';
             return `${p.name}${desc}`;
           });
-
           return new FunctionResult(
             `Available transfer destinations:\n${lines.join('\n')}`,
           );
@@ -208,90 +469,178 @@ export class SwmlTransferSkill extends SkillBase {
   }
 
   protected override _getPromptSections(): SkillPromptSection[] {
-    const patterns = this.getConfig<TransferPattern[]>('patterns', []);
+    const toolName = this.getConfig<string>('tool_name', this.toolName);
+    const parameterName = this.getConfig<string>(
+      'parameter_name',
+      this.parameterName,
+    );
+    const transfers =
+      Object.keys(this.transfers).length > 0
+        ? this.transfers
+        : this.getConfig<Record<string, TransferConfig>>('transfers', {}) ?? {};
+    const patterns =
+      this.patterns.length > 0
+        ? this.patterns
+        : this.getConfig<TransferPattern[]>('patterns', []) ?? [];
+    const requiredFields =
+      this.getConfig<Record<string, string>>('required_fields', this.requiredFields) ?? {};
     const allowArbitrary = this.getConfig<boolean | undefined>(
       'allow_arbitrary',
-      undefined,
+      this.allowArbitraryOverride,
     );
     const canUseArbitrary =
       allowArbitrary !== undefined
         ? allowArbitrary
-        : patterns.length === 0;
+        : patterns.length === 0 && Object.keys(transfers).length === 0;
 
-    const bullets: string[] = [
-      'Use the transfer_call tool to transfer the current call to another destination.',
-      'You can optionally provide a message to say to the caller before the transfer.',
-    ];
+    const sections: SkillPromptSection[] = [];
 
-    if (patterns.length > 0) {
-      const patternNames = patterns.map((p) => `"${p.name}"`).join(', ');
-      bullets.push(
-        `Named transfer destinations are available: ${patternNames}. Use these names as the destination.`,
-      );
+    // Build "Transferring" section with destinations
+    const transferBullets: string[] = [];
 
-      for (const pattern of patterns) {
-        if (pattern.description) {
-          bullets.push(`${pattern.name}: ${pattern.description}`);
+    for (const [patternKey, config] of Object.entries(transfers)) {
+      let clean = patternKey;
+      if (clean.startsWith('/')) clean = clean.slice(1);
+      if (clean.endsWith('/')) clean = clean.slice(0, -1);
+      else if (clean.endsWith('/i')) clean = clean.slice(0, -2);
+
+      if (clean && !clean.startsWith('.')) {
+        const destination = config.url ?? config.address ?? '';
+        transferBullets.push(`"${clean}" - transfers to ${destination}`);
+      }
+    }
+
+    for (const p of patterns) {
+      const desc = p.description ? ` - ${p.description}` : ` - transfers to ${p.destination}`;
+      transferBullets.push(`"${p.name}"${desc}`);
+    }
+
+    if (transferBullets.length > 0) {
+      sections.push({
+        title: 'Transferring',
+        body: `You can transfer calls using the ${toolName} function with the following destinations:`,
+        bullets: transferBullets,
+      });
+
+      const instructionBullets: string[] = [
+        `Use the ${toolName} function when a transfer is needed`,
+        `Pass the destination type to the '${parameterName}' parameter`,
+      ];
+
+      if (Object.keys(requiredFields).length > 0) {
+        instructionBullets.push(
+          'You must provide the following information before transferring:',
+        );
+        for (const [fieldName, description] of Object.entries(requiredFields)) {
+          instructionBullets.push(`  - ${fieldName}: ${description}`);
         }
+        instructionBullets.push(
+          "All required information will be saved under 'call_data' for the next agent",
+        );
       }
 
       if (canUseArbitrary) {
-        bullets.push(
+        instructionBullets.push(
           'You can also transfer to arbitrary phone numbers or SIP URIs.',
         );
       }
 
-      bullets.push(
-        'Use list_transfer_destinations to see all available named destinations.',
+      instructionBullets.push(
+        'The system will match patterns and handle the transfer automatically',
+        "After transfer completes, you'll regain control of the conversation",
       );
-    } else {
-      bullets.push(
-        'Provide a phone number, SIP URI, or agent URL as the transfer destination.',
-      );
-    }
 
-    return [
-      {
+      sections.push({
+        title: 'Transfer Instructions',
+        body: 'How to use the transfer capability:',
+        bullets: instructionBullets,
+      });
+    } else {
+      sections.push({
         title: 'Call Transfer',
         body: 'You can transfer the current call to another destination.',
-        bullets,
-      },
-    ];
-  }
-
-  /**
-   * Build the tool description based on available patterns.
-   */
-  private _buildTransferDescription(
-    patterns: TransferPattern[],
-    canUseArbitrary: boolean,
-  ): string {
-    if (patterns.length === 0) {
-      return 'Transfer the current call to a specified destination (phone number, SIP URI, or agent URL).';
+        bullets: [
+          `Use the ${toolName} function to transfer the current call to another destination.`,
+          'You can optionally provide a message to say to the caller before the transfer.',
+          'Provide a phone number, SIP URI, or agent URL as the transfer destination.',
+        ],
+      });
     }
 
-    const names = patterns.map((p) => `"${p.name}"`).join(', ');
-    const base = `Transfer the current call. Named destinations: ${names}.`;
+    return sections;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Build a FunctionResult for a Python-style TransferConfig. */
+  private _buildTransferResult(
+    config: TransferConfig,
+    messageOverride: string | undefined,
+    callData: Record<string, unknown>,
+  ): FunctionResult {
+    const message = messageOverride ?? config.message ?? 'Transferring you now...';
+    const returnMessage =
+      config.return_message ?? 'The transfer is complete. How else can I help you?';
+    const postProcess = config.post_process ?? true;
+    const final = config.final ?? true;
+
+    const result = new FunctionResult(message, postProcess);
+    if (Object.keys(callData).length > 0) {
+      result.updateGlobalData({ call_data: callData });
+    }
+
+    if (config.url) {
+      result.swmlTransfer(config.url, returnMessage, final);
+    } else if (config.address) {
+      result.connect(config.address, final, config.from_addr);
+    }
+    return result;
+  }
+
+  /** Build a FunctionResult for a TS-style named TransferPattern. */
+  private _buildPatternResult(
+    pattern: TransferPattern,
+    message: string,
+    callData: Record<string, unknown>,
+  ): FunctionResult {
+    const returnMessage =
+      pattern.returnMessage ?? 'The transfer is complete. How else can I help you?';
+    const postProcess = pattern.postProcess ?? true;
+    const final = pattern.final ?? true;
+
+    const result = new FunctionResult(message, postProcess);
+    if (Object.keys(callData).length > 0) {
+      result.updateGlobalData({ call_data: callData });
+    }
+
+    // If destination looks like a URL, use swmlTransfer; otherwise use connect
+    if (/^https?:\/\//i.test(pattern.destination)) {
+      result.swmlTransfer(pattern.destination, returnMessage, final);
+    } else {
+      result.connect(pattern.destination, final, pattern.fromAddr);
+    }
+    return result;
+  }
+
+  private _buildTransferDescription(
+    baseDescription: string,
+    patterns: TransferPattern[],
+    transfers: Record<string, TransferConfig>,
+    canUseArbitrary: boolean,
+  ): string {
+    const names = [
+      ...Object.keys(transfers).map((k) => `"${k}"`),
+      ...patterns.map((p) => `"${p.name}"`),
+    ];
+    if (names.length === 0) {
+      return baseDescription;
+    }
+    const base = `${baseDescription}. Named destinations: ${names.join(', ')}.`;
     return canUseArbitrary
       ? `${base} You may also use arbitrary phone numbers or SIP URIs.`
       : base;
-  }
-
-  /**
-   * Build the destination parameter description based on available patterns.
-   */
-  private _buildDestinationDescription(
-    patterns: TransferPattern[],
-    canUseArbitrary: boolean,
-  ): string {
-    if (patterns.length === 0) {
-      return 'The transfer destination: a phone number (e.g., +15551234567), SIP URI, or agent URL.';
-    }
-
-    const names = patterns.map((p) => `"${p.name}"`).join(', ');
-    return canUseArbitrary
-      ? `A named destination (${names}) or an arbitrary phone number / SIP URI.`
-      : `One of the named destinations: ${names}.`;
   }
 }
 

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -352,18 +352,18 @@ describe('SwmlTransferSkill', () => {
     expect(result.action.length).toBeGreaterThan(0);
   });
 
-  it('should reject unknown named destinations when patterns configured and arbitrary disallowed', () => {
+  it('should use no-match message when patterns configured and arbitrary disallowed', () => {
     const skill = createSwmlTransferSkill({
       patterns: [
         { name: 'sales', destination: 'sip:sales@example.com' },
       ],
       allow_arbitrary: false,
+      no_match_message: 'Please specify a valid transfer type.',
     });
     const handler = skill.getTools()[0].handler;
     const result = handler({ destination: 'unknown_dept' }, {}) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
-    expect(result.response).toContain('Unknown transfer destination');
-    expect(result.response).toContain('sales');
+    expect(result.response).toContain('valid transfer type');
   });
 });
 
@@ -813,27 +813,36 @@ describe('NativeVectorSearchSkill', () => {
     expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should return a search_documents tool', () => {
+  it('should return a search_knowledge tool (Python-aligned default name)', async () => {
     const skill = createNativeVectorSearchSkill({ documents: testDocuments });
+    await skill.setup();
     const tools = skill.getTools();
     expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('search_documents');
+    expect(tools[0].name).toBe('search_knowledge');
     expect(tools[0].required).toContain('query');
   });
 
-  it('should execute search and find relevant documents', () => {
+  it('should execute search and find relevant documents', async () => {
     const skill = createNativeVectorSearchSkill({ documents: testDocuments });
+    await skill.setup();
     const handler = skill.getTools()[0].handler;
-    const result = handler({ query: 'TypeScript programming language' }, {}) as FunctionResult;
+    const result = (await handler(
+      { query: 'TypeScript programming language' },
+      {},
+    )) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
     expect(result.response).toContain('doc1');
     expect(result.response).toContain('TypeScript');
   });
 
-  it('should rank relevant documents higher (scoring works)', () => {
+  it('should rank relevant documents higher (scoring works)', async () => {
     const skill = createNativeVectorSearchSkill({ documents: testDocuments });
+    await skill.setup();
     const handler = skill.getTools()[0].handler;
-    const result = handler({ query: 'programming language', top_k: 4 }, {}) as FunctionResult;
+    const result = (await handler(
+      { query: 'programming language', count: 4 },
+      {},
+    )) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
     // Programming-related docs should appear; weather doc should not (no overlap)
     expect(result.response).toContain('programming');
@@ -857,26 +866,28 @@ describe('SpiderSkill', () => {
     const manifest = skill.getManifest();
     expect(manifest.name).toBe('spider');
     expect(manifest.version).toBe('1.0.0');
-    expect(manifest.requiredEnvVars).toContain('SPIDER_API_KEY');
   });
 
-  it('should return a scrape_url tool', () => {
+  it('should return the three Python-aligned tools (scrape_url, crawl_site, extract_structured_data)', async () => {
     const skill = createSpiderSkill();
+    await skill.setup();
     const tools = skill.getTools();
-    expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('scrape_url');
-    expect(tools[0].required).toContain('url');
+    expect(tools).toHaveLength(3);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('scrape_url');
+    expect(names).toContain('crawl_site');
+    expect(names).toContain('extract_structured_data');
+    const scrape = tools.find((t) => t.name === 'scrape_url')!;
+    expect(scrape.required).toContain('url');
   });
 
-  it('should return error when API key is not set', async () => {
-    const origKey = process.env['SPIDER_API_KEY'];
-    delete process.env['SPIDER_API_KEY'];
+  it('should reject invalid URL in scrape_url handler', async () => {
     const skill = createSpiderSkill();
-    const handler = skill.getTools()[0].handler;
-    const result = await handler({ url: 'https://example.com' }, {}) as FunctionResult;
+    await skill.setup();
+    const handler = skill.getTools().find((t) => t.name === 'scrape_url')!.handler;
+    const result = (await handler({ url: 'not-a-url' }, {})) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
-    expect(result.response).toContain('not configured');
-    if (origKey !== undefined) process.env['SPIDER_API_KEY'] = origKey;
+    expect(result.response).toMatch(/Invalid URL/i);
   });
 });
 
@@ -1328,15 +1339,15 @@ describe('McpGatewaySkill', () => {
     const skill = createMcpGatewaySkill();
     const manifest = skill.getManifest();
     expect(manifest.name).toBe('mcp_gateway');
-    expect(manifest.version).toBe('0.1.0');
+    expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should return not implemented message from handler', () => {
+  it('should return a configuration-prompt message when unconfigured', async () => {
     const skill = createMcpGatewaySkill();
     const handler = skill.getTools()[0].handler;
-    const result = handler({ server: 'test', method: 'test' }, {}) as FunctionResult;
+    const result = (await handler({ server: 'test', method: 'test' }, {})) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
-    expect(result.response).toContain('not yet implemented');
+    expect(result.response).toMatch(/not configured|configure/i);
   });
 });
 
@@ -1374,18 +1385,20 @@ describe('SpiderSkill - SSRF protection', () => {
     const saved = process.env['SWML_ALLOW_PRIVATE_URLS'];
     delete process.env['SWML_ALLOW_PRIVATE_URLS'];
     const skill = createSpiderSkill();
-    const handler = skill.getTools()[0].handler;
-    const result = await handler({ url: 'http://127.0.0.1/secret' }, {}) as FunctionResult;
+    await skill.setup();
+    const handler = skill.getTools().find((t) => t.name === 'scrape_url')!.handler;
+    const result = (await handler({ url: 'http://127.0.0.1/secret' }, {})) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
-    expect(result.response).toContain('could not be validated');
+    expect(result.response).toMatch(/private or internal URLs/);
     if (saved) process.env['SWML_ALLOW_PRIVATE_URLS'] = saved;
   });
 
   it('should reject overly long input', async () => {
     const skill = createSpiderSkill();
-    const handler = skill.getTools()[0].handler;
+    await skill.setup();
+    const handler = skill.getTools().find((t) => t.name === 'scrape_url')!.handler;
     const longUrl = 'https://example.com/' + 'a'.repeat(2000);
-    const result = await handler({ url: longUrl }, {}) as FunctionResult;
+    const result = (await handler({ url: longUrl }, {})) as FunctionResult;
     expect(result).toBeInstanceOf(FunctionResult);
     expect(result.response).toContain('too long');
   });

--- a/tests/skills/mcp-gateway.test.ts
+++ b/tests/skills/mcp-gateway.test.ts
@@ -16,35 +16,47 @@ describe('McpGatewaySkill', () => {
     expect(createMcpGatewaySkill()).toBeInstanceOf(McpGatewaySkill);
   });
 
-  it('should complete setup without errors', async () => {
+  it('should complete setup without errors even when unconfigured', async () => {
     await expect(new McpGatewaySkill().setup()).resolves.toBeUndefined();
   });
 
-  it('should register tools', () => {
+  it('should register a placeholder tool when unconfigured', () => {
     const tools = new McpGatewaySkill().getTools();
     expect(tools.length).toBeGreaterThan(0);
     expect(tools[0].handler).toBeTypeOf('function');
+    // Placeholder handler should return a configuration-prompt message
+    const res = tools[0].handler({}, {}) as FunctionResult;
+    expect(res.response).toMatch(/not configured|configure/i);
   });
 
-  it('should provide prompt sections', () => {
-    const sections = new McpGatewaySkill().getPromptSections();
-    expect(sections.length).toBeGreaterThan(0);
+  it('should provide no prompt sections without configured services', () => {
+    // Without configured services the prompt section should be empty (Python parity)
+    expect(new McpGatewaySkill().getPromptSections()).toEqual([]);
   });
 
   it('should skip prompt sections when skip_prompt is set', () => {
     expect(new McpGatewaySkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
-    const skill = new McpGatewaySkill();
-    expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  it('should return mcp hints with configured services', () => {
+    const skill = new McpGatewaySkill({
+      services: [{ name: 'calculator' }, { name: 'weather' }],
+    });
+    const hints = skill.getHints();
+    expect(hints).toContain('MCP');
+    expect(hints).toContain('gateway');
+    expect(hints).toContain('calculator');
+    expect(hints).toContain('weather');
+  });
+
+  it('should return empty global data when not ready', () => {
+    expect(new McpGatewaySkill().getGlobalData()).toEqual({});
   });
 
   it('should return correct manifest', () => {
     const manifest = new McpGatewaySkill().getManifest();
     expect(manifest.name).toBe('mcp_gateway');
-    expect(manifest.version).toBe('0.1.0');
+    expect(manifest.version).toBe('1.0.0');
   });
 
   it('should accept gateway_url config', () => {
@@ -52,9 +64,35 @@ describe('McpGatewaySkill', () => {
     expect(skill.getConfig('gateway_url')).toBe('http://localhost:8080');
   });
 
-  it('should have a parameter schema', () => {
+  it('should have a parameter schema with all expected keys', () => {
     const schema = McpGatewaySkill.getParameterSchema();
     expect(schema['gateway_url']).toBeDefined();
     expect(schema['tool_prefix']).toBeDefined();
+    expect((schema['tool_prefix'] as { default?: unknown }).default).toBe('mcp_');
+    expect(schema['auth_token']).toBeDefined();
+    expect((schema['auth_token'] as { env_var?: string }).env_var).toBe('MCP_GATEWAY_AUTH_TOKEN');
+    expect(schema['auth_user']).toBeDefined();
+    expect(schema['auth_password']).toBeDefined();
+    expect(schema['services']).toBeDefined();
+    expect(schema['session_timeout']).toBeDefined();
+    expect(schema['retry_attempts']).toBeDefined();
+    expect(schema['request_timeout']).toBeDefined();
+    expect(schema['verify_ssl']).toBeDefined();
+  });
+
+  it('should build prompt sections when services are configured', () => {
+    const skill = new McpGatewaySkill({
+      gateway_url: 'http://localhost:8080',
+      auth_token: 'abc',
+      services: [
+        { name: 'calculator', tools: '*' },
+        { name: 'weather', tools: ['forecast', 'current'] },
+      ],
+    });
+    // Skill is not ready until setup succeeds, so sections are empty.
+    // But we can still verify the internal formatting builds without throwing:
+    const sections = skill.getPromptSections();
+    // Without setup, services list is still populated from config for prompt building
+    expect(Array.isArray(sections)).toBe(true);
   });
 });

--- a/tests/skills/spider.test.ts
+++ b/tests/skills/spider.test.ts
@@ -20,10 +20,15 @@ describe('SpiderSkill', () => {
     await expect(new SpiderSkill().setup()).resolves.toBeUndefined();
   });
 
-  it('should register a scrape_url tool', () => {
-    const tools = new SpiderSkill().getTools();
-    expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe('scrape_url');
+  it('should register three tools', async () => {
+    const skill = new SpiderSkill();
+    await skill.setup();
+    const tools = skill.getTools();
+    expect(tools).toHaveLength(3);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('scrape_url');
+    expect(names).toContain('crawl_site');
+    expect(names).toContain('extract_structured_data');
     expect(tools[0].required).toContain('url');
   });
 
@@ -36,27 +41,69 @@ describe('SpiderSkill', () => {
     expect(new SpiderSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
-    const skill = new SpiderSkill();
-    expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  it('should return speech recognition hints', () => {
+    const hints = new SpiderSkill().getHints();
+    expect(hints).toContain('scrape');
+    expect(hints).toContain('spider');
+    expect(hints.length).toBeGreaterThanOrEqual(8);
   });
 
-  it('should return correct manifest with required env vars', () => {
+  it('should return empty global data', () => {
+    expect(new SpiderSkill().getGlobalData()).toEqual({});
+  });
+
+  it('should return correct manifest', () => {
     const manifest = new SpiderSkill().getManifest();
     expect(manifest.name).toBe('spider');
-    expect(manifest.requiredEnvVars).toContain('SPIDER_API_KEY');
+    expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should return error when API key is missing', async () => {
-    delete process.env['SPIDER_API_KEY'];
-    const handler = new SpiderSkill().getTools()[0].handler;
-    const result = await handler({ url: 'https://example.com' }, {}) as FunctionResult;
-    expect(result.response).toContain('not configured');
-  });
-
-  it('should have a parameter schema', () => {
+  it('should have full parameter schema', () => {
     const schema = SpiderSkill.getParameterSchema();
     expect(schema['api_key']).toBeDefined();
+    expect(schema['delay']).toBeDefined();
+    expect(schema['concurrent_requests']).toBeDefined();
+    expect(schema['timeout']).toBeDefined();
+    expect(schema['max_pages']).toBeDefined();
+    expect(schema['max_depth']).toBeDefined();
+    expect(schema['extract_type']).toBeDefined();
+    expect(schema['max_text_length']).toBeDefined();
+    expect(schema['clean_text']).toBeDefined();
+    expect(schema['selectors']).toBeDefined();
+    expect(schema['follow_patterns']).toBeDefined();
+    expect(schema['user_agent']).toBeDefined();
+    expect(schema['headers']).toBeDefined();
+    expect(schema['follow_robots_txt']).toBeDefined();
+    expect(schema['cache_enabled']).toBeDefined();
+  });
+
+  it('should support multiple instances', () => {
+    expect(SpiderSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
+    const skill = new SpiderSkill({ tool_name: 'custom' });
+    expect(skill.getInstanceKey()).toBe('spider_custom');
+  });
+
+  it('should validate URL format in scrape_url handler', async () => {
+    const skill = new SpiderSkill();
+    await skill.setup();
+    const handler = skill.getTools().find((t) => t.name === 'scrape_url')!.handler;
+    const res = (await handler({ url: 'not-a-url' }, {})) as FunctionResult;
+    expect(res.response).toMatch(/Invalid URL/i);
+  });
+
+  it('should require selectors for extract_structured_data', async () => {
+    const skill = new SpiderSkill();
+    await skill.setup();
+    const handler = skill
+      .getTools()
+      .find((t) => t.name === 'extract_structured_data')!.handler;
+    // URL is fine but selectors are empty, so we get an error before any fetch
+    const res = (await handler(
+      { url: 'https://example.com' },
+      {},
+    )) as FunctionResult;
+    // Either SSRF validation or missing selectors should trigger an error
+    expect(typeof res.response).toBe('string');
+    expect(res.response.length).toBeGreaterThan(0);
   });
 });

--- a/tests/skills/swml-transfer.test.ts
+++ b/tests/skills/swml-transfer.test.ts
@@ -20,10 +20,28 @@ describe('SwmlTransferSkill', () => {
     await expect(new SwmlTransferSkill().setup()).resolves.toBeUndefined();
   });
 
-  it('should register tools', () => {
-    const tools = new SwmlTransferSkill().getTools();
+  it('should register transfer_call tool by default', async () => {
+    const skill = new SwmlTransferSkill();
+    await skill.setup();
+    const tools = skill.getTools();
     expect(tools.length).toBeGreaterThan(0);
+    expect(tools[0].name).toBe('transfer_call');
     expect(tools[0].handler).toBeTypeOf('function');
+  });
+
+  it('should use custom tool_name if provided', async () => {
+    const skill = new SwmlTransferSkill({ tool_name: 'my_transfer' });
+    await skill.setup();
+    expect(skill.getTools()[0].name).toBe('my_transfer');
+  });
+
+  it('should register list_transfer_destinations when patterns configured', async () => {
+    const skill = new SwmlTransferSkill({
+      patterns: [{ name: 'sales', destination: '+15551112222' }],
+    });
+    await skill.setup();
+    const names = skill.getTools().map((t) => t.name);
+    expect(names).toContain('list_transfer_destinations');
   });
 
   it('should provide prompt sections', () => {
@@ -35,10 +53,30 @@ describe('SwmlTransferSkill', () => {
     expect(new SwmlTransferSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
-    const skill = new SwmlTransferSkill();
-    expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  it('should return transfer hints', () => {
+    const hints = new SwmlTransferSkill().getHints();
+    expect(hints).toContain('transfer');
+    expect(hints).toContain('connect');
+    expect(hints).toContain('speak to');
+    expect(hints).toContain('talk to');
+  });
+
+  it('should extract hints from transfer patterns', async () => {
+    const skill = new SwmlTransferSkill({
+      transfers: {
+        sales: { address: '+15551112222' },
+        'billing|accounts': { address: '+15552223333' },
+      },
+    });
+    await skill.setup();
+    const hints = skill.getHints();
+    expect(hints).toContain('sales');
+    expect(hints).toContain('billing');
+    expect(hints).toContain('accounts');
+  });
+
+  it('should return empty global data', () => {
+    expect(new SwmlTransferSkill().getGlobalData()).toEqual({});
   });
 
   it('should return correct manifest', () => {
@@ -47,8 +85,77 @@ describe('SwmlTransferSkill', () => {
     expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should have a parameter schema', () => {
+  it('should support multiple instances', () => {
+    expect(SwmlTransferSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
+    const a = new SwmlTransferSkill({ tool_name: 'a' });
+    const b = new SwmlTransferSkill({ tool_name: 'b' });
+    expect(a.getInstanceKey()).not.toBe(b.getInstanceKey());
+  });
+
+  it('should have a full parameter schema', () => {
     const schema = SwmlTransferSkill.getParameterSchema();
-    expect(schema).toBeDefined();
+    expect(schema['transfers']).toBeDefined();
+    expect(schema['tool_name']).toBeDefined();
+    expect(schema['description']).toBeDefined();
+    expect(schema['parameter_name']).toBeDefined();
+    expect(schema['parameter_description']).toBeDefined();
+    expect(schema['default_message']).toBeDefined();
+    expect(schema['no_match_message']).toBeDefined();
+    expect(schema['default_post_process']).toBeDefined();
+    expect(schema['required_fields']).toBeDefined();
+    expect(schema['patterns']).toBeDefined();
+    expect(schema['allow_arbitrary']).toBeDefined();
+  });
+
+  it('should transfer to a named pattern destination', async () => {
+    const skill = new SwmlTransferSkill({
+      patterns: [{ name: 'sales', destination: '+15551112222' }],
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler({ destination: 'sales' }, {})) as FunctionResult;
+    expect(res.action.length).toBeGreaterThan(0);
+  });
+
+  it('should use no_match_message when destination is unknown and arbitrary disallowed', async () => {
+    const skill = new SwmlTransferSkill({
+      patterns: [{ name: 'sales', destination: '+15551112222' }],
+      allow_arbitrary: false,
+      no_match_message: 'I cannot transfer there.',
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler({ destination: 'unknown' }, {})) as FunctionResult;
+    expect(res.response).toContain('cannot transfer');
+  });
+
+  it('should support Python-style transfers config with regex keys', async () => {
+    const skill = new SwmlTransferSkill({
+      transfers: {
+        sales: { address: '+15551112222', message: 'Connecting to sales.' },
+      },
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler({ destination: 'sales' }, {})) as FunctionResult;
+    expect(res.action.length).toBeGreaterThan(0);
+  });
+
+  it('should save required fields to call_data under global_data', async () => {
+    const skill = new SwmlTransferSkill({
+      patterns: [{ name: 'support', destination: '+15551234567' }],
+      required_fields: { name: 'Caller name', reason: 'Reason for calling' },
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler(
+      { destination: 'support', name: 'Alice', reason: 'Billing issue' },
+      {},
+    )) as FunctionResult;
+    // Look for updateGlobalData action with call_data
+    const updateAction = res.action.find(
+      (a) => typeof a === 'object' && a !== null && 'set_global_data' in a,
+    );
+    expect(updateAction).toBeDefined();
   });
 });

--- a/tests/skills/vector-search.test.ts
+++ b/tests/skills/vector-search.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { NativeVectorSearchSkill, createNativeVectorSearchSkill } from '../../src/skills/builtin/index.js';
 import { SkillBase } from '../../src/skills/SkillBase.js';
+import { FunctionResult } from '../../src/FunctionResult.js';
 import { suppressAllLogs } from '../../src/Logger.js';
 
 beforeAll(() => { suppressAllLogs(true); });
@@ -19,10 +20,22 @@ describe('NativeVectorSearchSkill', () => {
     await expect(new NativeVectorSearchSkill().setup()).resolves.toBeUndefined();
   });
 
-  it('should register tools', () => {
-    const tools = new NativeVectorSearchSkill().getTools();
-    expect(tools.length).toBeGreaterThan(0);
+  it('should register a search tool using configured tool_name', async () => {
+    const skill = new NativeVectorSearchSkill({
+      tool_name: 'my_search',
+      documents: [{ id: 'd1', text: 'hello world' }],
+    });
+    await skill.setup();
+    const tools = skill.getTools();
+    expect(tools.length).toBe(1);
+    expect(tools[0].name).toBe('my_search');
     expect(tools[0].handler).toBeTypeOf('function');
+  });
+
+  it('should default to search_knowledge tool name', async () => {
+    const skill = new NativeVectorSearchSkill();
+    await skill.setup();
+    expect(skill.getTools()[0].name).toBe('search_knowledge');
   });
 
   it('should provide prompt sections', () => {
@@ -34,10 +47,30 @@ describe('NativeVectorSearchSkill', () => {
     expect(new NativeVectorSearchSkill({ skip_prompt: true }).getPromptSections()).toHaveLength(0);
   });
 
-  it('should return empty hints and global data', () => {
-    const skill = new NativeVectorSearchSkill();
-    expect(skill.getHints()).toEqual([]);
-    expect(skill.getGlobalData()).toEqual({});
+  it('should return search hints', () => {
+    const hints = new NativeVectorSearchSkill().getHints();
+    expect(hints).toContain('search');
+    expect(hints).toContain('knowledge base');
+  });
+
+  it('should include custom hints from config', () => {
+    const skill = new NativeVectorSearchSkill({ hints: ['foo', 'bar'] });
+    const hints = skill.getHints();
+    expect(hints).toContain('foo');
+    expect(hints).toContain('bar');
+  });
+
+  it('should return empty global data before indexing', () => {
+    expect(new NativeVectorSearchSkill().getGlobalData()).toEqual({});
+  });
+
+  it('should include search_stats after indexing', async () => {
+    const skill = new NativeVectorSearchSkill({
+      documents: [{ id: 'd1', text: 'test document' }],
+    });
+    await skill.setup();
+    const data = skill.getGlobalData();
+    expect(data['search_stats']).toBeDefined();
   });
 
   it('should return correct manifest', () => {
@@ -46,8 +79,51 @@ describe('NativeVectorSearchSkill', () => {
     expect(manifest.version).toBe('1.0.0');
   });
 
-  it('should have a parameter schema', () => {
+  it('should have a parameter schema with all expected keys', () => {
     const schema = NativeVectorSearchSkill.getParameterSchema();
-    expect(schema).toBeDefined();
+    expect(schema['count']).toBeDefined();
+    expect(schema['similarity_threshold']).toBeDefined();
+    expect(schema['tags']).toBeDefined();
+    expect(schema['global_tags']).toBeDefined();
+    expect(schema['no_results_message']).toBeDefined();
+    expect(schema['response_prefix']).toBeDefined();
+    expect(schema['response_postfix']).toBeDefined();
+    expect(schema['max_content_length']).toBeDefined();
+    expect(schema['description']).toBeDefined();
+    expect(schema['hints']).toBeDefined();
+    expect(schema['verbose']).toBeDefined();
+    expect(schema['remote_url']).toBeDefined();
+    expect(schema['backend']).toBeDefined();
+  });
+
+  it('should support multiple instances with distinct keys', () => {
+    expect(NativeVectorSearchSkill.SUPPORTS_MULTIPLE_INSTANCES).toBe(true);
+    const a = new NativeVectorSearchSkill({ tool_name: 'a', index_file: 'ia' });
+    const b = new NativeVectorSearchSkill({ tool_name: 'b', index_file: 'ib' });
+    expect(a.getInstanceKey()).not.toBe(b.getInstanceKey());
+  });
+
+  it('should return empty query error when query is missing', async () => {
+    const skill = new NativeVectorSearchSkill({
+      documents: [{ id: 'd1', text: 'hello world' }],
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler({}, {})) as FunctionResult;
+    expect(res.response).toMatch(/provide a search query/i);
+  });
+
+  it('should return search results for matching query', async () => {
+    const skill = new NativeVectorSearchSkill({
+      documents: [
+        { id: 'doc1', text: 'The quick brown fox jumps over the lazy dog' },
+        { id: 'doc2', text: 'Nothing related here' },
+      ],
+    });
+    await skill.setup();
+    const handler = skill.getTools()[0].handler;
+    const res = (await handler({ query: 'fox' }, {})) as FunctionResult;
+    expect(res.response).toContain('Result 1');
+    expect(res.response).toContain('doc1');
   });
 });


### PR DESCRIPTION
## What this PR does

Aligns 4 high-gap skills with Python — 75 gaps total. These were "Tier 3 stub/placeholder" skills in the TS SDK while Python had full production implementations. Each is now a complete port.

## Changes

**SpiderSkill (20 gaps):** Rewrote stub into full port with 3 tools (`scrape_url`, `crawl_site`, `extract_structured_data`), 14-key schema, `setup`/`getHints`/`getInstanceKey`/`cleanup` overrides, multi-instance support, in-memory LRU cache.

**MCPGatewaySkill (19 gaps):** Rewrote stub into full MCP gateway client with 10-key schema, dynamic service/tool discovery via `_discoverTools`, Bearer/Basic auth, retry loop in `_callMcpTool`, `_mcp_gateway_hangup` session cleanup.

**NativeVectorSearchSkill (19 gaps):** Expanded TF-IDF implementation with full Python schema (30 keys), `response_prefix`/`response_postfix`/`no_results_message`/`max_content_length`/`response_format_callback`, Python-style tool name (`search_knowledge`), `count`/`similarity_threshold` renames, `tags`/`global_tags` filtering, remote HTTP search via `_searchRemote`.

**SWMLTransferSkill (17 gaps):** Added Python-style `transfers` regex-keyed config with per-destination url/address/message/return_message/post_process/final/from_addr, `required_fields` → `call_data` global_data flow, `SUPPORTS_MULTIPLE_INSTANCES`, `getInstanceKey`/`setup`/`getHints`, split `no_match_message` from pre-transfer `default_message`, 2-section prompt.

## Verification

- `npm run build` passes
- 1458/1458 tests pass

Closes #37
Closes #39
Closes #57
Closes #62