### PR TITLE
Align Prefab agents with Python SDK

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1756,29 +1756,29 @@ Pre-built agent templates with declarative configuration, built-in tools, and pr
 import { InfoGathererAgent, createInfoGathererAgent } from '@anthropic/@signalwire/sdk';
 ```
 
-Sequentially collects named fields from a caller with optional validation and completion callback.
+Asks the caller a sequence of questions one at a time. Supports static mode (questions provided at construction) and dynamic mode (questions resolved per request via a callback).
 
 #### InfoGathererConfig
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `name` | `string` | `'InfoGatherer'` | Agent display name |
-| `fields` | `InfoGathererField[]` | -- | Fields to collect (required) |
-| `introMessage` | `string` | Generic greeting | Opening message |
-| `confirmationMessage` | `string` | Generic thank you | Message after all fields gathered |
-| `onComplete` | `(data: Record<string, string>) => void \| Promise<void>` | -- | Completion callback |
+| `name` | `string` | `'info_gatherer'` | Agent display name |
+| `route` | `string` | `'/info_gatherer'` | HTTP route for this agent |
+| `questions` | `InfoGathererQuestion[]` | -- | Questions to ask (static mode). Omit for dynamic mode. |
+| `questionCallback` | `InfoGathererQuestionCallback` | -- | Resolves questions per request (dynamic mode). |
 | `agentOptions` | `Partial<AgentOptions>` | -- | Passed to `AgentBase` |
 
-#### InfoGathererField
+#### InfoGathererQuestion
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `name` | `string` | -- | Unique field name |
-| `description` | `string` | -- | Description shown to AI |
-| `required` | `boolean` | `true` | Whether field must be collected |
-| `validation` | `RegExp \| string` | -- | Optional validation pattern |
+| Property | Type | Description |
+|----------|------|-------------|
+| `key_name` | `string` | Identifier used as the key when storing the caller's answer |
+| `question_text` | `string` | Question text spoken to the caller |
+| `confirm` | `boolean` | When true, the agent insists on confirmation before submitting |
 
-**Built-in tools:** `save_field`, `get_status`
+**Built-in tools:** `start_questions`, `submit_answer`
+
+**Dynamic mode:** call `agent.setQuestionCallback(cb)` or pass `questionCallback` in the config. The callback receives `(queryParams, bodyParams, headers)` and returns the list of questions for that request. When no callback is registered, a default two-question fallback is used.
 
 **Factory:** `createInfoGathererAgent(config: InfoGathererConfig): InfoGathererAgent`
 
@@ -1794,10 +1794,14 @@ Conducts surveys with branching logic, answer scoring, and conditional question 
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `name` | `string` | `'SurveyAgent'` | Agent display name |
+| `name` | `string` | `'survey'` | Agent display name |
+| `route` | `string` | `'/survey'` | HTTP route |
+| `surveyName` | `string` | -- | Survey name used in prompts and global data (required) |
 | `questions` | `SurveyQuestion[]` | -- | Ordered list of survey questions (required) |
-| `introMessage` | `string` | Generic greeting | Opening message |
-| `completionMessage` | `string` | Generic thank you | Completion message |
+| `introduction` | `string` | Welcome message | Opening message (also used as a non-bargeable static greeting) |
+| `conclusion` | `string` | Thank-you message | Closing message |
+| `brandName` | `string` | `'Our Company'` | Brand or company name the agent represents |
+| `maxRetries` | `number` | `2` | Maximum retries for invalid answers |
 | `onComplete` | `(responses, score) => void \| Promise<void>` | -- | Completion callback |
 | `agentOptions` | `Partial<AgentOptions>` | -- | Passed to `AgentBase` |
 
@@ -1809,10 +1813,12 @@ Conducts surveys with branching logic, answer scoring, and conditional question 
 | `text` | `string` | Question text to ask |
 | `type` | `'multiple_choice' \| 'open_ended' \| 'rating' \| 'yes_no'` | Question type |
 | `options` | `string[]` | Options for `multiple_choice` |
+| `scale` | `number` | For `rating`, upper bound of the 1..scale range (default `5`) |
+| `required` | `boolean` | Whether the question requires an answer (default `true`) |
 | `nextQuestion` | `string \| Record<string, string>` | Branching logic: fixed next or answer-based map |
 | `points` | `number \| Record<string, number>` | Scoring: fixed or per-answer |
 
-**Built-in tools:** `answer_question`, `get_current_question`, `get_survey_progress`
+**Built-in tools:** `validate_response`, `log_response`, `answer_question`, `get_current_question`, `get_survey_progress`
 
 **Factory:** `createSurveyAgent(config: SurveyConfig): SurveyAgent`
 
@@ -1853,30 +1859,23 @@ Answers frequently asked questions using keyword/word-overlap matching with opti
 import { ConciergeAgent, createConciergeAgent } from '@anthropic/@signalwire/sdk';
 ```
 
-Multi-department routing with a knowledge base of department info, hours, and transfer capabilities.
+Virtual concierge for a venue or business. Provides information about services, amenities, hours of operation, and answers availability and directions questions.
 
 #### ConciergeConfig
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `name` | `string` | `'Concierge'` | Agent display name |
-| `departments` | `Department[]` | -- | Departments for routing (required) |
-| `companyName` | `string` | `'our company'` | Company name in prompts |
-| `generalInfo` | `string` | `''` | General company information |
-| `afterHoursMessage` | `string` | Generic closed message | Message when department is unavailable |
+| `name` | `string` | `'concierge'` | Agent display name |
+| `route` | `string` | `'/concierge'` | HTTP route |
+| `venueName` | `string` | -- | Name of the venue or business (required) |
+| `services` | `string[]` | -- | List of services offered (required) |
+| `amenities` | `Record<string, Record<string, string>>` | -- | Amenities with per-amenity detail pairs (required) |
+| `hoursOfOperation` | `Record<string, string>` | `{ default: '9 AM - 5 PM' }` | Hours of operation by category |
+| `specialInstructions` | `string[]` | `[]` | Extra instruction bullets to append |
+| `welcomeMessage` | `string` | -- | When set, installed as a non-bargeable static greeting |
 | `agentOptions` | `Partial<AgentOptions>` | -- | Passed to `AgentBase` |
 
-#### Department
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `name` | `string` | Department name |
-| `description` | `string` | What the department handles |
-| `transferNumber` | `string` | Phone/SIP for transfers |
-| `keywords` | `string[]` | Routing keywords |
-| `hoursOfOperation` | `string` | Human-readable hours |
-
-**Built-in tools:** `list_departments`, `get_department_info`, `transfer_to_department`
+**Built-in tools:** `check_availability`, `get_directions`
 
 **Factory:** `createConciergeAgent(config: ConciergeConfig): ConciergeAgent`
 
@@ -1886,17 +1885,19 @@ Multi-department routing with a knowledge base of department info, hours, and tr
 import { ReceptionistAgent, createReceptionistAgent } from '@anthropic/@signalwire/sdk';
 ```
 
-Front-desk agent that handles visitor check-in, department directory lookup, and call transfers by extension.
+Front-desk agent that greets callers, collects basic info, and transfers them to the appropriate department.
 
 #### ReceptionistConfig
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `name` | `string` | `'Receptionist'` | Agent display name |
-| `companyName` | `string` | -- | Company name (required) |
-| `departments` | `ReceptionistDepartment[]` | -- | Departments with extensions (required) |
-| `welcomeMessage` | `string` | Auto-generated | Custom welcome message |
-| `checkInEnabled` | `boolean` | `true` | Enable visitor check-in |
+| `name` | `string` | `'receptionist'` | Agent display name |
+| `route` | `string` | `'/receptionist'` | HTTP route |
+| `departments` | `ReceptionistDepartment[]` | -- | Departments (required) |
+| `greeting` | `string` | `'Thank you for calling. How can I help you today?'` | Initial greeting |
+| `voice` | `string` | `'rime.spore'` | Voice identifier passed to `addLanguage` |
+| `companyName` | `string` | -- | Optional company name appended to the greeting |
+| `checkInEnabled` | `boolean` | `false` | Register the optional `check_in_visitor` tool |
 | `onVisitorCheckIn` | `(visitor: Record<string, string>) => void \| Promise<void>` | -- | Check-in callback |
 | `agentOptions` | `Partial<AgentOptions>` | -- | Passed to `AgentBase` |
 
@@ -1904,11 +1905,11 @@ Front-desk agent that handles visitor check-in, department directory lookup, and
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `name` | `string` | Department name |
-| `extension` | `string` | Internal extension or SIP address |
-| `description` | `string` | Optional description |
+| `name` | `string` | Department identifier |
+| `description` | `string` | Description (shown to the AI) |
+| `number` | `string` | Phone number or SIP address dialed on transfer |
 
-**Built-in tools:** `get_department_list`, `transfer_to_department`, `check_in_visitor` (if enabled)
+**Built-in tools:** `collect_caller_info`, `transfer_call`, `check_in_visitor` (when `checkInEnabled`)
 
 **Factory:** `createReceptionistAgent(config: ReceptionistConfig): ReceptionistAgent`
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1052,8 +1052,8 @@ import {
 const agent = new InfoGathererAgent({
   name: 'info-gatherer',
   questions: [
-    { text: 'What is your name?', field: 'name' },
-    { text: 'What is your email?', field: 'email' },
+    { key_name: 'name', question_text: 'What is your name?' },
+    { key_name: 'email', question_text: 'What is your email?', confirm: true },
   ],
 });
 ```
@@ -1086,8 +1086,12 @@ const agent = new FAQBotAgent({
 ```typescript
 const agent = new ConciergeAgent({
   name: 'concierge',
-  venue: 'Grand Hotel',
+  venueName: 'Grand Hotel',
   services: ['room service', 'spa', 'restaurant reservations'],
+  amenities: {
+    pool: { hours: '7 AM - 10 PM', location: '2nd Floor' },
+    gym: { hours: '24 hours', location: '3rd Floor' },
+  },
 });
 ```
 

--- a/docs/prefabs-guide.md
+++ b/docs/prefabs-guide.md
@@ -68,7 +68,7 @@ import {
 
 ## InfoGathererAgent
 
-A conversational agent that sequentially collects named fields from a caller, validates each value against optional regex patterns, and fires a completion callback once all required fields are gathered.
+A conversational agent that asks the caller a sequence of questions one at a time and records each answer in `global_data`. Supports both static configuration (questions defined at construction) and dynamic configuration (questions resolved per request via a callback).
 
 **Source:** `src/prefabs/InfoGathererAgent.ts`
 
@@ -78,64 +78,68 @@ The constructor accepts an `InfoGathererConfig` object:
 
 | Property | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `name` | `string` | No | `"InfoGatherer"` | Agent display name. |
-| `fields` | `InfoGathererField[]` | **Yes** | -- | Fields to collect from the caller. |
-| `introMessage` | `string` | No | `"Hello! I need to collect some information from you. Let me walk you through it."` | Opening message the agent speaks when the call starts. |
-| `confirmationMessage` | `string` | No | `"Thank you! I have collected all the required information."` | Message spoken after all required fields are gathered. |
-| `onComplete` | `(data: Record<string, string>) => void \| Promise<void>` | No | -- | Callback fired when all required fields have been collected. Receives a copy of the collected data. |
-| `agentOptions` | `Partial<AgentOptions>` | No | -- | Additional AgentBase options forwarded to `super()` (e.g., `route`, `port`, `basicAuth`). |
+| `name` | `string` | No | `"info_gatherer"` | Agent display name. |
+| `route` | `string` | No | `"/info_gatherer"` | HTTP route for this agent. |
+| `questions` | `InfoGathererQuestion[]` | No | -- | Questions to ask (static mode). Omit for dynamic mode. |
+| `questionCallback` | `InfoGathererQuestionCallback` | No | -- | Resolves questions per request (dynamic mode); equivalent to calling `setQuestionCallback()` after construction. |
+| `agentOptions` | `Partial<AgentOptions>` | No | -- | Additional AgentBase options forwarded to `super()` (e.g., `port`, `basicAuth`). |
 
-### InfoGatherer Fields
+### InfoGatherer Questions
 
-Each entry in the `fields` array is an `InfoGathererField`:
+Each entry in the `questions` array is an `InfoGathererQuestion`:
 
 | Property | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `name` | `string` | **Yes** | -- | Unique field name, used as the key in collected data. |
-| `description` | `string` | **Yes** | -- | Human-readable description shown to the AI agent. |
-| `required` | `boolean` | No | `true` | Whether this field must be collected before completion. |
-| `validation` | `RegExp \| string` | No | -- | Optional validation pattern. Strings are compiled to `RegExp`. |
-
-Fields are presented to the AI prompt as a numbered list, each annotated with `(required)` or `(optional)` and the validation pattern source if present.
+| `key_name` | `string` | **Yes** | -- | Identifier used as the key when storing the caller's answer. |
+| `question_text` | `string` | **Yes** | -- | The question text spoken to the caller. |
+| `confirm` | `boolean` | No | `false` | When `true`, the agent insists the caller confirms the answer before submitting. |
 
 ### InfoGatherer Tools
 
 The agent registers two SWAIG tools:
 
-#### `save_field`
+#### `start_questions`
 
-Saves a collected field value from the caller. Validates the value if a validation pattern is configured.
+Retrieves the first question from `global_data.questions` and returns an instruction asking the caller to answer it.
+
+**Parameters:** None.
+
+**Returns:** A formatted instruction including the first question's text and confirmation guidance when `confirm` is set. Also sets `replace_in_history` to the generic "Welcome" prompt.
+
+#### `submit_answer`
+
+Records the caller's answer to the current question and advances to the next.
 
 **Parameters:**
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| `field_name` | `string` | Yes | The name of the field to save. |
-| `value` | `string` | Yes | The value provided by the caller. |
+| `answer` | `string` | Yes | The caller's answer to the current question. |
 
 **Behavior:**
-- Returns an error if the field name is unknown, listing available fields.
-- Runs the value against the field's validation regex (if configured). Returns a validation error with the expected pattern if it fails.
-- Saves the value into the per-call session.
-- If this save completes all required fields and `onComplete` has not yet fired, fires the `onComplete` callback with a shallow copy of the collected data and returns the confirmation message with a summary.
-- Otherwise, returns the list of remaining required fields.
+- Appends `{ key_name, answer }` to `global_data.answers`.
+- Increments `global_data.question_index`.
+- If more questions remain, returns the next question's instruction text.
+- If all questions are answered, returns the completion message.
 
-#### `get_status`
+### Dynamic Mode
 
-Returns the current status of information gathering.
+Omit `questions` and register a callback to resolve the question list per incoming request:
 
-**Parameters:** None.
+```typescript
+const agent = new InfoGathererAgent({ name: 'dynamic-intake' });
+agent.setQuestionCallback((queryParams, bodyParams, headers) => {
+  if (queryParams['set'] === 'support') {
+    return [
+      { key_name: 'name', question_text: 'What is your name?' },
+      { key_name: 'issue', question_text: "What's the issue?" },
+    ];
+  }
+  return [{ key_name: 'name', question_text: 'What is your name?' }];
+});
+```
 
-**Returns:** A string summarizing collected fields, remaining required fields, and remaining optional fields.
-
-### InfoGatherer Session Tracking
-
-Session state is keyed by `call_id` from the raw POST data. Each session tracks:
-
-- `collected` -- a `Record<string, string>` of field name to value.
-- `completeFired` -- a boolean ensuring the `onComplete` callback fires at most once per call.
-
-When a call comes in without a `call_id`, the fallback key `"default"` is used.
+The callback runs on every SWML request, and its return value populates `global_data.questions` for that call. If no callback is registered or the callback throws, a default two-question fallback (`name`, `message`) is used.
 
 ### InfoGatherer Example
 
@@ -144,43 +148,19 @@ import { InfoGathererAgent } from '@signalwire/sdk';
 
 const agent = new InfoGathererAgent({
   name: 'PatientIntake',
-  introMessage: 'Welcome to our clinic! I need to collect some information before your appointment.',
-  confirmationMessage: 'Thank you! Your information has been saved. A nurse will be with you shortly.',
-  fields: [
-    {
-      name: 'full_name',
-      description: 'The patient\'s full legal name',
-      required: true,
-    },
-    {
-      name: 'date_of_birth',
-      description: 'Date of birth in MM/DD/YYYY format',
-      required: true,
-      validation: /^\d{2}\/\d{2}\/\d{4}$/,
-    },
-    {
-      name: 'phone_number',
-      description: 'Contact phone number',
-      required: true,
-      validation: '^\\+?\\d{10,15}$',
-    },
-    {
-      name: 'insurance_provider',
-      description: 'Name of the insurance provider',
-      required: false,
-    },
+  questions: [
+    { key_name: 'full_name', question_text: 'What is your full legal name?' },
+    { key_name: 'date_of_birth', question_text: 'What is your date of birth?', confirm: true },
+    { key_name: 'phone_number', question_text: 'What is a good callback number?', confirm: true },
+    { key_name: 'insurance_provider', question_text: 'Who is your insurance provider?' },
   ],
-  onComplete: async (data) => {
-    console.log('Patient intake complete:', data);
-    // Save to database, send notification, etc.
-  },
   agentOptions: {
     port: 3001,
     route: '/intake',
   },
 });
 
-agent.start();
+agent.run();
 ```
 
 ---
@@ -197,10 +177,14 @@ The constructor accepts a `SurveyConfig` object:
 
 | Property | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `name` | `string` | No | `"SurveyAgent"` | Agent display name. |
+| `name` | `string` | No | `"survey"` | Agent display name. |
+| `route` | `string` | No | `"/survey"` | HTTP route for this agent. |
+| `surveyName` | `string` | **Yes** | -- | Human-readable survey name used in prompts and global data. |
 | `questions` | `SurveyQuestion[]` | **Yes** | -- | Ordered list of survey questions. |
-| `introMessage` | `string` | No | `"Thank you for taking our survey. I have a few questions for you."` | Opening message before the first question. |
-| `completionMessage` | `string` | No | `"Thank you for completing the survey! Your responses have been recorded."` | Message spoken after the survey is complete. |
+| `introduction` | `string` | No | `"Welcome to our ${surveyName}. We appreciate your participation."` | Opening message before the first question (used as a non-bargeable static greeting). |
+| `conclusion` | `string` | No | `"Thank you for completing our survey. Your feedback is valuable to us."` | Message spoken after the survey is complete. |
+| `brandName` | `string` | No | `"Our Company"` | Brand or company name the agent represents. |
+| `maxRetries` | `number` | No | `2` | Maximum number of times to retry invalid answers. |
 | `onComplete` | `(responses: Record<string, unknown>, score: number) => void \| Promise<void>` | No | -- | Callback fired when the survey is finished. Receives all responses and the total score. |
 | `agentOptions` | `Partial<AgentOptions>` | No | -- | Additional AgentBase options. |
 
@@ -212,6 +196,8 @@ Each `SurveyQuestion` has the following shape:
 | `text` | `string` | **Yes** | The question text to ask the caller. |
 | `type` | `'multiple_choice' \| 'open_ended' \| 'rating' \| 'yes_no'` | **Yes** | Question type; determines validation and display. |
 | `options` | `string[]` | No | Answer options (used when `type` is `multiple_choice`). |
+| `scale` | `number` | No | For `rating` questions, the upper bound of the 1..scale range. Defaults to `5`. |
+| `required` | `boolean` | No | Whether the question requires an answer. Defaults to `true`. |
 | `nextQuestion` | `string \| Record<string, string>` | No | Controls flow after this question (see Branching Logic). |
 | `points` | `number \| Record<string, number>` | No | Points awarded for answers (see Scoring). |
 
@@ -221,7 +207,7 @@ Each `SurveyQuestion` has the following shape:
 |---|---|---|
 | `multiple_choice` | Answer must exactly match one of the `options` (case-insensitive). | All options are read aloud. |
 | `open_ended` | No validation; any answer is accepted. | Free-form response. |
-| `rating` | Must be an integer between 1 and 10. | The AI specifies the scale to the caller. |
+| `rating` | Must be an integer between 1 and the question's `scale` (default `5`). | The AI specifies the scale to the caller. |
 | `yes_no` | Must be a recognized affirmative or negative word. | Accepts: `yes`, `y`, `yeah`, `yep`, `sure`, `absolutely`, `correct`, `true`, `no`, `n`, `nah`, `nope`, `negative`, `false`. Normalized to `"yes"` or `"no"` before storage. |
 
 ### Survey Branching Logic
@@ -248,7 +234,33 @@ The total score is accumulated across all answered questions and passed to the `
 
 ### Survey Tools
 
-The agent registers three SWAIG tools:
+The agent registers the following SWAIG tools:
+
+#### `validate_response`
+
+Validates whether a response satisfies the question's type and constraints without recording or advancing.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `question_id` | `string` | Yes | The ID of the question to validate against. |
+| `response` | `string` | Yes | The candidate response. |
+
+**Returns:** A confirmation message when valid, or a type-specific error describing why the response is invalid.
+
+#### `log_response`
+
+Acknowledges that a validated response has been recorded for the specified question.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `question_id` | `string` | Yes | The ID of the question. |
+| `response` | `string` | Yes | The validated response. |
+
+**Returns:** A confirmation message referencing the question's text.
 
 #### `answer_question`
 
@@ -292,8 +304,9 @@ import { SurveyAgent } from '@signalwire/sdk';
 
 const agent = new SurveyAgent({
   name: 'CustomerSatisfaction',
-  introMessage: 'Hi! We would love to hear your feedback about our service.',
-  completionMessage: 'Thanks for your feedback! We really appreciate it.',
+  surveyName: 'Customer Satisfaction Survey',
+  introduction: 'Hi! We would love to hear your feedback about our service.',
+  conclusion: 'Thanks for your feedback! We really appreciate it.',
   questions: [
     {
       id: 'overall',
@@ -457,7 +470,7 @@ agent.start();
 
 ## ConciergeAgent
 
-A multi-department routing agent that provides callers with department information, hours of operation, and call transfer capabilities.
+A virtual concierge for a venue or business. Provides information about services, amenities, and hours of operation, and answers availability and directions questions.
 
 **Source:** `src/prefabs/ConciergeAgent.ts`
 
@@ -467,62 +480,45 @@ The constructor accepts a `ConciergeConfig` object:
 
 | Property | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `name` | `string` | No | `"Concierge"` | Agent display name. |
-| `departments` | `Department[]` | **Yes** | -- | List of departments available for routing. |
-| `companyName` | `string` | No | `"our company"` | Company name used in greetings and prompts. |
-| `generalInfo` | `string` | No | `""` | General company information the agent can share. |
-| `afterHoursMessage` | `string` | No | `"This department is currently closed. Please try again during business hours."` | Message spoken when a department is closed or has no transfer number. |
+| `name` | `string` | No | `"concierge"` | Agent display name. |
+| `route` | `string` | No | `"/concierge"` | HTTP route for this agent. |
+| `venueName` | `string` | **Yes** | -- | Name of the venue or business. |
+| `services` | `string[]` | **Yes** | -- | List of services offered. |
+| `amenities` | `Record<string, Record<string, string>>` | **Yes** | -- | Amenities as an object of amenity-name → detail-pairs. |
+| `hoursOfOperation` | `Record<string, string>` | No | `{ default: '9 AM - 5 PM' }` | Operating hours by category. |
+| `specialInstructions` | `string[]` | No | `[]` | Extra instruction bullets to append. |
+| `welcomeMessage` | `string` | No | -- | When set, installed as a non-bargeable static greeting. |
 | `agentOptions` | `Partial<AgentOptions>` | No | -- | Additional AgentBase options. |
 
-Each `Department` has the following shape:
-
-| Property | Type | Required | Description |
-|---|---|---|---|
-| `name` | `string` | **Yes** | Department name (e.g., "Sales", "Support"). |
-| `description` | `string` | **Yes** | Description of what the department handles. |
-| `transferNumber` | `string` | No | Phone number or SIP address for transfers. |
-| `keywords` | `string[]` | No | Keywords that help route callers to this department. |
-| `hoursOfOperation` | `string` | No | Human-readable hours (e.g., "Mon-Fri 9am-5pm EST"). |
-
-Department names and keywords are added as speech recognition hints. Department lookup supports matching by name or by keyword (both case-insensitive).
+The venue name, all services, and amenity names are added as speech recognition hints.
 
 ### Concierge Tools
 
-#### `list_departments`
+#### `check_availability`
 
-Lists all available departments with their descriptions and hours of operation.
-
-**Parameters:** None.
-
-**Returns:** A formatted list of every department including name, description, hours, and whether direct transfer is available.
-
-#### `get_department_info`
-
-Gets detailed information about a specific department.
+Checks whether a given service is offered on a specified date and time.
 
 **Parameters:**
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| `department_name` | `string` | Yes | The name of the department to look up. |
+| `service` | `string` | Yes | The service to check. |
+| `date` | `string` | Yes | The date in `YYYY-MM-DD` format. |
+| `time` | `string` | Yes | The time in `HH:MM` 24-hour format. |
 
-**Returns:** Department name, description, hours of operation, transfer availability, and related topics (keywords). Returns an error with available department names if the department is not found.
+**Returns:** A confirmation or a list of offered services when the requested service is not available.
 
-#### `transfer_to_department`
+#### `get_directions`
 
-Transfers the caller to a specific department.
+Looks up directions for an amenity by name.
 
 **Parameters:**
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| `department_name` | `string` | Yes | The name of the department to transfer to. |
+| `location` | `string` | Yes | The amenity or location to get directions to. |
 
-**Behavior:**
-- Looks up the department by name or keyword (case-insensitive).
-- Returns an error if the department is not found.
-- Returns the `afterHoursMessage` if the department has no `transferNumber`.
-- Uses `FunctionResult.connect()` to initiate the transfer.
+**Returns:** Directions referencing the amenity's `location` detail, or a fallback pointing the caller to the front desk.
 
 ### Concierge Example
 
@@ -530,49 +526,25 @@ Transfers the caller to a specific department.
 import { ConciergeAgent } from '@signalwire/sdk';
 
 const agent = new ConciergeAgent({
-  name: 'MainLine',
-  companyName: 'Acme Corporation',
-  generalInfo: 'Acme Corporation is a leading provider of innovative solutions since 1985.',
-  afterHoursMessage: 'That department is currently closed. Please call back during business hours or leave a voicemail.',
-  departments: [
-    {
-      name: 'Sales',
-      description: 'New product inquiries, pricing, and demos',
-      transferNumber: '+15551001001',
-      keywords: ['buy', 'purchase', 'pricing', 'demo', 'quote'],
-      hoursOfOperation: 'Mon-Fri 8am-6pm EST',
-    },
-    {
-      name: 'Technical Support',
-      description: 'Help with existing products, troubleshooting, and bug reports',
-      transferNumber: '+15551001002',
-      keywords: ['help', 'broken', 'issue', 'bug', 'problem', 'error'],
-      hoursOfOperation: 'Mon-Fri 9am-9pm EST, Sat 10am-4pm EST',
-    },
-    {
-      name: 'Billing',
-      description: 'Invoices, payments, and subscription management',
-      transferNumber: '+15551001003',
-      keywords: ['invoice', 'payment', 'bill', 'subscription', 'charge'],
-      hoursOfOperation: 'Mon-Fri 9am-5pm EST',
-    },
-    {
-      name: 'Human Resources',
-      description: 'Employment opportunities and employee services',
-      keywords: ['job', 'career', 'hiring', 'employment'],
-      // No transferNumber -- caller will get afterHoursMessage
-    },
-  ],
+  venueName: 'Grand Hotel',
+  services: ['room service', 'spa bookings', 'restaurant reservations'],
+  amenities: {
+    pool: { hours: '7 AM - 10 PM', location: '2nd Floor' },
+    gym: { hours: '24 hours', location: '3rd Floor' },
+  },
+  hoursOfOperation: { weekday: '9 AM - 9 PM', weekend: '10 AM - 6 PM' },
+  specialInstructions: ['Always mention the weekly wine tasting.'],
+  welcomeMessage: 'Welcome to the Grand Hotel! How may I assist you?',
 });
 
-agent.start();
+agent.run();
 ```
 
 ---
 
 ## ReceptionistAgent
 
-A front-desk agent that handles visitor check-in, department directory lookup, and call transfers by extension.
+A front-desk agent that greets callers, collects their name and reason for calling, and transfers them to the appropriate department. Optionally supports visitor check-in as a TS-specific enhancement.
 
 **Source:** `src/prefabs/ReceptionistAgent.ts`
 
@@ -582,11 +554,13 @@ The constructor accepts a `ReceptionistConfig` object:
 
 | Property | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `name` | `string` | No | `"Receptionist"` | Agent display name. |
-| `companyName` | `string` | **Yes** | -- | Company name displayed in greetings and prompts. |
-| `departments` | `ReceptionistDepartment[]` | **Yes** | -- | Departments with extensions for the directory. |
-| `welcomeMessage` | `string` | No | `"Welcome to {companyName}! How may I help you today?"` | Custom welcome message. |
-| `checkInEnabled` | `boolean` | No | `true` | Whether visitor check-in functionality is enabled. |
+| `name` | `string` | No | `"receptionist"` | Agent display name. |
+| `route` | `string` | No | `"/receptionist"` | HTTP route for this agent. |
+| `departments` | `ReceptionistDepartment[]` | **Yes** | -- | Departments the agent can transfer callers to. |
+| `greeting` | `string` | No | `"Thank you for calling. How can I help you today?"` | Initial greeting message. |
+| `voice` | `string` | No | `"rime.spore"` | Voice identifier passed to `addLanguage`. |
+| `companyName` | `string` | No | -- | Optional company name appended to the greeting and used as a speech hint. |
+| `checkInEnabled` | `boolean` | No | `false` | Whether the TS-specific `check_in_visitor` tool is registered. |
 | `onVisitorCheckIn` | `(visitor: Record<string, string>) => void \| Promise<void>` | No | -- | Callback fired when a visitor checks in. |
 | `agentOptions` | `Partial<AgentOptions>` | No | -- | Additional AgentBase options. |
 
@@ -594,40 +568,44 @@ Each `ReceptionistDepartment` has the following shape:
 
 | Property | Type | Required | Description |
 |---|---|---|---|
-| `name` | `string` | **Yes** | Department name (e.g., "Engineering", "HR"). |
-| `extension` | `string` | **Yes** | Internal extension number or SIP address. |
-| `description` | `string` | No | Description of the department. |
-
-The company name and all department names are added as speech recognition hints. Department lookup is by name (case-insensitive).
+| `name` | `string` | **Yes** | Department identifier (used as enum value in `transfer_call`). |
+| `description` | `string` | **Yes** | Description of the department (shown to the AI). |
+| `number` | `string` | **Yes** | Phone number (or SIP address) to dial on transfer. |
 
 ### Receptionist Tools
 
-#### `get_department_list`
+#### `collect_caller_info`
 
-Lists all departments with their extensions and descriptions.
-
-**Parameters:** None.
-
-**Returns:** A formatted department directory for the company.
-
-#### `transfer_to_department`
-
-Transfers the caller to a department by dialing its extension.
+Records the caller's name and reason for calling in `global_data.caller_info` via `set_global_data`.
 
 **Parameters:**
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| `department_name` | `string` | Yes | The name of the department to transfer to. |
+| `name` | `string` | Yes | The caller's name. |
+| `reason` | `string` | Yes | The reason for the call. |
+
+**Returns:** An acknowledgement referencing the caller by name.
+
+#### `transfer_call`
+
+Transfers the caller to the selected department.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `department` | `string` (enum over department names) | Yes | The department to transfer to. |
 
 **Behavior:**
-- Looks up the department by name (case-insensitive).
-- Returns an error with the list of available departments if not found.
-- Uses `FunctionResult.connect()` to dial the extension.
+- Uses `post_process=true` so the AI speaks the response before executing the transfer.
+- Uses `FunctionResult.connect(number, final=true)` to make the transfer permanent.
+- Reads `global_data.caller_info.name` (populated by `collect_caller_info`) to personalize the hand-off message.
+- Returns an error if the department name is unknown.
 
-#### `check_in_visitor`
+#### `check_in_visitor` (TS enhancement)
 
-Checks in a visitor by recording their details. **Only registered when `checkInEnabled` is `true` (the default).**
+Only registered when `checkInEnabled` is `true`. Records a visitor in the per-call session and fires the `onVisitorCheckIn` callback.
 
 **Parameters:**
 
@@ -637,13 +615,6 @@ Checks in a visitor by recording their details. **Only registered when `checkInE
 | `purpose` | `string` | Yes | Purpose of the visit. |
 | `visiting` | `string` | Yes | Name of the person or department the visitor is here to see. |
 
-**Behavior:**
-- Validates that all three parameters are provided.
-- Creates a visitor record including `visitor_name`, `purpose`, `visiting`, and `checked_in_at` (ISO timestamp).
-- Stores the record in the per-call session.
-- Fires the `onVisitorCheckIn` callback with the visitor record.
-- Returns a confirmation message.
-
 ### Receptionist Example
 
 ```typescript
@@ -651,28 +622,29 @@ import { ReceptionistAgent } from '@signalwire/sdk';
 
 const agent = new ReceptionistAgent({
   companyName: 'Acme Corporation',
-  welcomeMessage: 'Hello and welcome to Acme Corporation! I can help you find a department, transfer your call, or check you in as a visitor.',
+  greeting: 'Thank you for calling Acme Corporation. How can I help you today?',
+  voice: 'rime.spore',
   checkInEnabled: true,
   departments: [
     {
-      name: 'Engineering',
-      extension: '1001',
+      name: 'engineering',
       description: 'Software development and technical teams',
+      number: '+15551001001',
     },
     {
-      name: 'Human Resources',
-      extension: '1002',
+      name: 'hr',
       description: 'Employee services, benefits, and recruiting',
+      number: '+15551001002',
     },
     {
-      name: 'Marketing',
-      extension: '1003',
+      name: 'marketing',
       description: 'Brand, communications, and events',
+      number: '+15551001003',
     },
     {
-      name: 'Executive Office',
-      extension: '1004',
+      name: 'executive',
       description: 'CEO and executive leadership',
+      number: '+15551001004',
     },
   ],
   onVisitorCheckIn: async (visitor) => {
@@ -751,12 +723,10 @@ class SpanishInfoGatherer extends InfoGathererAgent {
     {
       title: 'Rules',
       bullets: [
-        'Ask for one field at a time, in the order listed.',
-        'If the caller provides information for a later field, accept it and move on.',
-        'Always confirm each piece of information before saving it using the save_field tool.',
+        'Ask one question at a time, in the order provided by start_questions.',
+        'Use submit_answer to record each response and advance to the next question.',
+        'If a question has confirm=true, insist on confirmation before submitting.',
         'If validation fails, politely ask the caller to try again in their language.',
-        'Use the get_status tool when you need to check progress.',
-        'Once all required fields are collected, summarize the information and confirm with the caller.',
       ],
     },
   ];

--- a/examples/dynamic-info-gatherer.ts
+++ b/examples/dynamic-info-gatherer.ts
@@ -1,8 +1,9 @@
 /**
  * Dynamic InfoGatherer Example
  *
- * Shows how to use InfoGathererAgent with a callback function to dynamically
- * choose questions based on request parameters (query string).
+ * Shows how to use InfoGathererAgent in dynamic mode with a callback
+ * function that chooses the question set based on the request's query
+ * string.
  *
  * Run: npx tsx examples/dynamic-info-gatherer.ts
  * Test:
@@ -11,46 +12,42 @@
  */
 
 import { InfoGathererAgent } from '../src/index.js';
+import type { InfoGathererQuestion } from '../src/index.js';
 
-const questionSets: Record<string, Array<{ name: string; description: string; required?: boolean }>> = {
+const questionSets: Record<string, InfoGathererQuestion[]> = {
   default: [
-    { name: 'name', description: 'Full name', required: true },
-    { name: 'phone', description: 'Phone number', required: true },
-    { name: 'reason', description: 'How can I help you today?' },
+    { key_name: 'name', question_text: 'What is your full name?' },
+    { key_name: 'phone', question_text: 'What is a good callback number?' },
+    { key_name: 'reason', question_text: 'How can I help you today?' },
   ],
   support: [
-    { name: 'customer_name', description: 'Your name', required: true },
-    { name: 'account_number', description: 'Account number', required: true },
-    { name: 'issue', description: 'Describe the issue you are experiencing' },
-    { name: 'priority', description: 'Urgency level: Low, Medium, or High' },
+    { key_name: 'customer_name', question_text: 'What is your name?' },
+    { key_name: 'account_number', question_text: 'What is your account number?', confirm: true },
+    { key_name: 'issue', question_text: 'Describe the issue you are experiencing.' },
+    { key_name: 'priority', question_text: 'Is this low, medium, or high priority?' },
   ],
   medical: [
-    { name: 'patient_name', description: 'Patient full name', required: true },
-    { name: 'symptoms', description: 'Current symptoms', required: true },
-    { name: 'duration', description: 'How long have you had these symptoms?' },
-    { name: 'medications', description: 'Are you taking any medications?' },
+    { key_name: 'patient_name', question_text: 'What is the patient\'s full name?' },
+    { key_name: 'symptoms', question_text: 'What are the current symptoms?' },
+    { key_name: 'duration', question_text: 'How long have these symptoms been present?' },
+    { key_name: 'medications', question_text: 'Is the patient taking any medications?' },
   ],
   onboarding: [
-    { name: 'full_name', description: 'Your full name', required: true },
-    { name: 'email', description: 'Email address', required: true },
-    { name: 'company', description: 'Company name' },
-    { name: 'department', description: 'Department you will be working in' },
-    { name: 'start_date', description: 'Your start date' },
+    { key_name: 'full_name', question_text: 'What is your full name?' },
+    { key_name: 'email', question_text: 'What is your email address?', confirm: true },
+    { key_name: 'company', question_text: 'What company do you work for?' },
+    { key_name: 'department', question_text: 'What department will you be working in?' },
+    { key_name: 'start_date', question_text: 'What is your start date?' },
   ],
 };
 
 export const agent = new InfoGathererAgent({
   name: 'dynamic-intake',
-  fields: [], // dynamic mode: fields resolved per request
-  introMessage: 'Hi! I need to collect some information from you.',
-  confirmationMessage: 'Thank you, I have everything I need!',
+  // No `questions` → dynamic mode. Callback resolves them per request.
   questionCallback: (queryParams) => {
-    const set = queryParams.set ?? 'default';
+    const set = queryParams['set'] ?? 'default';
     console.log(`Dynamic question set: ${set}`);
-    return questionSets[set] ?? questionSets.default;
-  },
-  onComplete: (data) => {
-    console.log('All fields collected:', data);
+    return questionSets[set] ?? questionSets['default'];
   },
   agentOptions: {
     route: '/',

--- a/examples/prefab-concierge.ts
+++ b/examples/prefab-concierge.ts
@@ -1,41 +1,38 @@
 /**
  * Concierge Prefab Example
  *
- * Multi-department routing with knowledge base, hours of operation,
- * and call transfer capabilities.
+ * Virtual concierge for a venue. Answers questions about services,
+ * amenities, and hours, and checks availability and directions.
+ *
  * Run: npx tsx examples/prefab-concierge.ts
  */
 
 import { ConciergeAgent } from '../src/index.js';
 
 export const agent = new ConciergeAgent({
-  name: 'office-concierge',
-  companyName: 'Acme Technologies',
-  generalInfo: 'Acme Technologies is a leading provider of cloud communications. Founded in 2010, we serve over 10,000 customers worldwide.',
-  departments: [
-    {
-      name: 'Sales',
-      description: 'New accounts, pricing, and product demos',
-      transferNumber: '+18005551001',
-      keywords: ['buy', 'pricing', 'demo', 'trial', 'purchase'],
-      hoursOfOperation: 'Mon-Fri 8am-6pm EST',
-    },
-    {
-      name: 'Technical Support',
-      description: 'Product issues, troubleshooting, and bug reports',
-      transferNumber: '+18005551002',
-      keywords: ['help', 'broken', 'error', 'bug', 'issue', 'problem'],
-      hoursOfOperation: 'Mon-Fri 9am-9pm EST, Sat 10am-4pm EST',
-    },
-    {
-      name: 'Billing',
-      description: 'Invoices, payments, and account changes',
-      transferNumber: '+18005551003',
-      keywords: ['invoice', 'payment', 'charge', 'bill', 'subscription'],
-      hoursOfOperation: 'Mon-Fri 9am-5pm EST',
-    },
+  name: 'hotel-concierge',
+  venueName: 'Grand Plaza Hotel',
+  services: [
+    'room service',
+    'spa bookings',
+    'restaurant reservations',
+    'airport shuttle',
   ],
-  afterHoursMessage: 'This department is currently closed. Please call back during business hours or leave a message.',
+  amenities: {
+    pool: { hours: '7 AM - 10 PM', location: '2nd Floor (West Wing)' },
+    gym: { hours: '24 hours', location: '3rd Floor' },
+    spa: { hours: '9 AM - 8 PM', location: 'Ground Floor' },
+    'business center': { hours: '24 hours', location: 'Lobby Level' },
+  },
+  hoursOfOperation: {
+    weekday: '6 AM - 11 PM',
+    weekend: '7 AM - midnight',
+  },
+  specialInstructions: [
+    'Encourage guests to ask about our weekly wine tasting event.',
+    'Mention our partnership with local attractions when asked for recommendations.',
+  ],
+  welcomeMessage: 'Welcome to the Grand Plaza Hotel concierge! How may I assist you today?',
   agentOptions: {
     route: '/',
     basicAuth: [

--- a/examples/prefab-info-gatherer.ts
+++ b/examples/prefab-info-gatherer.ts
@@ -1,8 +1,11 @@
 /**
  * InfoGatherer Prefab Example
  *
- * Collects structured data from callers: name, email, phone.
- * Validates each field with regex, fires onComplete when done.
+ * Collects information from callers by asking a sequence of questions.
+ * Each question has a `key_name` used to store the answer and a
+ * `question_text` spoken to the caller. The `confirm` flag forces the AI
+ * to verify the answer before submitting.
+ *
  * Run: npx tsx examples/prefab-info-gatherer.ts
  */
 
@@ -10,35 +13,12 @@ import { InfoGathererAgent } from '../src/index.js';
 
 export const agent = new InfoGathererAgent({
   name: 'intake-agent',
-  fields: [
-    {
-      name: 'full_name',
-      description: 'The caller\'s full name (first and last)',
-      required: true,
-    },
-    {
-      name: 'email',
-      description: 'The caller\'s email address',
-      required: true,
-      validation: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-    },
-    {
-      name: 'phone',
-      description: 'A callback phone number',
-      required: true,
-      validation: /^\+?[\d\s\-()]{7,15}$/,
-    },
-    {
-      name: 'company',
-      description: 'The caller\'s company or organization',
-      required: false,
-    },
+  questions: [
+    { key_name: 'full_name', question_text: 'What is your full name?' },
+    { key_name: 'email', question_text: 'What is your email address?', confirm: true },
+    { key_name: 'phone', question_text: 'What is a good callback number?', confirm: true },
+    { key_name: 'reason', question_text: 'How can we help you today?' },
   ],
-  introMessage: 'Hi there! I need to collect a few details from you. Let\'s start with your name.',
-  confirmationMessage: 'Great, I have everything I need. Thank you for your time!',
-  onComplete: (data) => {
-    console.log('All fields collected:', data);
-  },
   agentOptions: {
     route: '/',
     basicAuth: [

--- a/examples/prefab-receptionist.ts
+++ b/examples/prefab-receptionist.ts
@@ -1,8 +1,10 @@
 /**
  * Receptionist Prefab Example
  *
- * Front-desk agent with visitor check-in, department directory,
- * and call transfers by extension.
+ * Front-desk agent that greets callers, collects their name + reason for
+ * calling, and transfers them to the appropriate department by phone
+ * number. Optionally supports visitor check-in.
+ *
  * Run: npx tsx examples/prefab-receptionist.ts
  */
 
@@ -12,12 +14,12 @@ export const agent = new ReceptionistAgent({
   name: 'front-desk',
   companyName: 'Acme Technologies',
   departments: [
-    { name: 'Engineering', extension: '1001', description: 'Software development team' },
-    { name: 'Marketing', extension: '1002', description: 'Marketing and communications' },
-    { name: 'Human Resources', extension: '1003', description: 'HR, hiring, and benefits' },
-    { name: 'Finance', extension: '1004', description: 'Accounting and finance' },
+    { name: 'engineering', description: 'Software development team', number: '+15551001001' },
+    { name: 'marketing', description: 'Marketing and communications', number: '+15551001002' },
+    { name: 'hr', description: 'Hiring and benefits', number: '+15551001003' },
+    { name: 'finance', description: 'Accounting and finance', number: '+15551001004' },
   ],
-  welcomeMessage: 'Welcome to Acme Technologies! I\'m the front desk assistant. How can I help you today?',
+  greeting: 'Welcome to Acme Technologies! How can I help you today?',
   checkInEnabled: true,
   onVisitorCheckIn: (visitor) => {
     console.log('Visitor checked in:', visitor);
@@ -30,7 +32,5 @@ export const agent = new ReceptionistAgent({
     ],
   },
 });
-
-agent.addLanguage({ name: 'English', code: 'en-US', voice: 'rachel' });
 
 agent.run();

--- a/examples/prefab-survey.ts
+++ b/examples/prefab-survey.ts
@@ -11,11 +11,13 @@ import { SurveyAgent } from '../src/index.js';
 
 export const agent = new SurveyAgent({
   name: 'csat-survey',
+  surveyName: 'Customer Satisfaction Survey',
   questions: [
     {
       id: 'satisfaction',
       text: 'Overall, how satisfied are you with our service?',
       type: 'rating',
+      scale: 10,
       points: { '9': 3, '10': 3, '7': 2, '8': 2 },
     },
     {
@@ -47,8 +49,8 @@ export const agent = new SurveyAgent({
       type: 'open_ended',
     },
   ],
-  introMessage: 'Thank you for calling! We\'d love your feedback. This survey takes about 2 minutes.',
-  completionMessage: 'Thank you for your feedback! It helps us improve.',
+  introduction: 'Thank you for calling! We\'d love your feedback. This survey takes about 2 minutes.',
+  conclusion: 'Thank you for your feedback! It helps us improve.',
   onComplete: (responses, score) => {
     console.log('Survey complete:', { responses, score });
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "signalwire-agents",
-  "version": "0.1.0",
+  "name": "@signalwire/sdk",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "signalwire-agents",
-      "version": "0.1.0",
+      "name": "@signalwire/sdk",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.11.0",

--- a/src/prefabs/ConciergeAgent.ts
+++ b/src/prefabs/ConciergeAgent.ts
@@ -1,6 +1,9 @@
 /**
- * ConciergeAgent - A prefab agent that provides multi-department routing
- * with a knowledge base of department info, hours, and transfer capabilities.
+ * ConciergeAgent - Prefab agent that acts as a virtual concierge for a venue
+ * or business, providing information about services, amenities, and hours,
+ * and answering availability and directions questions.
+ *
+ * Ported from the Python SDK `signalwire.prefabs.concierge.ConciergeAgent`.
  */
 
 import { AgentBase } from '../AgentBase.js';
@@ -9,231 +12,266 @@ import type { AgentOptions } from '../types.js';
 
 // ── Config types ────────────────────────────────────────────────────────────
 
-export interface Department {
-  /** Department name (e.g. "Sales", "Support"). */
-  name: string;
-  /** Description of what this department handles. */
-  description: string;
-  /** Phone number or SIP address for transfers. */
-  transferNumber?: string;
-  /** Keywords that help route callers to this department. */
-  keywords?: string[];
-  /** Human-readable hours of operation (e.g. "Mon-Fri 9am-5pm EST"). */
-  hoursOfOperation?: string;
-}
-
 export interface ConciergeConfig {
-  /** Agent display name. */
+  /** Name of the venue or business (required). */
+  venueName: string;
+  /** List of services offered by the venue (required). */
+  services: string[];
+  /** Dictionary of amenities, each mapping to a dict of detail keys/values. */
+  amenities: Record<string, Record<string, string>>;
+  /** Optional hours of operation by category (e.g. `{ default: "9 AM - 5 PM" }`). */
+  hoursOfOperation?: Record<string, string>;
+  /** Optional special instructions appended to the agent's instruction bullets. */
+  specialInstructions?: string[];
+  /** Optional custom welcome message spoken as a non-bargeable static greeting. */
+  welcomeMessage?: string;
+  /** Agent display name (defaults to `"concierge"`). */
   name?: string;
-  /** List of departments available for routing. */
-  departments: Department[];
-  /** Company name used in greetings and prompts. */
-  companyName?: string;
-  /** General company information the agent can share. */
-  generalInfo?: string;
-  /** Message spoken when a department is closed or unavailable. */
-  afterHoursMessage?: string;
-  /** Additional AgentBase options forwarded to super(). */
+  /** HTTP route for this agent (defaults to `"/concierge"`). */
+  route?: string;
+  /** Additional AgentBase options forwarded to `super()`. */
   agentOptions?: Partial<AgentOptions>;
 }
 
 // ── Agent ───────────────────────────────────────────────────────────────────
 
-/** Prefab agent that provides multi-department routing with a knowledge base of department info, hours, and transfer capabilities. */
+/**
+ * Prefab agent that acts as a virtual concierge for a venue, providing information
+ * about services, amenities, hours of operation, availability, and directions.
+ */
 export class ConciergeAgent extends AgentBase {
-  private departments: Department[];
-  private companyName: string;
-  private generalInfo: string;
-  private afterHoursMessage: string;
-
-  /** Declarative prompt sections merged by AgentBase constructor. */
-  static override PROMPT_SECTIONS = [
-    {
-      title: 'Role',
-      body: 'You are a professional concierge agent. Help callers find the right department, provide information about available services, and transfer calls when requested.',
-    },
-    {
-      title: 'Rules',
-      bullets: [
-        'Greet the caller warmly and ask how you can help.',
-        'Use list_departments to describe available departments if the caller is unsure where to go.',
-        'Use get_department_info to provide detailed information about a specific department.',
-        'Use transfer_to_department to connect the caller to the right department.',
-        'If a department has hours of operation listed, mention them before transferring.',
-        'If a department does not have a transfer number, inform the caller and offer alternatives.',
-        'Be polite, professional, and efficient.',
-      ],
-    },
-  ];
+  /** Name of the venue or business. */
+  public venueName: string;
+  /** List of services offered by the venue. */
+  public services: string[];
+  /** Dictionary of amenities, each mapping to a dict of detail keys/values. */
+  public amenities: Record<string, Record<string, string>>;
+  /** Hours of operation by category. Defaults to `{ default: "9 AM - 5 PM" }`. */
+  public hoursOfOperation: Record<string, string>;
+  /** Special instructions appended to the agent's instruction bullets. */
+  public specialInstructions: string[];
 
   /**
-   * Create a ConciergeAgent with the specified departments and company info.
-   * @param config - Configuration including departments, company name, and after-hours message.
+   * Create a ConciergeAgent for a venue with the given services, amenities, and hours.
+   * @param config - Configuration including venue name, services, amenities, and optional hours/instructions/welcome.
    */
   constructor(config: ConciergeConfig) {
-    const agentName = config.name ?? 'Concierge';
+    const agentName = config.name ?? 'concierge';
     super({
       name: agentName,
+      route: config.route ?? '/concierge',
+      usePom: true,
       ...config.agentOptions,
     });
 
-    this.departments = config.departments;
-    this.companyName = config.companyName ?? 'our company';
-    this.generalInfo = config.generalInfo ?? '';
-    this.afterHoursMessage = config.afterHoursMessage ?? 'This department is currently closed. Please try again during business hours.';
+    // Store configuration
+    this.venueName = config.venueName;
+    this.services = config.services;
+    this.amenities = config.amenities;
+    this.hoursOfOperation = config.hoursOfOperation ?? { default: '9 AM - 5 PM' };
+    this.specialInstructions = config.specialInstructions ?? [];
 
-    // Company intro section
-    let introBody = `You are the concierge for ${this.companyName}.`;
-    if (this.generalInfo) {
-      introBody += ` Company information: ${this.generalInfo}`;
-    }
-    this.promptAddSection('Company', { body: introBody });
-
-    // Build department overview section
-    const deptBullets = this.departments.map((dept) => {
-      let desc = `${dept.name}: ${dept.description}`;
-      if (dept.hoursOfOperation) desc += ` (Hours: ${dept.hoursOfOperation})`;
-      if (dept.transferNumber) desc += ' [transfer available]';
-      return desc;
-    });
-    this.promptAddSection('Available Departments', { bullets: deptBullets });
-
-    // Speech recognition hints from department names and keywords
-    const hints: string[] = this.departments.map((d) => d.name);
-    for (const dept of this.departments) {
-      if (dept.keywords) hints.push(...dept.keywords);
-    }
-    this.addHints(hints);
+    // Build the agent prompt and settings
+    this.setupConciergeAgent(config.welcomeMessage);
 
     // Register tools after all fields are initialized
     this.defineTools();
   }
 
-  // ── Department helpers ────────────────────────────────────────────────
+  /** Configure the concierge agent's prompt, hints, params, and global data. */
+  private setupConciergeAgent(welcomeMessage?: string): void {
+    // Personality
+    this.promptAddSection('Personality', {
+      body: `You are a professional and helpful virtual concierge for ${this.venueName}.`,
+    });
 
-  private findDepartment(name: string): Department | undefined {
-    const normalized = name.toLowerCase().trim();
-    return this.departments.find(
-      (d) =>
-        d.name.toLowerCase() === normalized ||
-        d.keywords?.some((k) => k.toLowerCase() === normalized),
-    );
+    // Goal
+    this.promptAddSection('Goal', {
+      body: 'Provide exceptional service by helping users with information, recommendations, and booking assistance.',
+    });
+
+    // Instructions (base + special)
+    const instructions = [
+      'Be warm and welcoming but professional at all times.',
+      'Provide accurate information about amenities, services, and operating hours.',
+      'Offer to help with reservations and bookings when appropriate.',
+      'Answer questions concisely with specific, relevant details.',
+      ...this.specialInstructions,
+    ];
+    this.promptAddSection('Instructions', { bullets: instructions });
+
+    // Services
+    const servicesList = this.services.join(', ');
+    this.promptAddSection('Available Services', {
+      body: `The following services are available: ${servicesList}`,
+    });
+
+    // Amenities (each as a subsection)
+    const amenitiesSubsections = Object.entries(this.amenities).map(([name, details]) => ({
+      title: this.titleCase(name),
+      body: Object.entries(details)
+        .map(([k, v]) => `${this.titleCase(k)}: ${v}`)
+        .join('\n'),
+    }));
+    this.promptAddSection('Amenities', {
+      body: 'Information about available amenities:',
+      subsections: amenitiesSubsections,
+    });
+
+    // Hours of operation
+    const hoursList = Object.entries(this.hoursOfOperation)
+      .map(([k, v]) => `${this.titleCase(k)}: ${v}`)
+      .join('\n');
+    this.promptAddSection('Hours of Operation', { body: hoursList });
+
+    // Post-prompt summary template
+    this.setPostPrompt(`
+        Return a JSON summary of this interaction:
+        {
+            "topic": "MAIN_TOPIC",
+            "service_requested": "SPECIFIC_SERVICE_REQUESTED_OR_null",
+            "questions_answered": ["QUESTION_1", "QUESTION_2"],
+            "follow_up_needed": true/false
+        }
+        `);
+
+    // Hints for speech recognition
+    this.addHints([
+      this.venueName,
+      ...this.services,
+      ...Object.keys(this.amenities),
+    ]);
+
+    // AI behavior params
+    this.setParams({
+      wait_for_user: false,
+      end_of_speech_timeout: 1000,
+      ai_volume: 5,
+      local_tz: 'America/New_York',
+    });
+
+    // Global data
+    this.setGlobalData({
+      venue_name: this.venueName,
+      services: this.services,
+      amenities: this.amenities,
+      hours: this.hoursOfOperation,
+    });
+
+    // Native functions
+    this.setNativeFunctions(['check_time']);
+
+    // Custom welcome message (non-bargeable static greeting)
+    if (welcomeMessage) {
+      this.setParams({
+        static_greeting: welcomeMessage,
+        static_greeting_no_barge: true,
+      });
+    }
+  }
+
+  private titleCase(value: string): string {
+    // Mirrors Python's str.title(): title-cases each word separated by non-letters.
+    return value.replace(/[A-Za-z]+/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
   }
 
   // ── Tool registration ─────────────────────────────────────────────────
 
-  /** Register the list_departments, get_department_info, and transfer_to_department SWAIG tools. */
+  /** Register the `check_availability` and `get_directions` SWAIG tools. */
   protected override defineTools(): void {
-    // Tool: list_departments
+    // Tool: check_availability
     this.defineTool({
-      name: 'list_departments',
-      description: `List all available departments at ${this.companyName} with their descriptions and hours of operation.`,
+      name: 'check_availability',
+      description: 'Check availability for a service on a specific date and time',
       parameters: {
         type: 'object',
-        properties: {},
+        properties: {
+          service: {
+            type: 'string',
+            description: 'The service to check (e.g., spa, restaurant)',
+          },
+          date: {
+            type: 'string',
+            description: 'The date to check (YYYY-MM-DD format)',
+          },
+          time: {
+            type: 'string',
+            description: 'The time to check (HH:MM format, 24-hour)',
+          },
+        },
+        required: ['service', 'date', 'time'],
       },
-      handler: () => {
-        if (this.departments.length === 0) {
-          return new FunctionResult('No departments are currently configured.');
+      handler: (args: Record<string, unknown>) => {
+        const service = ((args['service'] as string) ?? '').toLowerCase();
+        const date = (args['date'] as string) ?? '';
+        const time = (args['time'] as string) ?? '';
+
+        // Simple availability simulation — in a real app this would hit a booking system.
+        const lowerServices = this.services.map((s) => s.toLowerCase());
+        if (lowerServices.includes(service)) {
+          return new FunctionResult(
+            `Yes, ${service} is available on ${date} at ${time}. Would you like to make a reservation?`,
+          );
         }
-
-        const lines = this.departments.map((dept) => {
-          let line = `${dept.name}: ${dept.description}`;
-          if (dept.hoursOfOperation) line += ` | Hours: ${dept.hoursOfOperation}`;
-          if (!dept.transferNumber) line += ' | (no direct transfer available)';
-          return line;
-        });
-
         return new FunctionResult(
-          `Available departments at ${this.companyName}:\n${lines.join('\n')}`,
+          `I'm sorry, we don't offer ${service} at ${this.venueName}. ` +
+            `Our available services are: ${this.services.join(', ')}.`,
         );
       },
     });
 
-    // Tool: get_department_info
+    // Tool: get_directions
     this.defineTool({
-      name: 'get_department_info',
-      description: 'Get detailed information about a specific department including description, hours of operation, and transfer availability.',
+      name: 'get_directions',
+      description: 'Get directions to a specific location or amenity',
       parameters: {
         type: 'object',
         properties: {
-          department_name: {
+          location: {
             type: 'string',
-            description: 'The name of the department to look up.',
+            description: 'The location or amenity to get directions to',
           },
         },
-        required: ['department_name'],
+        required: ['location'],
       },
-      handler: (_args: Record<string, unknown>) => {
-        const deptName = _args['department_name'] as string;
-        if (!deptName) {
-          return new FunctionResult('Please provide a department name.');
-        }
+      handler: (args: Record<string, unknown>) => {
+        const location = ((args['location'] as string) ?? '').toLowerCase();
 
-        const dept = this.findDepartment(deptName);
-        if (!dept) {
-          const available = this.departments.map((d) => d.name).join(', ');
+        const amenity = this.amenities[location];
+        if (amenity && typeof amenity['location'] === 'string') {
+          const amenityLocation = amenity['location'];
           return new FunctionResult(
-            `Department "${deptName}" not found. Available departments: ${available}`,
+            `The ${location} is located at ${amenityLocation}. ` +
+              `From the main entrance, follow the signs to ${amenityLocation}.`,
           );
         }
-
-        let info = `Department: ${dept.name}\nDescription: ${dept.description}`;
-        if (dept.hoursOfOperation) info += `\nHours: ${dept.hoursOfOperation}`;
-        if (dept.transferNumber) {
-          info += '\nTransfer: available';
-        } else {
-          info += '\nTransfer: not available (no phone number configured)';
-        }
-        if (dept.keywords && dept.keywords.length > 0) {
-          info += `\nRelated topics: ${dept.keywords.join(', ')}`;
-        }
-
-        return new FunctionResult(info);
-      },
-    });
-
-    // Tool: transfer_to_department
-    this.defineTool({
-      name: 'transfer_to_department',
-      description: 'Transfer the caller to a specific department. Only works if the department has a transfer number configured.',
-      parameters: {
-        type: 'object',
-        properties: {
-          department_name: {
-            type: 'string',
-            description: 'The name of the department to transfer to.',
-          },
-        },
-        required: ['department_name'],
-      },
-      handler: (_args: Record<string, unknown>) => {
-        const deptName = _args['department_name'] as string;
-        if (!deptName) {
-          return new FunctionResult('Please provide a department name.');
-        }
-
-        const dept = this.findDepartment(deptName);
-        if (!dept) {
-          const available = this.departments.map((d) => d.name).join(', ');
-          return new FunctionResult(
-            `Department "${deptName}" not found. Available departments: ${available}`,
-          );
-        }
-
-        if (!dept.transferNumber) {
-          return new FunctionResult(
-            `The ${dept.name} department does not have a direct transfer number. ${this.afterHoursMessage}`,
-          );
-        }
-
-        const result = new FunctionResult(
-          `Transferring you to the ${dept.name} department now.`,
+        return new FunctionResult(
+          `I don't have specific directions to ${location}. ` +
+            'You can ask our staff at the front desk for assistance.',
         );
-        result.connect(dept.transferNumber);
-        return result;
       },
     });
+  }
+
+  // ── Lifecycle hooks ───────────────────────────────────────────────────
+
+  /**
+   * Process the interaction summary returned at the end of a call.
+   * Logs structured summaries as JSON. Subclasses may override to persist or process.
+   */
+  override onSummary(
+    summary: Record<string, unknown> | null,
+    _rawData: Record<string, unknown>,
+  ): void | Promise<void> {
+    if (summary) {
+      try {
+        // eslint-disable-next-line no-console
+        console.log(`Concierge interaction summary: ${JSON.stringify(summary, null, 2)}`);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log(`Error processing summary: ${String(err)}`);
+      }
+    }
   }
 }
 

--- a/src/prefabs/ConciergeAgent.ts
+++ b/src/prefabs/ConciergeAgent.ts
@@ -199,7 +199,6 @@ export class ConciergeAgent extends AgentBase {
             description: 'The time to check (HH:MM format, 24-hour)',
           },
         },
-        required: ['service', 'date', 'time'],
       },
       handler: (args: Record<string, unknown>) => {
         const service = ((args['service'] as string) ?? '').toLowerCase();
@@ -232,7 +231,6 @@ export class ConciergeAgent extends AgentBase {
             description: 'The location or amenity to get directions to',
           },
         },
-        required: ['location'],
       },
       handler: (args: Record<string, unknown>) => {
         const location = ((args['location'] as string) ?? '').toLowerCase();

--- a/src/prefabs/FAQBotAgent.ts
+++ b/src/prefabs/FAQBotAgent.ts
@@ -261,11 +261,11 @@ export class FAQBotAgent extends AgentBase {
         properties: {
           query: {
             type: 'string',
-            description: 'The caller\'s question or search query.',
+            description: 'The search query',
           },
           category: {
             type: 'string',
-            description: 'Optional category to filter the FAQ list by.',
+            description: 'Optional category to filter by',
           },
         },
       },
@@ -298,11 +298,13 @@ export class FAQBotAgent extends AgentBase {
           return new FunctionResult('No matching FAQs found.');
         }
 
-        // Match Python's response format: a numbered list of the top matches'
-        // question text. The answer text is supplied to the AI via the prompt's
-        // "FAQ Database" section — the tool just indicates which FAQs matched.
-        const limit = this.suggestRelated ? 3 : 1;
-        const top = scored.slice(0, limit);
+        // Match Python's response format: a numbered list of the top 3 matches'
+        // question text (faq_bot.py:276-283). The answer text is supplied to
+        // the AI via the prompt's "FAQ Database" section — the tool just
+        // indicates which FAQs matched. The `suggest_related` flag does not
+        // change the top-N here; it only toggles the prompt's "Related
+        // Questions" section and the extra instruction bullet (Python parity).
+        const top = scored.slice(0, 3);
         const lines = top.map((s, i) => `${i + 1}. ${s.faq.question}`).join('\n');
         return new FunctionResult(`Here are the most relevant FAQs:\n\n${lines}\n`);
       },

--- a/src/prefabs/FAQBotAgent.ts
+++ b/src/prefabs/FAQBotAgent.ts
@@ -255,7 +255,7 @@ export class FAQBotAgent extends AgentBase {
     // Tool: search_faqs (matches Python name; supports optional category filter)
     this.defineTool({
       name: 'search_faqs',
-      description: 'Search the FAQ knowledge base for answers matching a query, optionally filtered by category.',
+      description: 'Search for FAQs matching a specific query or category',
       parameters: {
         type: 'object',
         properties: {
@@ -268,7 +268,6 @@ export class FAQBotAgent extends AgentBase {
             description: 'Optional category to filter the FAQ list by.',
           },
         },
-        required: ['query'],
       },
       handler: (args: Record<string, unknown>) => {
         const query = (args['query'] as string) ?? '';
@@ -286,44 +285,26 @@ export class FAQBotAgent extends AgentBase {
           : this.faqs;
 
         if (pool.length === 0) {
-          return new FunctionResult(
-            `No FAQs found in category "${category}". ${this.escalationMessage}`,
-          );
+          return new FunctionResult('No matching FAQs found.');
         }
 
         // Score all FAQs in the (possibly filtered) pool
-        const scored = pool.map((faq) => ({
-          faq,
-          score: this.computeMatchScore(query, faq),
-        }));
+        const scored = pool
+          .map((faq) => ({ faq, score: this.computeMatchScore(query, faq) }))
+          .filter((s) => s.score >= this.threshold)
+          .sort((a, b) => b.score - a.score);
 
-        // Sort by score descending
-        scored.sort((a, b) => b.score - a.score);
-
-        const best = scored[0];
-
-        if (!best || best.score < this.threshold) {
-          return new FunctionResult(
-            `No FAQ matched the query "${query}" with sufficient confidence (best score: ${best ? best.score.toFixed(2) : '0.00'}, threshold: ${this.threshold.toFixed(2)}). ${this.escalationMessage}`,
-          );
+        if (scored.length === 0) {
+          return new FunctionResult('No matching FAQs found.');
         }
 
-        // Return the best match
-        let response = `FAQ Match (confidence: ${best.score.toFixed(2)}): Q: "${best.faq.question}" A: ${best.faq.answer}`;
-
-        // Runner-ups: only suggested when `suggestRelated` is true
-        if (this.suggestRelated) {
-          const runnerUps = scored.filter((s, i) => i > 0 && s.score >= this.threshold);
-          if (runnerUps.length > 0) {
-            const alsoStr = runnerUps
-              .slice(0, 2)
-              .map((s) => `"${s.faq.question}" (${s.score.toFixed(2)})`)
-              .join(', ');
-            response += ` Also related: ${alsoStr}`;
-          }
-        }
-
-        return new FunctionResult(response);
+        // Match Python's response format: a numbered list of the top matches'
+        // question text. The answer text is supplied to the AI via the prompt's
+        // "FAQ Database" section — the tool just indicates which FAQs matched.
+        const limit = this.suggestRelated ? 3 : 1;
+        const top = scored.slice(0, limit);
+        const lines = top.map((s, i) => `${i + 1}. ${s.faq.question}`).join('\n');
+        return new FunctionResult(`Here are the most relevant FAQs:\n\n${lines}\n`);
       },
     });
 
@@ -344,7 +325,7 @@ export class FAQBotAgent extends AgentBase {
         handler: (_args: Record<string, unknown>) => {
           const reason = (_args['reason'] as string) || 'Caller needs assistance beyond FAQ';
           const result = new FunctionResult(
-            `Transferring caller to a live agent. Reason: ${reason}`,
+            `${this.escalationMessage} Transferring caller to a live agent. Reason: ${reason}`,
           );
           result.connect(this.escalationNumber!);
           return result;

--- a/src/prefabs/FAQBotAgent.ts
+++ b/src/prefabs/FAQBotAgent.ts
@@ -2,6 +2,10 @@
  * FAQBotAgent - A prefab agent that answers frequently asked questions using
  * keyword/word-overlap matching with configurable similarity thresholds
  * and optional escalation to a live agent.
+ *
+ * Ported from the Python SDK `signalwire.prefabs.faq_bot.FAQBotAgent`. Keeps
+ * TS-specific enhancements (configurable similarity threshold, word-overlap
+ * matcher, escalation tool) alongside the Python prefab's public surface.
  */
 
 import { AgentBase } from '../AgentBase.js';
@@ -17,13 +21,21 @@ export interface FAQEntry {
   answer: string;
   /** Additional keywords to boost matching accuracy. */
   keywords?: string[];
+  /** Taxonomy categories this FAQ belongs to (used for filtering and hints). */
+  categories?: string[];
 }
 
 export interface FAQBotConfig {
-  /** Agent display name. */
+  /** Agent display name (defaults to `"faq_bot"`). */
   name?: string;
+  /** HTTP route for this agent (defaults to `"/faq"`). */
+  route?: string;
   /** List of FAQ entries for the knowledge base. */
   faqs: FAQEntry[];
+  /** Whether to suggest related questions alongside a match. Default `true`. */
+  suggestRelated?: boolean;
+  /** Custom personality description for the agent's "Personality" prompt section. */
+  persona?: string;
   /** Minimum match score (0-1) for an FAQ to be considered a match. Default 0.5. */
   threshold?: number;
   /** Message spoken when no FAQ matches the query. */
@@ -38,63 +50,147 @@ export interface FAQBotConfig {
 
 /** Prefab agent that answers frequently asked questions using keyword matching with optional escalation to a live agent. */
 export class FAQBotAgent extends AgentBase {
-  private faqs: FAQEntry[];
+  /** The configured FAQ entries. */
+  public faqs: FAQEntry[];
+  /** Whether runner-up FAQ suggestions are appended to matches. */
+  public suggestRelated: boolean;
+  /** The personality description used in the prompt. */
+  public persona: string;
   private threshold: number;
   private escalationMessage: string;
   private escalationNumber: string | null;
-
-  /** Declarative prompt sections merged by AgentBase constructor. */
-  static override PROMPT_SECTIONS = [
-    {
-      title: 'Role',
-      body: 'You are a helpful FAQ assistant. Answer the caller\'s questions by searching the knowledge base. If you cannot find a satisfactory answer, offer to escalate to a human agent.',
-    },
-    {
-      title: 'Rules',
-      bullets: [
-        'Always use the search_faq tool to find answers. Do not make up answers.',
-        'If the search returns a good match, relay the answer naturally to the caller.',
-        'If the match score is low or no match is found, let the caller know and offer to escalate.',
-        'Be concise and helpful in your responses.',
-        'If the caller asks a follow-up, search again with the new query.',
-      ],
-    },
-  ];
 
   /**
    * Create a FAQBotAgent with the specified FAQ entries and matching threshold.
    * @param config - Configuration including FAQ entries, threshold, and escalation settings.
    */
   constructor(config: FAQBotConfig) {
-    const agentName = config.name ?? 'FAQBot';
+    const agentName = config.name ?? 'faq_bot';
     super({
       name: agentName,
+      route: config.route ?? '/faq',
+      usePom: true,
       ...config.agentOptions,
     });
 
     this.faqs = config.faqs;
+    this.suggestRelated = config.suggestRelated ?? true;
+    this.persona =
+      config.persona ??
+      'You are a helpful FAQ bot that provides accurate answers to common questions.';
     this.threshold = config.threshold ?? 0.5;
-    this.escalationMessage = config.escalationMessage ?? 'I\'m sorry, I couldn\'t find an answer to your question. Let me transfer you to someone who can help.';
+    this.escalationMessage =
+      config.escalationMessage ??
+      "I'm sorry, I couldn't find an answer to your question. Let me transfer you to someone who can help.";
     this.escalationNumber = config.escalationNumber ?? null;
 
-    // Build FAQ topics section for the prompt
-    const topicBullets = this.faqs.map((faq) => {
-      const kw = faq.keywords ? ` (keywords: ${faq.keywords.join(', ')})` : '';
-      return `${faq.question}${kw}`;
-    });
-    this.promptAddSection('Available FAQ Topics', { bullets: topicBullets });
-
-    // Add hints from FAQ keywords for speech recognition
-    const allKeywords: string[] = [];
-    for (const faq of this.faqs) {
-      if (faq.keywords) allKeywords.push(...faq.keywords);
-    }
-    if (allKeywords.length > 0) {
-      this.addHints(allKeywords);
-    }
+    this.buildPrompt();
+    this.configureAgentSettings();
 
     // Register tools after all fields are initialized
     this.defineTools();
+  }
+
+  // ── Prompt construction (mirrors Python _build_faq_bot_prompt) ────────
+
+  private buildPrompt(): void {
+    // Personality
+    this.promptAddSection('Personality', { body: this.persona });
+
+    // Goal
+    this.promptAddSection('Goal', {
+      body:
+        'Answer user questions by matching them to the most similar FAQ in your database.',
+    });
+
+    // Instructions
+    const instructions = [
+      'Compare user questions to your FAQ database and find the best match.',
+      'Provide the answer from the FAQ database for the matching question.',
+      'If no close match exists, politely say you don\'t have that information.',
+      'Be concise and factual in your responses.',
+    ];
+    if (this.suggestRelated) {
+      instructions.push(
+        'When appropriate, suggest other related questions from the FAQ database that might be helpful.',
+      );
+    }
+    this.promptAddSection('Instructions', { bullets: instructions });
+
+    // FAQ Database (each FAQ as a subsection with optional categories line)
+    const faqSubsections = this.faqs
+      .filter((faq) => faq.question && faq.answer)
+      .map((faq) => {
+        let body = faq.answer;
+        if (faq.categories && faq.categories.length > 0) {
+          body = `${body}\n\nCategories: ${faq.categories.join(', ')}`;
+        }
+        return { title: faq.question, body };
+      });
+    this.promptAddSection('FAQ Database', {
+      body: 'Here is your database of frequently asked questions and answers:',
+      subsections: faqSubsections,
+    });
+
+    if (this.suggestRelated) {
+      this.promptAddSection('Related Questions', {
+        body:
+          'When appropriate, suggest other related questions from the FAQ database that might be helpful.',
+      });
+    }
+  }
+
+  // ── Agent settings (mirrors Python _configure_agent_settings + _setup_post_prompt) ─
+
+  private configureAgentSettings(): void {
+    // Post-prompt summary template
+    this.setPostPrompt(`
+        Return a JSON summary of this interaction:
+        {
+            "question": "MAIN_QUESTION_ASKED",
+            "matched_faq": "MATCHED_FAQ_QUESTION_OR_null",
+            "answered_successfully": true/false,
+            "suggested_related": []
+        }
+        `);
+
+    // Hints: 4+ char question words, FAQ keywords, and categories
+    const hints: string[] = [];
+    for (const faq of this.faqs) {
+      const question = faq.question ?? '';
+      if (question) {
+        const words = question
+          .split(/\s+/)
+          .map((w) => w.replace(/^[.,?!]+|[.,?!]+$/g, ''))
+          .filter((w) => w.length >= 4);
+        hints.push(...words);
+      }
+      if (faq.keywords) hints.push(...faq.keywords);
+      if (faq.categories) hints.push(...faq.categories);
+    }
+    const unique = Array.from(new Set(hints));
+    if (unique.length > 0) this.addHints(unique);
+
+    // AI behavior parameters
+    this.setParams({
+      wait_for_user: false,
+      end_of_speech_timeout: 1000,
+      ai_volume: 5,
+    });
+
+    // Global data: faq count and categories
+    const categories = Array.from(
+      new Set(
+        this.faqs.flatMap((faq) => faq.categories ?? []),
+      ),
+    );
+    this.setGlobalData({
+      faq_count: this.faqs.length,
+      categories,
+    });
+
+    // Native functions
+    this.setNativeFunctions(['check_time']);
   }
 
   // ── Matching engine ───────────────────────────────────────────────────
@@ -154,12 +250,12 @@ export class FAQBotAgent extends AgentBase {
 
   // ── Tool registration ─────────────────────────────────────────────────
 
-  /** Register the search_faq and optional escalate SWAIG tools. */
+  /** Register the search_faqs and optional escalate SWAIG tools. */
   protected override defineTools(): void {
-    // Tool: search_faq
+    // Tool: search_faqs (matches Python name; supports optional category filter)
     this.defineTool({
-      name: 'search_faq',
-      description: 'Search the FAQ knowledge base for an answer to the caller\'s question. Returns the best matching FAQ entry with a confidence score.',
+      name: 'search_faqs',
+      description: 'Search the FAQ knowledge base for answers matching a query, optionally filtered by category.',
       parameters: {
         type: 'object',
         properties: {
@@ -167,17 +263,36 @@ export class FAQBotAgent extends AgentBase {
             type: 'string',
             description: 'The caller\'s question or search query.',
           },
+          category: {
+            type: 'string',
+            description: 'Optional category to filter the FAQ list by.',
+          },
         },
         required: ['query'],
       },
-      handler: (_args: Record<string, unknown>) => {
-        const query = _args['query'] as string;
+      handler: (args: Record<string, unknown>) => {
+        const query = (args['query'] as string) ?? '';
+        const category = ((args['category'] as string) ?? '').toLowerCase().trim();
         if (!query) {
           return new FunctionResult('A query is required to search the FAQ.');
         }
 
-        // Score all FAQs
-        const scored = this.faqs.map((faq) => ({
+        // Optionally filter by category
+        const pool = category
+          ? this.faqs.filter(
+              (faq) =>
+                (faq.categories ?? []).some((c) => c.toLowerCase().trim() === category),
+            )
+          : this.faqs;
+
+        if (pool.length === 0) {
+          return new FunctionResult(
+            `No FAQs found in category "${category}". ${this.escalationMessage}`,
+          );
+        }
+
+        // Score all FAQs in the (possibly filtered) pool
+        const scored = pool.map((faq) => ({
           faq,
           score: this.computeMatchScore(query, faq),
         }));
@@ -196,14 +311,16 @@ export class FAQBotAgent extends AgentBase {
         // Return the best match
         let response = `FAQ Match (confidence: ${best.score.toFixed(2)}): Q: "${best.faq.question}" A: ${best.faq.answer}`;
 
-        // If there are close runner-ups, mention them
-        const runnerUps = scored.filter((s, i) => i > 0 && s.score >= this.threshold);
-        if (runnerUps.length > 0) {
-          const alsoStr = runnerUps
-            .slice(0, 2)
-            .map((s) => `"${s.faq.question}" (${s.score.toFixed(2)})`)
-            .join(', ');
-          response += ` Also related: ${alsoStr}`;
+        // Runner-ups: only suggested when `suggestRelated` is true
+        if (this.suggestRelated) {
+          const runnerUps = scored.filter((s, i) => i > 0 && s.score >= this.threshold);
+          if (runnerUps.length > 0) {
+            const alsoStr = runnerUps
+              .slice(0, 2)
+              .map((s) => `"${s.faq.question}" (${s.score.toFixed(2)})`)
+              .join(', ');
+            response += ` Also related: ${alsoStr}`;
+          }
         }
 
         return new FunctionResult(response);
@@ -233,6 +350,27 @@ export class FAQBotAgent extends AgentBase {
           return result;
         },
       });
+    }
+  }
+
+  // ── Lifecycle hooks ───────────────────────────────────────────────────
+
+  /**
+   * Process the interaction summary returned at the end of a call.
+   * Logs structured summaries as JSON. Subclasses may override to persist or process.
+   */
+  override onSummary(
+    summary: Record<string, unknown> | null,
+    _rawData: Record<string, unknown>,
+  ): void | Promise<void> {
+    if (summary) {
+      try {
+        // eslint-disable-next-line no-console
+        console.log(`FAQ interaction summary: ${JSON.stringify(summary, null, 2)}`);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log(`Error processing summary: ${String(err)}`);
+      }
     }
   }
 }

--- a/src/prefabs/InfoGathererAgent.ts
+++ b/src/prefabs/InfoGathererAgent.ts
@@ -176,22 +176,25 @@ export class InfoGathererAgent extends AgentBase {
   // ── Lifecycle: onSwmlRequest (dynamic mode hook) ──────────────────────
 
   /**
-   * Handle dynamic configuration using the registered callback. Injects the
-   * per-request questions into `global_data`. Mirrors Python's
-   * `on_swml_request` override.
+   * Handle dynamic configuration using the registered callback. Returns the
+   * per-request global_data payload which AgentBase merges into the SWML
+   * response. Mirrors Python's `on_swml_request` return-dict contract.
    */
-  override async onSwmlRequest(rawData: Record<string, unknown>): Promise<void> {
+  override async onSwmlRequest(
+    rawData: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | void> {
     // Static mode: nothing to do.
     if (this.staticQuestions !== null) return;
 
-    // Dynamic mode with no callback: inject fallback questions.
+    // Dynamic mode with no callback: return fallback questions as global_data.
     if (!this.questionCallback) {
-      this.setGlobalData({
-        questions: FALLBACK_QUESTIONS,
-        question_index: 0,
-        answers: [],
-      });
-      return;
+      return {
+        global_data: {
+          questions: FALLBACK_QUESTIONS,
+          question_index: 0,
+          answers: [],
+        },
+      };
     }
 
     // Build callback inputs from the incoming raw data.
@@ -202,18 +205,22 @@ export class InfoGathererAgent extends AgentBase {
     try {
       const questions = await this.questionCallback(queryParams, bodyParams, headers);
       InfoGathererAgent.validateQuestions(questions);
-      this.setGlobalData({
-        questions,
-        question_index: 0,
-        answers: [],
-      });
+      return {
+        global_data: {
+          questions,
+          question_index: 0,
+          answers: [],
+        },
+      };
     } catch (err) {
       this.log.error(`Error in question callback: ${String(err)}`);
-      this.setGlobalData({
-        questions: FALLBACK_QUESTIONS,
-        question_index: 0,
-        answers: [],
-      });
+      return {
+        global_data: {
+          questions: FALLBACK_QUESTIONS,
+          question_index: 0,
+          answers: [],
+        },
+      };
     }
   }
 
@@ -275,7 +282,6 @@ export class InfoGathererAgent extends AgentBase {
             description: "The user's answer to the current question",
           },
         },
-        required: ['answer'],
       },
       handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) => {
         const answer = (args['answer'] as string) ?? '';

--- a/src/prefabs/InfoGathererAgent.ts
+++ b/src/prefabs/InfoGathererAgent.ts
@@ -1,9 +1,10 @@
 /**
- * InfoGathererAgent - A prefab agent that sequentially collects information
- * from callers through conversational interaction.
+ * InfoGathererAgent - Prefab agent for collecting answers to a series of
+ * questions.
  *
- * Tracks fields per call, validates with optional regex patterns, and fires
- * an onComplete callback once all required fields are gathered.
+ * Ported from the Python SDK `signalwire.prefabs.info_gatherer.InfoGathererAgent`.
+ * Supports both static (questions provided at init) and dynamic (questions
+ * determined by a callback function per request) configuration modes.
  */
 
 import { AgentBase } from '../AgentBase.js';
@@ -12,251 +13,307 @@ import type { AgentOptions } from '../types.js';
 
 // ── Config types ────────────────────────────────────────────────────────────
 
-export interface InfoGathererField {
-  /** Unique field name (used as key in collected data). */
-  name: string;
-  /** Human-readable description shown to the AI agent. */
-  description: string;
-  /** Whether this field must be collected before completion. Default true. */
-  required?: boolean;
-  /** Optional validation pattern. String is compiled to RegExp. */
-  validation?: RegExp | string;
+/** A single question in the information-gathering flow. */
+export interface InfoGathererQuestion {
+  /** Identifier used as the key when storing the caller's answer. */
+  key_name: string;
+  /** The question text to ask the caller. */
+  question_text: string;
+  /** When true, the agent insists the caller confirms before submitting. */
+  confirm?: boolean;
 }
 
+/**
+ * Callback invoked on each incoming SWML request to produce the list of
+ * questions for that request. Mirrors Python's `set_question_callback`.
+ * @returns a list of questions (may be async).
+ */
+export type InfoGathererQuestionCallback = (
+  queryParams: Record<string, string>,
+  bodyParams: Record<string, unknown>,
+  headers: Record<string, string>,
+) => InfoGathererQuestion[] | Promise<InfoGathererQuestion[]>;
+
+/** Configuration for the InfoGathererAgent. */
 export interface InfoGathererConfig {
-  /** Agent display name. */
+  /**
+   * Optional list of questions to ask. When omitted, the agent runs in
+   * dynamic mode and resolves questions via the callback registered with
+   * `setQuestionCallback()` (or via `questionCallback` below).
+   */
+  questions?: InfoGathererQuestion[];
+  /**
+   * Convenience alternative to calling `setQuestionCallback()` after
+   * construction. Only consulted when `questions` is not provided.
+   */
+  questionCallback?: InfoGathererQuestionCallback;
+  /** Agent display name (defaults to `"info_gatherer"`). */
   name?: string;
-  /** Fields to collect from the caller. */
-  fields: InfoGathererField[];
-  /** Opening message the agent speaks when call starts. */
-  introMessage?: string;
-  /** Message spoken after all required fields are gathered. */
-  confirmationMessage?: string;
-  /** Callback fired when all required fields have been collected. */
-  onComplete?: (data: Record<string, string>) => void | Promise<void>;
+  /** HTTP route for this agent (defaults to `"/info_gatherer"`). */
+  route?: string;
   /** Additional AgentBase options forwarded to super(). */
   agentOptions?: Partial<AgentOptions>;
 }
 
-// ── Per-call session state ──────────────────────────────────────────────────
-
-interface GatherSession {
-  collected: Record<string, string>;
-  completeFired: boolean;
-}
-
 // ── Agent ───────────────────────────────────────────────────────────────────
 
-/** Prefab agent that sequentially collects named fields from a caller with optional validation and completion callback. */
+/** Fallback questions used in dynamic mode when no callback is registered or the callback throws. */
+const FALLBACK_QUESTIONS: InfoGathererQuestion[] = [
+  { key_name: 'name', question_text: 'What is your name?' },
+  { key_name: 'message', question_text: 'How can I help you today?' },
+];
+
+/** Prefab agent that gathers caller information one question at a time. */
 export class InfoGathererAgent extends AgentBase {
-  private fields: InfoGathererField[];
-  private introMessage: string;
-  private confirmationMessage: string;
-  private onCompleteCallback?: (data: Record<string, string>) => void | Promise<void>;
-  private sessions: Map<string, GatherSession> = new Map();
+  private staticQuestions: InfoGathererQuestion[] | null;
+  private questionCallback: InfoGathererQuestionCallback | null = null;
 
   /**
-   * Declarative prompt sections merged by AgentBase constructor.
-   * Additional dynamic sections are added in the constructor body below.
+   * Create an InfoGathererAgent.
+   * @param config - Either `questions` (static mode) or leave omitted and use
+   *                 `questionCallback` / `setQuestionCallback()` (dynamic mode).
    */
-  static override PROMPT_SECTIONS = [
-    {
-      title: 'Role',
-      body: 'You are an information-gathering assistant. Your job is to collect specific pieces of information from the caller in a friendly, conversational manner.',
-    },
-    {
-      title: 'Rules',
-      bullets: [
-        'Ask for one field at a time, in the order listed.',
-        'If the caller provides information for a later field, accept it and move on.',
-        'Always confirm each piece of information before saving it using the save_field tool.',
-        'If validation fails, politely ask the caller to try again.',
-        'Use the get_status tool when you need to check progress.',
-        'Once all required fields are collected, summarize the information and confirm with the caller.',
-      ],
-    },
-  ];
-
-  /**
-   * Create an InfoGathererAgent with the specified fields and callbacks.
-   * @param config - Configuration including fields to collect, messages, and completion callback.
-   */
-  constructor(config: InfoGathererConfig) {
-    const agentName = config.name ?? 'InfoGatherer';
+  constructor(config: InfoGathererConfig = {}) {
+    const agentName = config.name ?? 'info_gatherer';
     super({
       name: agentName,
+      route: config.route ?? '/info_gatherer',
+      usePom: true,
       ...config.agentOptions,
     });
 
-    this.fields = config.fields;
-    this.introMessage = config.introMessage ?? 'Hello! I need to collect some information from you. Let me walk you through it.';
-    this.confirmationMessage = config.confirmationMessage ?? 'Thank you! I have collected all the required information.';
-    this.onCompleteCallback = config.onComplete;
-
-    // Build the dynamic fields section
-    const fieldBullets = this.fields.map((f) => {
-      const reqLabel = f.required === false ? '(optional)' : '(required)';
-      const valLabel = f.validation ? ` [validation: ${f.validation instanceof RegExp ? f.validation.source : f.validation}]` : '';
-      return `${f.name}: ${f.description} ${reqLabel}${valLabel}`;
-    });
-    this.promptAddSection('Fields to Collect', { bullets: fieldBullets, numbered: true });
-
-    if (this.introMessage) {
-      this.promptAddSection('Introduction', {
-        body: `Begin the conversation with: "${this.introMessage}"`,
+    if (config.questions !== undefined) {
+      InfoGathererAgent.validateQuestions(config.questions);
+      this.staticQuestions = config.questions;
+      this.setGlobalData({
+        questions: config.questions,
+        question_index: 0,
+        answers: [],
       });
+      this.buildPrompt('static');
+    } else {
+      this.staticQuestions = null;
+      this.buildPrompt('dynamic');
     }
 
-    // Hints for speech recognition
-    this.addHints(this.fields.map((f) => f.name));
+    if (config.questionCallback) {
+      this.questionCallback = config.questionCallback;
+    }
+
+    // AI behavior parameters (mirrors Python _configure_agent_settings)
+    this.setParams({
+      end_of_speech_timeout: 800,
+      speech_event_timeout: 1000,
+    });
 
     // Register tools after all fields are initialized
     this.defineTools();
   }
 
-  // ── Session helpers ───────────────────────────────────────────────────
+  /**
+   * Register a callback for dynamic question configuration. The callback is
+   * invoked on each incoming SWML request with the query params, body, and
+   * headers, and must return the list of questions to ask on that call.
+   * Mirrors Python `set_question_callback`.
+   */
+  setQuestionCallback(callback: InfoGathererQuestionCallback): this {
+    this.questionCallback = callback;
+    return this;
+  }
 
-  private getSession(rawData: Record<string, unknown>): GatherSession {
-    const callId = (rawData['call_id'] as string) ?? 'default';
-    let session = this.sessions.get(callId);
-    if (!session) {
-      session = { collected: {}, completeFired: false };
-      this.sessions.set(callId, session);
+  private static validateQuestions(questions: unknown): asserts questions is InfoGathererQuestion[] {
+    if (!Array.isArray(questions) || questions.length === 0) {
+      throw new Error('At least one question is required');
     }
-    return session;
+    for (let i = 0; i < questions.length; i++) {
+      const q = questions[i] as Record<string, unknown>;
+      if (!q || typeof q !== 'object') {
+        throw new Error(`Question ${i + 1} must be an object`);
+      }
+      if (typeof q['key_name'] !== 'string' || !q['key_name']) {
+        throw new Error(`Question ${i + 1} is missing 'key_name' field`);
+      }
+      if (typeof q['question_text'] !== 'string' || !q['question_text']) {
+        throw new Error(`Question ${i + 1} is missing 'question_text' field`);
+      }
+    }
   }
 
-  private getFieldByName(name: string): InfoGathererField | undefined {
-    return this.fields.find((f) => f.name.toLowerCase() === name.toLowerCase());
+  private buildPrompt(mode: 'static' | 'dynamic'): void {
+    const body =
+      mode === 'dynamic'
+        ? 'Your role is to gather information by asking questions. Begin by asking the user if they are ready to answer some questions. If they confirm they are ready, call the start_questions function to begin the process.'
+        : 'Your role is to get answers to a series of questions. Begin by asking the user if they are ready to answer some questions. If they confirm they are ready, call the start_questions function to begin the process.';
+    this.promptAddSection('Objective', { body });
   }
 
-  private validateValue(field: InfoGathererField, value: string): boolean {
-    if (!field.validation) return true;
-    const pattern = field.validation instanceof RegExp
-      ? field.validation
-      : new RegExp(field.validation);
-    return pattern.test(value);
+  /**
+   * Generate the instruction text for asking a question. Mirrors Python's
+   * `_generate_question_instruction`.
+   */
+  private generateQuestionInstruction(
+    questionText: string,
+    needsConfirmation: boolean,
+    isFirstQuestion = false,
+  ): string {
+    let instruction = isFirstQuestion
+      ? `Ask the user to answer the following question: ${questionText}\n\n`
+      : `Previous Answer recorded. Now ask the user to answer the following question: ${questionText}\n\n`;
+
+    instruction +=
+      'Make sure the answer fits the scope and context of the question before submitting it. ';
+
+    if (needsConfirmation) {
+      instruction +=
+        'Insist that the user confirms the answer as many times as needed until they say it is correct.';
+    } else {
+      instruction += "You don't need the user to confirm the answer to this question.";
+    }
+
+    return instruction;
   }
 
-  private getRequiredFields(): InfoGathererField[] {
-    return this.fields.filter((f) => f.required !== false);
+  // ── Lifecycle: onSwmlRequest (dynamic mode hook) ──────────────────────
+
+  /**
+   * Handle dynamic configuration using the registered callback. Injects the
+   * per-request questions into `global_data`. Mirrors Python's
+   * `on_swml_request` override.
+   */
+  override async onSwmlRequest(rawData: Record<string, unknown>): Promise<void> {
+    // Static mode: nothing to do.
+    if (this.staticQuestions !== null) return;
+
+    // Dynamic mode with no callback: inject fallback questions.
+    if (!this.questionCallback) {
+      this.setGlobalData({
+        questions: FALLBACK_QUESTIONS,
+        question_index: 0,
+        answers: [],
+      });
+      return;
+    }
+
+    // Build callback inputs from the incoming raw data.
+    const queryParams = this.extractRecord(rawData['query_params']);
+    const headers = this.extractRecord(rawData['headers']);
+    const bodyParams = rawData;
+
+    try {
+      const questions = await this.questionCallback(queryParams, bodyParams, headers);
+      InfoGathererAgent.validateQuestions(questions);
+      this.setGlobalData({
+        questions,
+        question_index: 0,
+        answers: [],
+      });
+    } catch (err) {
+      this.log.error(`Error in question callback: ${String(err)}`);
+      this.setGlobalData({
+        questions: FALLBACK_QUESTIONS,
+        question_index: 0,
+        answers: [],
+      });
+    }
   }
 
-  private allRequiredCollected(session: GatherSession): boolean {
-    return this.getRequiredFields().every((f) => f.name in session.collected);
+  private extractRecord(value: unknown): Record<string, string> {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const result: Record<string, string> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        if (typeof v === 'string') result[k] = v;
+        else if (v !== null && v !== undefined) result[k] = String(v);
+      }
+      return result;
+    }
+    return {};
   }
 
   // ── Tool registration ─────────────────────────────────────────────────
 
-  /** Register the save_field and get_status SWAIG tools. */
+  /** Register the `start_questions` and `submit_answer` SWAIG tools. */
   protected override defineTools(): void {
-    // Tool: save_field
+    // Tool: start_questions
     this.defineTool({
-      name: 'save_field',
-      description: 'Save a collected field value from the caller. Validates the value if a validation pattern is configured for the field.',
-      parameters: {
-        type: 'object',
-        properties: {
-          field_name: {
-            type: 'string',
-            description: 'The name of the field to save.',
-          },
-          value: {
-            type: 'string',
-            description: 'The value provided by the caller.',
-          },
-        },
-        required: ['field_name', 'value'],
-      },
-      handler: async (args: Record<string, unknown>, rawData: Record<string, unknown>) => {
-        const fieldName = args['field_name'] as string;
-        const value = args['value'] as string;
-
-        if (!fieldName || !value) {
-          return new FunctionResult('Both field_name and value are required.');
-        }
-
-        const field = this.getFieldByName(fieldName);
-        if (!field) {
-          const available = this.fields.map((f) => f.name).join(', ');
-          return new FunctionResult(
-            `Unknown field "${fieldName}". Available fields: ${available}`,
-          );
-        }
-
-        if (!this.validateValue(field, value)) {
-          return new FunctionResult(
-            `The value "${value}" is not valid for field "${field.name}". Please ask the caller to provide a valid value. Expected format: ${field.validation instanceof RegExp ? field.validation.source : field.validation}`,
-          );
-        }
-
-        const session = this.getSession(rawData);
-        session.collected[field.name] = value;
-
-        // Check if all required fields are now collected
-        if (this.allRequiredCollected(session) && !session.completeFired) {
-          session.completeFired = true;
-          if (this.onCompleteCallback) {
-            try {
-              await this.onCompleteCallback({ ...session.collected });
-            } catch (err) {
-              this.log.error(`onComplete callback error: ${err}`);
-            }
-          }
-          const collectedSummary = Object.entries(session.collected)
-            .map(([k, v]) => `${k}: ${v}`)
-            .join(', ');
-          return new FunctionResult(
-            `Field "${field.name}" saved successfully. All required fields are now collected! Summary: ${collectedSummary}. ${this.confirmationMessage}`,
-          );
-        }
-
-        // Determine remaining fields
-        const remaining = this.fields
-          .filter((f) => f.required !== false && !(f.name in session.collected))
-          .map((f) => f.name);
-
-        return new FunctionResult(
-          `Field "${field.name}" saved as "${value}". Remaining required fields: ${remaining.length > 0 ? remaining.join(', ') : 'none'}.`,
-        );
-      },
-    });
-
-    // Tool: get_status
-    this.defineTool({
-      name: 'get_status',
-      description: 'Get the current status of information gathering, showing which fields have been collected and which remain.',
+      name: 'start_questions',
+      description: 'Start the question sequence with the first question',
       parameters: {
         type: 'object',
         properties: {},
       },
+      handler: (_args: Record<string, unknown>, rawData: Record<string, unknown>) => {
+        const globalData = (rawData['global_data'] as Record<string, unknown>) ?? {};
+        const questions = (globalData['questions'] as InfoGathererQuestion[]) ?? [];
+        const questionIndex = (globalData['question_index'] as number) ?? 0;
+
+        if (!questions || questionIndex >= questions.length) {
+          return new FunctionResult("I don't have any questions to ask.");
+        }
+
+        const current = questions[questionIndex];
+        const instruction = this.generateQuestionInstruction(
+          current.question_text ?? '',
+          current.confirm === true,
+          true,
+        );
+
+        const result = new FunctionResult(instruction);
+        result.replaceInHistory('Welcome! Let me ask you a few questions.');
+        return result;
+      },
+    });
+
+    // Tool: submit_answer
+    this.defineTool({
+      name: 'submit_answer',
+      description: 'Submit an answer to the current question and move to the next one',
+      parameters: {
+        type: 'object',
+        properties: {
+          answer: {
+            type: 'string',
+            description: "The user's answer to the current question",
+          },
+        },
+        required: ['answer'],
+      },
       handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) => {
-        const session = this.getSession(rawData);
+        const answer = (args['answer'] as string) ?? '';
 
-        const collectedEntries = Object.entries(session.collected);
-        const collectedStr = collectedEntries.length > 0
-          ? collectedEntries.map(([k, v]) => `${k}: ${v}`).join(', ')
-          : 'none';
+        const globalData = (rawData['global_data'] as Record<string, unknown>) ?? {};
+        const questions = (globalData['questions'] as InfoGathererQuestion[]) ?? [];
+        const questionIndex = (globalData['question_index'] as number) ?? 0;
+        const priorAnswers =
+          (globalData['answers'] as Array<{ key_name: string; answer: string }>) ?? [];
 
-        const remainingRequired = this.getRequiredFields()
-          .filter((f) => !(f.name in session.collected))
-          .map((f) => f.name);
-
-        const remainingOptional = this.fields
-          .filter((f) => f.required === false && !(f.name in session.collected))
-          .map((f) => f.name);
-
-        let status = `Collected: ${collectedStr}.`;
-        if (remainingRequired.length > 0) {
-          status += ` Remaining required: ${remainingRequired.join(', ')}.`;
-        } else {
-          status += ' All required fields have been collected!';
-        }
-        if (remainingOptional.length > 0) {
-          status += ` Optional fields not yet collected: ${remainingOptional.join(', ')}.`;
+        if (questionIndex >= questions.length) {
+          return new FunctionResult('All questions have already been answered.');
         }
 
-        return new FunctionResult(status);
+        const current = questions[questionIndex];
+        const keyName = current.key_name ?? '';
+        const newAnswers = [...priorAnswers, { key_name: keyName, answer }];
+        const newIndex = questionIndex + 1;
+
+        if (newIndex < questions.length) {
+          const next = questions[newIndex];
+          const instruction = this.generateQuestionInstruction(
+            next.question_text ?? '',
+            next.confirm === true,
+            false,
+          );
+          const result = new FunctionResult(instruction);
+          result.replaceInHistory();
+          result.updateGlobalData({ answers: newAnswers, question_index: newIndex });
+          return result;
+        }
+
+        const result = new FunctionResult(
+          "Thank you! All questions have been answered. You can now summarize the information collected or ask if there's anything else the user would like to discuss.",
+        );
+        result.replaceInHistory();
+        result.updateGlobalData({ answers: newAnswers, question_index: newIndex });
+        return result;
       },
     });
   }
@@ -269,7 +326,7 @@ export class InfoGathererAgent extends AgentBase {
  * @param config - Configuration for the info gatherer agent.
  * @returns A configured InfoGathererAgent instance.
  */
-export function createInfoGathererAgent(config: InfoGathererConfig): InfoGathererAgent {
+export function createInfoGathererAgent(config: InfoGathererConfig = {}): InfoGathererAgent {
   return new InfoGathererAgent(config);
 }
 

--- a/src/prefabs/ReceptionistAgent.ts
+++ b/src/prefabs/ReceptionistAgent.ts
@@ -139,7 +139,7 @@ export class ReceptionistAgent extends AgentBase {
       'Based on their needs, determine which department would be most appropriate.',
       'Use the collect_caller_info function when you have their name and reason for calling.',
       'Use the transfer_call function to transfer them to the appropriate department.',
-      'Before transferring, always confirm with the caller that they are being transferred to the right department.',
+      "Before transferring, always confirm with the caller that they're being transferred to the right department.",
       'If a caller\'s request does not clearly match a department, ask follow-up questions to clarify.',
     ];
     if (this.checkInEnabled) {
@@ -219,7 +219,6 @@ export class ReceptionistAgent extends AgentBase {
             description: 'The reason for the call',
           },
         },
-        required: ['name', 'reason'],
       },
       handler: (args: Record<string, unknown>) => {
         const name = (args['name'] as string) ?? '';
@@ -252,7 +251,6 @@ export class ReceptionistAgent extends AgentBase {
             enum: departmentNames,
           },
         },
-        required: ['department'],
       },
       handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) => {
         const departmentName = ((args['department'] as string) ?? '').trim();

--- a/src/prefabs/ReceptionistAgent.ts
+++ b/src/prefabs/ReceptionistAgent.ts
@@ -1,6 +1,10 @@
 /**
- * ReceptionistAgent - A prefab front-desk agent that handles visitor
- * check-in, department directory lookup, and call transfers by extension.
+ * ReceptionistAgent - Prefab agent that greets callers, collects basic info,
+ * and transfers them to the appropriate department.
+ *
+ * Ported from the Python SDK `signalwire.prefabs.receptionist.ReceptionistAgent`.
+ * Preserves TS-specific enhancements (`companyName`, visitor check-in) as
+ * additive features.
  */
 
 import { AgentBase } from '../AgentBase.js';
@@ -10,24 +14,28 @@ import type { AgentOptions } from '../types.js';
 // ── Config types ────────────────────────────────────────────────────────────
 
 export interface ReceptionistDepartment {
-  /** Department name (e.g. "Engineering", "HR"). */
+  /** Department identifier (e.g. `"sales"`, `"support"`). */
   name: string;
-  /** Internal extension number or SIP address. */
-  extension: string;
-  /** Optional description of the department. */
-  description?: string;
+  /** Description of the department's purpose (shown to the AI). */
+  description: string;
+  /** Phone number (or SIP address) used by `transfer_call`. */
+  number: string;
 }
 
 export interface ReceptionistConfig {
-  /** Agent display name. */
-  name?: string;
-  /** Company name displayed in greetings and prompts. */
-  companyName: string;
-  /** Departments with extensions for the directory. */
+  /** Departments the agent can transfer callers to. */
   departments: ReceptionistDepartment[];
-  /** Custom welcome message. */
-  welcomeMessage?: string;
-  /** Whether visitor check-in functionality is enabled. Default true. */
+  /** Agent display name (defaults to `"receptionist"`). */
+  name?: string;
+  /** HTTP route for this agent (defaults to `"/receptionist"`). */
+  route?: string;
+  /** Initial greeting message. Defaults to the Python receptionist greeting. */
+  greeting?: string;
+  /** Voice identifier passed to `addLanguage`. Defaults to `"rime.spore"`. */
+  voice?: string;
+  /** Optional company name. Appended to the greeting when provided. */
+  companyName?: string;
+  /** Whether visitor check-in functionality is enabled. Default `false`. */
   checkInEnabled?: boolean;
   /** Callback fired when a visitor checks in. */
   onVisitorCheckIn?: (visitor: Record<string, string>) => void | Promise<void>;
@@ -43,77 +51,136 @@ interface CheckInSession {
 
 // ── Agent ───────────────────────────────────────────────────────────────────
 
-/** Prefab front-desk agent that handles visitor check-in, department directory lookup, and call transfers by extension. */
+/** Prefab agent that greets callers, collects basic information, and transfers them to the correct department. */
 export class ReceptionistAgent extends AgentBase {
-  private companyName: string;
-  private departments: ReceptionistDepartment[];
-  private welcomeMessage: string;
-  private checkInEnabled: boolean;
-  private onVisitorCheckInCallback?: (visitor: Record<string, string>) => void | Promise<void>;
-  private sessions: Map<string, CheckInSession> = new Map();
-
-  /** Declarative prompt sections merged by AgentBase constructor. */
-  static override PROMPT_SECTIONS = [
-    {
-      title: 'Role',
-      body: 'You are a friendly and professional receptionist. Greet visitors warmly, help them check in, look up department information, and transfer calls to the appropriate extension.',
-    },
-    {
-      title: 'Rules',
-      bullets: [
-        'Always greet the caller with the company welcome message.',
-        'If a caller wants to reach a department, use get_department_list to find the right one, then transfer_to_department.',
-        'If a caller wants to check in as a visitor, collect their name, purpose of visit, and who they are visiting, then use check_in_visitor.',
-        'Be warm, helpful, and professional at all times.',
-        'If you are unsure which department the caller needs, offer to list all departments.',
-        'Confirm the department name before transferring.',
-      ],
-    },
-  ];
+  private readonly greeting: string;
+  private readonly departments: ReceptionistDepartment[];
+  private readonly companyName: string | undefined;
+  private readonly checkInEnabled: boolean;
+  private readonly onVisitorCheckInCallback?: (visitor: Record<string, string>) => void | Promise<void>;
+  private readonly sessions: Map<string, CheckInSession> = new Map();
 
   /**
-   * Create a ReceptionistAgent with the specified company, departments, and check-in settings.
-   * @param config - Configuration including company name, departments, and visitor check-in callback.
+   * Create a ReceptionistAgent with the specified departments.
+   * @param config - Configuration including departments (name/description/number), greeting, and voice.
    */
   constructor(config: ReceptionistConfig) {
-    const agentName = config.name ?? 'Receptionist';
+    const agentName = config.name ?? 'receptionist';
     super({
       name: agentName,
+      route: config.route ?? '/receptionist',
+      usePom: true,
       ...config.agentOptions,
     });
 
-    this.companyName = config.companyName;
+    // Validate departments (Python _validate_departments parity)
+    ReceptionistAgent.validateDepartments(config.departments);
+
+    this.greeting = config.greeting ?? 'Thank you for calling. How can I help you today?';
     this.departments = config.departments;
-    this.welcomeMessage = config.welcomeMessage ?? `Welcome to ${this.companyName}! How may I help you today?`;
-    this.checkInEnabled = config.checkInEnabled ?? true;
+    this.companyName = config.companyName;
+    this.checkInEnabled = config.checkInEnabled ?? false;
     this.onVisitorCheckInCallback = config.onVisitorCheckIn;
 
-    // Welcome section
-    this.promptAddSection('Welcome', {
-      body: `You are the receptionist for ${this.companyName}. Greet callers with: "${this.welcomeMessage}"`,
+    // Initial global data: departments + empty caller_info bucket
+    this.setGlobalData({
+      departments: this.departments,
+      caller_info: {},
     });
 
-    // Department directory section
-    const deptBullets = this.departments.map((dept) => {
-      let line = `${dept.name} (ext: ${dept.extension})`;
-      if (dept.description) line += ` - ${dept.description}`;
-      return line;
-    });
-    this.promptAddSection('Department Directory', { bullets: deptBullets });
-
-    if (this.checkInEnabled) {
-      this.promptAddSection('Visitor Check-In', {
-        body: 'If a caller wants to check in as a visitor, collect their full name, the purpose of their visit, and the name of the person they are visiting. Then use the check_in_visitor tool.',
-      });
-    }
-
-    // Speech recognition hints
-    const hints: string[] = [this.companyName];
-    hints.push(...this.departments.map((d) => d.name));
-    this.addHints(hints);
+    this.buildPrompt();
+    this.configureAgentSettings(config.voice ?? 'rime.spore');
 
     // Register tools after all fields are initialized
     this.defineTools();
+  }
+
+  private static validateDepartments(departments: unknown): asserts departments is ReceptionistDepartment[] {
+    if (!Array.isArray(departments) || departments.length === 0) {
+      throw new Error('At least one department is required');
+    }
+    for (let i = 0; i < departments.length; i++) {
+      const d = departments[i] as Record<string, unknown>;
+      if (!d || typeof d !== 'object') {
+        throw new Error(`Department ${i + 1} must be an object`);
+      }
+      if (typeof d['name'] !== 'string' || !d['name']) {
+        throw new Error(`Department ${i + 1} is missing 'name' field`);
+      }
+      if (typeof d['description'] !== 'string' || !d['description']) {
+        throw new Error(`Department ${i + 1} is missing 'description' field`);
+      }
+      if (typeof d['number'] !== 'string' || !d['number']) {
+        throw new Error(`Department ${i + 1} is missing 'number' field`);
+      }
+    }
+  }
+
+  private buildPrompt(): void {
+    // Personality
+    this.promptAddSection('Personality', {
+      body: 'You are a friendly and professional receptionist. You speak clearly and efficiently while maintaining a warm, helpful tone.',
+    });
+
+    // Goal
+    this.promptAddSection('Goal', {
+      body: 'Your goal is to greet callers, collect their basic information, and transfer them to the appropriate department.',
+    });
+
+    // Greeting instruction honors optional companyName branding
+    const branded = this.companyName
+      ? `${this.greeting.trimEnd()} Welcome to ${this.companyName}.`
+      : this.greeting;
+
+    // Instructions
+    const instructions = [
+      `Begin by greeting the caller with: '${branded}'`,
+      'Collect their name and a brief description of their needs.',
+      'Based on their needs, determine which department would be most appropriate.',
+      'Use the collect_caller_info function when you have their name and reason for calling.',
+      'Use the transfer_call function to transfer them to the appropriate department.',
+      'Before transferring, always confirm with the caller that they are being transferred to the right department.',
+      'If a caller\'s request does not clearly match a department, ask follow-up questions to clarify.',
+    ];
+    if (this.checkInEnabled) {
+      instructions.push(
+        'If a caller wants to check in as a visitor, collect their full name, purpose of visit, and who they are visiting, then use the check_in_visitor tool.',
+      );
+    }
+    this.promptAddSection('Instructions', { bullets: instructions });
+
+    // Departments list as a bulleted section
+    const deptBullets = this.departments.map(
+      (dept) => `${dept.name}: ${dept.description}`,
+    );
+    this.promptAddSection('Available Departments', { bullets: deptBullets });
+
+    // Post-prompt JSON summary template (Python parity)
+    this.setPostPrompt(`
+        Return a JSON summary of the conversation:
+        {
+            "caller_name": "CALLER'S NAME",
+            "reason": "REASON FOR CALLING",
+            "department": "DEPARTMENT TRANSFERRED TO",
+            "satisfaction": "high/medium/low (estimated caller satisfaction)"
+        }
+        `);
+  }
+
+  private configureAgentSettings(voice: string): void {
+    this.setParams({
+      end_of_speech_timeout: 700,
+      speech_event_timeout: 1000,
+      transfer_summary: true,
+    });
+
+    this.addLanguage({ name: 'English', code: 'en-US', voice });
+
+    // Speech recognition hints derived from company + department names
+    const hints: string[] = [];
+    if (this.companyName) hints.push(this.companyName);
+    hints.push(...this.departments.map((d) => d.name));
+    if (hints.length) this.addHints(hints);
   }
 
   // ── Session helpers ───────────────────────────────────────────────────
@@ -128,79 +195,90 @@ export class ReceptionistAgent extends AgentBase {
     return session;
   }
 
-  // ── Department helpers ────────────────────────────────────────────────
-
-  private findDepartment(name: string): ReceptionistDepartment | undefined {
-    const normalized = name.toLowerCase().trim();
-    return this.departments.find((d) => d.name.toLowerCase() === normalized);
-  }
-
   // ── Tool registration ─────────────────────────────────────────────────
 
-  /** Register the get_department_list, transfer_to_department, and optional check_in_visitor SWAIG tools. */
+  /**
+   * Register the `collect_caller_info` and `transfer_call` SWAIG tools
+   * (Python parity). When `checkInEnabled` is `true`, also registers the
+   * TS-specific `check_in_visitor` tool.
+   */
   protected override defineTools(): void {
-    // Tool: get_department_list
+    // Tool: collect_caller_info (Python parity)
     this.defineTool({
-      name: 'get_department_list',
-      description: `List all departments at ${this.companyName} with their extensions and descriptions.`,
-      parameters: {
-        type: 'object',
-        properties: {},
-      },
-      handler: () => {
-        if (this.departments.length === 0) {
-          return new FunctionResult('No departments are currently listed in the directory.');
-        }
-
-        const lines = this.departments.map((dept) => {
-          let line = `${dept.name} - Extension: ${dept.extension}`;
-          if (dept.description) line += ` (${dept.description})`;
-          return line;
-        });
-
-        return new FunctionResult(
-          `Department directory for ${this.companyName}:\n${lines.join('\n')}`,
-        );
-      },
-    });
-
-    // Tool: transfer_to_department
-    this.defineTool({
-      name: 'transfer_to_department',
-      description: 'Transfer the caller to a department by dialing its extension.',
+      name: 'collect_caller_info',
+      description: "Collect the caller's information for routing",
       parameters: {
         type: 'object',
         properties: {
-          department_name: {
+          name: {
             type: 'string',
-            description: 'The name of the department to transfer to.',
+            description: "The caller's name",
+          },
+          reason: {
+            type: 'string',
+            description: 'The reason for the call',
           },
         },
-        required: ['department_name'],
+        required: ['name', 'reason'],
       },
-      handler: (_args: Record<string, unknown>) => {
-        const deptName = _args['department_name'] as string;
-        if (!deptName) {
-          return new FunctionResult('Please provide a department name to transfer to.');
-        }
-
-        const dept = this.findDepartment(deptName);
-        if (!dept) {
-          const available = this.departments.map((d) => d.name).join(', ');
-          return new FunctionResult(
-            `Department "${deptName}" not found in the directory. Available departments: ${available}`,
-          );
-        }
-
+      handler: (args: Record<string, unknown>) => {
+        const name = (args['name'] as string) ?? '';
+        const reason = (args['reason'] as string) ?? '';
         const result = new FunctionResult(
-          `Transferring you to ${dept.name} at extension ${dept.extension}. One moment please.`,
+          `Thank you, ${name}. I've noted that you're calling about ${reason}.`,
         );
-        result.connect(dept.extension);
+        result.addActions([
+          {
+            set_global_data: {
+              caller_info: { name, reason },
+            },
+          },
+        ]);
         return result;
       },
     });
 
-    // Tool: check_in_visitor (only if enabled)
+    // Tool: transfer_call (Python parity with enum on department)
+    const departmentNames = this.departments.map((d) => d.name);
+    this.defineTool({
+      name: 'transfer_call',
+      description: 'Transfer the caller to the appropriate department',
+      parameters: {
+        type: 'object',
+        properties: {
+          department: {
+            type: 'string',
+            description: 'The department to transfer to',
+            enum: departmentNames,
+          },
+        },
+        required: ['department'],
+      },
+      handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) => {
+        const departmentName = ((args['department'] as string) ?? '').trim();
+        const globalData = (rawData['global_data'] as Record<string, unknown>) ?? {};
+        const callerInfo = (globalData['caller_info'] as Record<string, unknown>) ?? {};
+        const name = (callerInfo['name'] as string) ?? 'the caller';
+
+        const dept = this.departments.find((d) => d.name === departmentName);
+        if (!dept) {
+          return new FunctionResult(
+            `Sorry, I couldn't find the ${departmentName} department.`,
+          );
+        }
+
+        // Python uses post_process=True and final=True so the AI speaks
+        // before executing the transfer.
+        const result = new FunctionResult(
+          `I'll transfer you to our ${departmentName} department now. Thank you for calling, ${name}!`,
+          true,
+        );
+        result.connect(dept.number, true);
+        return result;
+      },
+    });
+
+    // Tool: check_in_visitor (TS-specific; only if checkInEnabled)
     if (this.checkInEnabled) {
       this.defineTool({
         name: 'check_in_visitor',
@@ -223,14 +301,14 @@ export class ReceptionistAgent extends AgentBase {
           },
           required: ['visitor_name', 'purpose', 'visiting'],
         },
-        handler: async (_args: Record<string, unknown>, rawData: Record<string, unknown>) => {
-          const visitorName = _args['visitor_name'] as string;
-          const purpose = _args['purpose'] as string;
-          const visiting = _args['visiting'] as string;
+        handler: async (args: Record<string, unknown>, rawData: Record<string, unknown>) => {
+          const visitorName = args['visitor_name'] as string;
+          const purpose = args['purpose'] as string;
+          const visiting = args['visiting'] as string;
 
           if (!visitorName || !purpose || !visiting) {
             return new FunctionResult(
-              'Please provide the visitor\'s name, purpose of visit, and who they are visiting.',
+              "Please provide the visitor's name, purpose of visit, and who they are visiting.",
             );
           }
 
@@ -241,11 +319,9 @@ export class ReceptionistAgent extends AgentBase {
             checked_in_at: new Date().toISOString(),
           };
 
-          // Store in session
           const session = this.getSession(rawData);
           session.visitors.push(visitorRecord);
 
-          // Fire callback
           if (this.onVisitorCheckInCallback) {
             try {
               await this.onVisitorCheckInCallback(visitorRecord);
@@ -254,12 +330,27 @@ export class ReceptionistAgent extends AgentBase {
             }
           }
 
+          const companyPart = this.companyName ? ` Welcome to ${this.companyName}!` : '';
           return new FunctionResult(
-            `Visitor checked in successfully! Name: ${visitorName}, Purpose: ${purpose}, Visiting: ${visiting}. Welcome to ${this.companyName}!`,
+            `Visitor checked in successfully! Name: ${visitorName}, Purpose: ${purpose}, Visiting: ${visiting}.${companyPart}`,
           );
         },
       });
     }
+  }
+
+  // ── Lifecycle hooks ───────────────────────────────────────────────────
+
+  /**
+   * Python-style receptionist summary hook. Default is a no-op; subclasses
+   * may override to persist the summary. Mirrors Python `on_summary`
+   * (receptionist.py lines 278–287).
+   */
+  override onSummary(
+    _summary: Record<string, unknown> | null,
+    _rawData: Record<string, unknown>,
+  ): void | Promise<void> {
+    // Intentional no-op pass-through; subclasses override to handle the summary.
   }
 }
 

--- a/src/prefabs/SurveyAgent.ts
+++ b/src/prefabs/SurveyAgent.ts
@@ -2,8 +2,9 @@
  * SurveyAgent - A prefab agent that conducts surveys with branching logic,
  * scoring, and conditional question flow.
  *
- * Supports multiple question types (multiple choice, open ended, rating,
- * yes/no), conditional branching based on answers, and per-answer scoring.
+ * Ported from the Python SDK `signalwire.prefabs.survey.SurveyAgent`. Keeps
+ * TS-specific enhancements (per-call session state, branching via
+ * `nextQuestion`, answer scoring via `points`) alongside the Python surface.
  */
 
 import { AgentBase } from '../AgentBase.js';
@@ -22,6 +23,16 @@ export interface SurveyQuestion {
   /** Options for multiple_choice questions. */
   options?: string[];
   /**
+   * For `rating` questions, the upper bound of the scale (1..scale).
+   * Defaults to 5 (matching the Python prefab) when unspecified.
+   */
+  scale?: number;
+  /**
+   * Whether the question requires an answer. Defaults to `true`.
+   * Mirrors the Python `required` flag on each question dict.
+   */
+  required?: boolean;
+  /**
    * Next question ID after this one.
    * - string: always go to that question
    * - Record<string, string>: map from answer value to next question ID
@@ -37,14 +48,22 @@ export interface SurveyQuestion {
 }
 
 export interface SurveyConfig {
-  /** Agent display name. */
-  name?: string;
+  /** Human-readable survey name, used in prompts and global data. */
+  surveyName: string;
   /** Ordered list of survey questions. */
   questions: SurveyQuestion[];
-  /** Opening message before the first question. */
-  introMessage?: string;
-  /** Message after the survey is complete. */
-  completionMessage?: string;
+  /** Opening message before the first question (matches Python `introduction`). */
+  introduction?: string;
+  /** Message after the survey is complete (matches Python `conclusion`). */
+  conclusion?: string;
+  /** Brand or company name the agent represents (matches Python `brand_name`). */
+  brandName?: string;
+  /** Maximum number of times to retry invalid answers. Defaults to 2. */
+  maxRetries?: number;
+  /** Agent display name (defaults to `"survey"`). */
+  name?: string;
+  /** HTTP route for this agent (defaults to `"/survey"`). */
+  route?: string;
   /** Callback fired when the survey is finished. */
   onComplete?: (responses: Record<string, unknown>, score: number) => void | Promise<void>;
   /** Additional AgentBase options forwarded to super(). */
@@ -65,66 +84,177 @@ interface SurveySession {
 
 /** Prefab agent that conducts surveys with branching logic, answer scoring, and conditional question flow. */
 export class SurveyAgent extends AgentBase {
-  private questions: SurveyQuestion[];
+  /** Human-readable survey name. */
+  public surveyName: string;
+  /** The configured survey questions (public, matching Python). */
+  public questions: SurveyQuestion[];
+  /** Brand/company name used in prompts. */
+  public brandName: string;
+  /** Maximum number of times to retry invalid answers. */
+  public maxRetries: number;
+  /** Opening message before the first question. */
+  public introduction: string;
+  /** Closing message shown when the survey completes. */
+  public conclusion: string;
+
   private questionMap: Map<string, SurveyQuestion>;
-  private introMessage: string;
-  private completionMessage: string;
   private onCompleteCallback?: (responses: Record<string, unknown>, score: number) => void | Promise<void>;
   private sessions: Map<string, SurveySession> = new Map();
-
-  /** Declarative prompt sections merged by AgentBase constructor. */
-  static override PROMPT_SECTIONS = [
-    {
-      title: 'Role',
-      body: 'You are a friendly survey agent. Your job is to ask the caller a series of questions and record their answers accurately.',
-    },
-    {
-      title: 'Rules',
-      bullets: [
-        'Always start by calling get_current_question to know which question to ask.',
-        'Ask one question at a time.',
-        'For multiple choice questions, read all available options to the caller.',
-        'For rating questions, specify the scale (1-5 or 1-10 as appropriate).',
-        'For yes/no questions, accept variations like "yeah", "nope", "sure", etc.',
-        'After each answer, use answer_question to record the response.',
-        'Use get_survey_progress to check how far along the survey is.',
-        'Do not skip questions unless the branching logic directs you to.',
-        'When the survey is complete, thank the caller for their time.',
-      ],
-    },
-  ];
 
   /**
    * Create a SurveyAgent with the specified questions and callbacks.
    * @param config - Configuration including questions, messages, and completion callback.
    */
   constructor(config: SurveyConfig) {
-    const agentName = config.name ?? 'SurveyAgent';
+    const agentName = config.name ?? 'survey';
     super({
       name: agentName,
+      route: config.route ?? '/survey',
+      usePom: true,
       ...config.agentOptions,
     });
 
+    // Store configuration (matches Python __init__)
+    this.surveyName = config.surveyName;
     this.questions = config.questions;
-    this.questionMap = new Map(config.questions.map((q) => [q.id, q]));
-    this.introMessage = config.introMessage ?? 'Thank you for taking our survey. I have a few questions for you.';
-    this.completionMessage = config.completionMessage ?? 'Thank you for completing the survey! Your responses have been recorded.';
+    this.brandName = config.brandName ?? 'Our Company';
+    this.maxRetries = config.maxRetries ?? 2;
+    this.introduction =
+      config.introduction ?? `Welcome to our ${config.surveyName}. We appreciate your participation.`;
+    this.conclusion =
+      config.conclusion ?? 'Thank you for completing our survey. Your feedback is valuable to us.';
     this.onCompleteCallback = config.onComplete;
 
-    // Build questions overview for the prompt
-    const questionBullets = this.questions.map((q) => {
-      let desc = `[${q.id}] (${q.type}) ${q.text}`;
-      if (q.options) desc += ` Options: ${q.options.join(', ')}`;
-      return desc;
-    });
-    this.promptAddSection('Survey Questions', { bullets: questionBullets, numbered: true });
+    // Validate and default questions (mirrors Python _validate_questions)
+    this.validateQuestions();
 
-    this.promptAddSection('Introduction', {
-      body: `Begin the conversation with: "${this.introMessage}"`,
-    });
+    this.questionMap = new Map(this.questions.map((q) => [q.id, q]));
+
+    this.setupSurveyAgent();
 
     // Register tools after all fields are initialized
     this.defineTools();
+  }
+
+  // ── Question validation (mirrors Python _validate_questions) ──────────
+
+  private validateQuestions(): void {
+    const validTypes = new Set(['rating', 'multiple_choice', 'yes_no', 'open_ended']);
+
+    for (let i = 0; i < this.questions.length; i++) {
+      const q = this.questions[i];
+      if (!q.id) q.id = `question_${i + 1}`;
+      if (!q.text) throw new Error(`Question ${i + 1} is missing the 'text' field`);
+      if (!q.type || !validTypes.has(q.type)) {
+        throw new Error(
+          `Question ${i + 1} has an invalid type. Must be one of: ${Array.from(validTypes).join(', ')}`,
+        );
+      }
+      if (q.required === undefined) q.required = true;
+      if (q.type === 'multiple_choice' && (!q.options || q.options.length === 0)) {
+        throw new Error(`Multiple choice question '${q.id}' must have options`);
+      }
+      if (q.type === 'rating' && q.scale === undefined) q.scale = 5;
+    }
+  }
+
+  // ── Prompt + settings (mirrors Python _setup_survey_agent) ────────────
+
+  private setupSurveyAgent(): void {
+    // Personality
+    this.promptAddSection('Personality', {
+      body: `You are a friendly and professional survey agent representing ${this.brandName}.`,
+    });
+
+    // Goal
+    this.promptAddSection('Goal', {
+      body: `Conduct the '${this.surveyName}' survey by asking questions and collecting responses.`,
+    });
+
+    // Instructions
+    const instructions = [
+      'Guide the user through each survey question in sequence.',
+      'Ask only one question at a time and wait for a response.',
+      'For rating questions, explain the scale (e.g., 1-5, where 5 is best).',
+      'For multiple choice questions, list all the options.',
+      `If a response is invalid, explain and retry up to ${this.maxRetries} times.`,
+      'Be conversational but stay focused on collecting the survey data.',
+      'After all questions are answered, thank the user for their participation.',
+    ];
+    this.promptAddSection('Instructions', { bullets: instructions });
+
+    // Introduction
+    this.promptAddSection('Introduction', {
+      body: `Begin with this introduction: ${this.introduction}`,
+    });
+
+    // Questions subsection
+    const questionsSubsections = this.questions.map((q) => {
+      let description = `ID: ${q.id}\nType: ${q.type}\nRequired: ${q.required}`;
+      if (q.type === 'rating') description += `\nScale: 1-${q.scale}`;
+      if (q.type === 'multiple_choice' && q.options) {
+        description += `\nOptions: ${q.options.join(', ')}`;
+      }
+      return { title: q.text, body: description };
+    });
+    this.promptAddSection('Survey Questions', {
+      body: 'Ask these questions in order:',
+      subsections: questionsSubsections,
+    });
+
+    // Conclusion
+    this.promptAddSection('Conclusion', {
+      body: `End with this conclusion: ${this.conclusion}`,
+    });
+
+    // Post-prompt summary template
+    this.setPostPrompt(`
+        Return a JSON summary of the survey responses:
+        {
+            "survey_name": "SURVEY_NAME",
+            "responses": {
+                "QUESTION_ID_1": "RESPONSE_1",
+                "QUESTION_ID_2": "RESPONSE_2",
+                ...
+            },
+            "completion_status": "complete/incomplete",
+            "timestamp": "CURRENT_TIMESTAMP"
+        }
+        `);
+
+    // Hints: rating numbers, MC options, yes/no, plus the names
+    const typeTerms: string[] = [];
+    for (const q of this.questions) {
+      if (q.type === 'rating') {
+        const scale = q.scale ?? 5;
+        for (let i = 1; i <= scale; i++) typeTerms.push(String(i));
+      } else if (q.type === 'multiple_choice' && q.options) {
+        typeTerms.push(...q.options);
+      } else if (q.type === 'yes_no') {
+        typeTerms.push('yes', 'no');
+      }
+    }
+    this.addHints([this.surveyName, this.brandName, ...typeTerms]);
+
+    // AI behavior parameters (includes non-bargeable static greeting = introduction)
+    this.setParams({
+      wait_for_user: false,
+      end_of_speech_timeout: 1500,
+      ai_volume: 5,
+      static_greeting: this.introduction,
+      static_greeting_no_barge: true,
+    });
+
+    // Global data
+    this.setGlobalData({
+      survey_name: this.surveyName,
+      brand_name: this.brandName,
+      questions: this.questions,
+      max_retries: this.maxRetries,
+    });
+
+    // Native functions
+    this.setNativeFunctions(['check_time']);
   }
 
   // ── Session helpers ───────────────────────────────────────────────────
@@ -148,19 +278,17 @@ export class SurveyAgent extends AgentBase {
 
   private resolveNextQuestion(question: SurveyQuestion, answer: string): string | null {
     if (!question.nextQuestion) {
-      // Default: find next in array order
       const idx = this.questions.findIndex((q) => q.id === question.id);
       if (idx >= 0 && idx < this.questions.length - 1) {
         return this.questions[idx + 1].id;
       }
-      return null; // end of survey
+      return null;
     }
 
     if (typeof question.nextQuestion === 'string') {
       return question.nextQuestion;
     }
 
-    // Conditional branching: try exact match first, then case-insensitive
     const normalizedAnswer = answer.toLowerCase().trim();
     for (const [key, nextId] of Object.entries(question.nextQuestion)) {
       if (key.toLowerCase().trim() === normalizedAnswer) {
@@ -168,7 +296,6 @@ export class SurveyAgent extends AgentBase {
       }
     }
 
-    // If no branch matches, try default key or fall through to next in order
     if ('_default' in question.nextQuestion) {
       return question.nextQuestion['_default'];
     }
@@ -184,7 +311,6 @@ export class SurveyAgent extends AgentBase {
     if (question.points === undefined) return 0;
     if (typeof question.points === 'number') return question.points;
 
-    // Per-answer scoring
     const normalizedAnswer = answer.toLowerCase().trim();
     for (const [key, pts] of Object.entries(question.points)) {
       if (key.toLowerCase().trim() === normalizedAnswer) {
@@ -194,6 +320,11 @@ export class SurveyAgent extends AgentBase {
     return 0;
   }
 
+  /**
+   * Validate an answer against the question's type and constraints.
+   * Mirrors the Python `validate_response` tool body.
+   * @returns error message string if invalid, or `null` if valid.
+   */
   private validateAnswer(question: SurveyQuestion, answer: string): string | null {
     switch (question.type) {
       case 'multiple_choice': {
@@ -201,14 +332,16 @@ export class SurveyAgent extends AgentBase {
         const normalized = answer.toLowerCase().trim();
         const match = question.options.find((o) => o.toLowerCase().trim() === normalized);
         if (!match) {
-          return `Invalid answer. Please choose one of: ${question.options.join(', ')}`;
+          return `Invalid choice. Please select one of: ${question.options.join(', ')}.`;
         }
         return null;
       }
       case 'rating': {
-        const num = parseInt(answer, 10);
-        if (isNaN(num) || num < 1 || num > 10) {
-          return 'Please provide a rating between 1 and 10.';
+        const scale = question.scale ?? 5;
+        const trimmed = answer.trim();
+        const num = parseInt(trimmed, 10);
+        if (!/^-?\d+$/.test(trimmed) || isNaN(num) || num < 1 || num > scale) {
+          return `Invalid rating. Please provide a number between 1 and ${scale}.`;
         }
         return null;
       }
@@ -221,8 +354,13 @@ export class SurveyAgent extends AgentBase {
         }
         return null;
       }
-      case 'open_ended':
-        return null; // Accept anything
+      case 'open_ended': {
+        // Python: required open_ended with empty response is invalid.
+        if (!answer.trim() && question.required !== false) {
+          return 'A response is required for this question.';
+        }
+        return null;
+      }
       default:
         return null;
     }
@@ -239,12 +377,86 @@ export class SurveyAgent extends AgentBase {
 
   // ── Tool registration ─────────────────────────────────────────────────
 
-  /** Register the answer_question, get_current_question, and get_survey_progress SWAIG tools. */
+  /**
+   * Register SWAIG tools:
+   *   - Python-parity tools: `validate_response`, `log_response`
+   *   - TS-specific session tools: `answer_question`, `get_current_question`, `get_survey_progress`
+   */
   protected override defineTools(): void {
-    // Tool: answer_question
+    // Tool: validate_response (Python parity)
+    this.defineTool({
+      name: 'validate_response',
+      description: 'Validate if a response meets the requirements for a specific question',
+      parameters: {
+        type: 'object',
+        properties: {
+          question_id: {
+            type: 'string',
+            description: 'The ID of the question',
+          },
+          response: {
+            type: 'string',
+            description: "The user's response to validate",
+          },
+        },
+        required: ['question_id', 'response'],
+      },
+      handler: (args: Record<string, unknown>) => {
+        const questionId = (args['question_id'] as string) ?? '';
+        const response = (args['response'] as string) ?? '';
+
+        const question = this.questionMap.get(questionId);
+        if (!question) {
+          return new FunctionResult(`Error: Question with ID '${questionId}' not found.`);
+        }
+
+        const error = this.validateAnswer(question, response);
+        if (error) return new FunctionResult(error);
+        return new FunctionResult(`Response to '${questionId}' is valid.`);
+      },
+    });
+
+    // Tool: log_response (Python parity — acknowledge recording)
+    this.defineTool({
+      name: 'log_response',
+      description: 'Log a validated response to a survey question',
+      parameters: {
+        type: 'object',
+        properties: {
+          question_id: {
+            type: 'string',
+            description: 'The ID of the question',
+          },
+          response: {
+            type: 'string',
+            description: "The user's validated response",
+          },
+        },
+        required: ['question_id', 'response'],
+      },
+      handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) => {
+        const questionId = (args['question_id'] as string) ?? '';
+        const response = (args['response'] as string) ?? '';
+
+        const question = this.questionMap.get(questionId);
+        const questionText = question ? question.text : '';
+
+        // Record on the per-call session for observability.
+        const session = this.getSession(rawData);
+        if (question) {
+          session.responses[questionId] = this.normalizeAnswer(question, response);
+        }
+
+        return new FunctionResult(
+          `Response to '${questionText}' has been recorded.`,
+        );
+      },
+    });
+
+    // Tool: answer_question (TS-specific atomic validate+record+advance)
     this.defineTool({
       name: 'answer_question',
-      description: 'Record the caller\'s answer to the current survey question. Validates the answer based on question type and advances to the next question.',
+      description: "Record the caller's answer to the current survey question. Validates the answer based on question type and advances to the next question.",
       parameters: {
         type: 'object',
         properties: {
@@ -254,7 +466,7 @@ export class SurveyAgent extends AgentBase {
           },
           answer: {
             type: 'string',
-            description: 'The caller\'s answer to the question.',
+            description: "The caller's answer to the question.",
           },
         },
         required: ['question_id', 'answer'],
@@ -278,25 +490,20 @@ export class SurveyAgent extends AgentBase {
           return new FunctionResult('The survey has already been completed.');
         }
 
-        // Validate the answer
         const validationError = this.validateAnswer(question, answer);
         if (validationError) {
           return new FunctionResult(validationError);
         }
 
-        // Normalize and save
         const normalizedAnswer = this.normalizeAnswer(question, answer);
         session.responses[questionId] = normalizedAnswer;
 
-        // Calculate and add points
         const points = this.calculatePoints(question, normalizedAnswer);
         session.score += points;
 
-        // Determine next question
         const nextId = this.resolveNextQuestion(question, normalizedAnswer);
 
         if (!nextId || !this.questionMap.has(nextId)) {
-          // Survey complete
           session.completed = true;
           if (this.onCompleteCallback) {
             try {
@@ -307,11 +514,10 @@ export class SurveyAgent extends AgentBase {
           }
           const answeredCount = Object.keys(session.responses).length;
           return new FunctionResult(
-            `Answer recorded. The survey is now complete! ${answeredCount} questions answered, total score: ${session.score}. ${this.completionMessage}`,
+            `Answer recorded. The survey is now complete! ${answeredCount} questions answered, total score: ${session.score}. ${this.conclusion}`,
           );
         }
 
-        // Advance to next question
         session.currentQuestionId = nextId;
         const nextQ = this.questionMap.get(nextId)!;
         const nextIdx = this.questions.findIndex((q) => q.id === nextId);
@@ -321,7 +527,7 @@ export class SurveyAgent extends AgentBase {
         if (nextQ.type === 'multiple_choice' && nextQ.options) {
           nextInfo += ` (Options: ${nextQ.options.join(', ')})`;
         } else if (nextQ.type === 'rating') {
-          nextInfo += ' (Rating: 1-10)';
+          nextInfo += ` (Rating: 1-${nextQ.scale ?? 5})`;
         } else if (nextQ.type === 'yes_no') {
           nextInfo += ' (Yes/No)';
         }
@@ -354,7 +560,7 @@ export class SurveyAgent extends AgentBase {
         if (question.type === 'multiple_choice' && question.options) {
           info += ` Options: ${question.options.join(', ')}`;
         } else if (question.type === 'rating') {
-          info += ' (Caller should provide a rating from 1 to 10)';
+          info += ` (Caller should provide a rating from 1 to ${question.scale ?? 5})`;
         } else if (question.type === 'yes_no') {
           info += ' (Caller should answer yes or no)';
         }
@@ -385,7 +591,6 @@ export class SurveyAgent extends AgentBase {
           progress += ` Current question: ${session.currentQuestionId}.`;
         }
 
-        // List answered questions
         if (answeredCount > 0) {
           const answered = Object.entries(session.responses)
             .map(([qId, ans]) => `${qId}: ${ans}`)
@@ -396,6 +601,27 @@ export class SurveyAgent extends AgentBase {
         return new FunctionResult(progress);
       },
     });
+  }
+
+  // ── Lifecycle hooks ───────────────────────────────────────────────────
+
+  /**
+   * Process the survey results summary returned at the end of a call.
+   * Logs the structured summary as JSON (mirrors Python `on_summary`).
+   */
+  override onSummary(
+    summary: Record<string, unknown> | null,
+    _rawData: Record<string, unknown>,
+  ): void | Promise<void> {
+    if (summary) {
+      try {
+        // eslint-disable-next-line no-console
+        console.log(`Survey completed: ${JSON.stringify(summary, null, 2)}`);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log(`Error processing survey summary: ${String(err)}`);
+      }
+    }
   }
 }
 

--- a/src/prefabs/SurveyAgent.ts
+++ b/src/prefabs/SurveyAgent.ts
@@ -347,10 +347,9 @@ export class SurveyAgent extends AgentBase {
       }
       case 'yes_no': {
         const normalized = answer.toLowerCase().trim();
-        const yesValues = ['yes', 'y', 'yeah', 'yep', 'sure', 'absolutely', 'correct', 'true'];
-        const noValues = ['no', 'n', 'nah', 'nope', 'negative', 'false'];
-        if (!yesValues.includes(normalized) && !noValues.includes(normalized)) {
-          return 'Please answer with yes or no.';
+        // Python reference accepts only 'yes', 'no', 'y', 'n' (survey.py:260).
+        if (!['yes', 'y', 'no', 'n'].includes(normalized)) {
+          return "Please answer with 'yes' or 'no'.";
         }
         return null;
       }
@@ -369,8 +368,8 @@ export class SurveyAgent extends AgentBase {
   private normalizeAnswer(question: SurveyQuestion, answer: string): string {
     if (question.type === 'yes_no') {
       const normalized = answer.toLowerCase().trim();
-      const yesValues = ['yes', 'y', 'yeah', 'yep', 'sure', 'absolutely', 'correct', 'true'];
-      return yesValues.includes(normalized) ? 'yes' : 'no';
+      // Mirrors validateAnswer's accepted set (Python: 'yes','y','no','n').
+      return ['yes', 'y'].includes(normalized) ? 'yes' : 'no';
     }
     return answer;
   }
@@ -399,7 +398,6 @@ export class SurveyAgent extends AgentBase {
             description: "The user's response to validate",
           },
         },
-        required: ['question_id', 'response'],
       },
       handler: (args: Record<string, unknown>) => {
         const questionId = (args['question_id'] as string) ?? '';
@@ -432,7 +430,6 @@ export class SurveyAgent extends AgentBase {
             description: "The user's validated response",
           },
         },
-        required: ['question_id', 'response'],
       },
       handler: (args: Record<string, unknown>, rawData: Record<string, unknown>) => {
         const questionId = (args['question_id'] as string) ?? '';
@@ -607,16 +604,26 @@ export class SurveyAgent extends AgentBase {
 
   /**
    * Process the survey results summary returned at the end of a call.
-   * Logs the structured summary as JSON (mirrors Python `on_summary`).
+   * Mirrors Python `on_summary`: structured (dict-like) summaries are logged
+   * as JSON; unstructured summaries are logged verbatim.
+   *
+   * The parameter type widens the base `AgentBase.onSummary` signature to
+   * accept string payloads as well, matching Python's `isinstance(summary, dict)`
+   * branch even though the current framework only surfaces object summaries.
    */
   override onSummary(
-    summary: Record<string, unknown> | null,
+    summary: Record<string, unknown> | string | null,
     _rawData: Record<string, unknown>,
   ): void | Promise<void> {
     if (summary) {
       try {
-        // eslint-disable-next-line no-console
-        console.log(`Survey completed: ${JSON.stringify(summary, null, 2)}`);
+        if (typeof summary === 'string') {
+          // eslint-disable-next-line no-console
+          console.log(`Survey summary (unstructured): ${summary}`);
+        } else {
+          // eslint-disable-next-line no-console
+          console.log(`Survey completed: ${JSON.stringify(summary, null, 2)}`);
+        }
       } catch (err) {
         // eslint-disable-next-line no-console
         console.log(`Error processing survey summary: ${String(err)}`);

--- a/src/prefabs/index.ts
+++ b/src/prefabs/index.ts
@@ -4,7 +4,11 @@
 
 // InfoGathererAgent
 export { InfoGathererAgent, createInfoGathererAgent } from './InfoGathererAgent.js';
-export type { InfoGathererConfig, InfoGathererField } from './InfoGathererAgent.js';
+export type {
+  InfoGathererConfig,
+  InfoGathererQuestion,
+  InfoGathererQuestionCallback,
+} from './InfoGathererAgent.js';
 
 // SurveyAgent
 export { SurveyAgent, createSurveyAgent } from './SurveyAgent.js';
@@ -16,7 +20,7 @@ export type { FAQBotConfig, FAQEntry } from './FAQBotAgent.js';
 
 // ConciergeAgent
 export { ConciergeAgent, createConciergeAgent } from './ConciergeAgent.js';
-export type { ConciergeConfig, Department } from './ConciergeAgent.js';
+export type { ConciergeConfig } from './ConciergeAgent.js';
 
 // ReceptionistAgent
 export { ReceptionistAgent, createReceptionistAgent } from './ReceptionistAgent.js';

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -29,14 +29,14 @@ describe('examples', () => {
   // ── Prefab examples ─────────────────────────────────────────────
 
   describe('prefab-info-gatherer.ts', () => {
-    it('renders SWML with save_field and get_status tools', async () => {
+    it('renders SWML with start_questions and submit_answer tools', async () => {
       const agent = await loadExample('prefab-info-gatherer.ts');
       const swml = JSON.parse(agent.renderSwml('test-call-id'));
       expect(swml).toHaveProperty('version');
       const tools = agent.getRegisteredTools();
       const names = tools.map((t: any) => t.name);
-      expect(names).toContain('save_field');
-      expect(names).toContain('get_status');
+      expect(names).toContain('start_questions');
+      expect(names).toContain('submit_answer');
     });
   });
 
@@ -52,23 +52,22 @@ describe('examples', () => {
   });
 
   describe('prefab-faq.ts', () => {
-    it('renders SWML with search_faq and escalate tools', async () => {
+    it('renders SWML with search_faqs and escalate tools', async () => {
       const agent = await loadExample('prefab-faq.ts');
       const tools = agent.getRegisteredTools();
       const names = tools.map((t: any) => t.name);
-      expect(names).toContain('search_faq');
+      expect(names).toContain('search_faqs');
       expect(names).toContain('escalate');
     });
   });
 
   describe('prefab-concierge.ts', () => {
-    it('renders SWML with department tools', async () => {
+    it('renders SWML with concierge tools', async () => {
       const agent = await loadExample('prefab-concierge.ts');
       const tools = agent.getRegisteredTools();
       const names = tools.map((t: any) => t.name);
-      expect(names).toContain('list_departments');
-      expect(names).toContain('get_department_info');
-      expect(names).toContain('transfer_to_department');
+      expect(names).toContain('check_availability');
+      expect(names).toContain('get_directions');
     });
   });
 
@@ -77,8 +76,8 @@ describe('examples', () => {
       const agent = await loadExample('prefab-receptionist.ts');
       const tools = agent.getRegisteredTools();
       const names = tools.map((t: any) => t.name);
-      expect(names).toContain('get_department_list');
-      expect(names).toContain('transfer_to_department');
+      expect(names).toContain('collect_caller_info');
+      expect(names).toContain('transfer_call');
       expect(names).toContain('check_in_visitor');
     });
   });

--- a/tests/prefabs/prefabs.test.ts
+++ b/tests/prefabs/prefabs.test.ts
@@ -15,20 +15,20 @@ beforeAll(() => {
 // ============================================================================
 
 describe('InfoGathererAgent', () => {
-  const baseFields = [
-    { name: 'full_name', description: 'Full name of the caller', required: true },
-    { name: 'email', description: 'Email address', required: true, validation: '^[^@]+@[^@]+\\.[^@]+$' },
-    { name: 'phone', description: 'Phone number', required: true, validation: /^\d{10}$/ },
+  const baseQuestions = [
+    { key_name: 'full_name', question_text: 'What is your full name?' },
+    { key_name: 'email', question_text: 'What is your email address?', confirm: true },
+    { key_name: 'reason', question_text: 'How can I help you today?' },
   ];
 
   function createAgent(overrides?: Record<string, unknown>) {
     return new InfoGathererAgent({
-      fields: baseFields,
+      questions: baseQuestions,
       ...overrides,
     });
   }
 
-  it('creates with fields config', () => {
+  it('creates with questions config', () => {
     const agent = createAgent();
     expect(agent).toBeInstanceOf(InfoGathererAgent);
   });
@@ -41,150 +41,188 @@ describe('InfoGathererAgent', () => {
     expect(parsed.sections.main).toBeDefined();
   });
 
-  it('has save_field and get_status tools', () => {
+  it('registers start_questions and submit_answer tools', () => {
     const agent = createAgent();
-    expect(agent.getTool('save_field')).toBeDefined();
-    expect(agent.getTool('get_status')).toBeDefined();
+    expect(agent.getTool('start_questions')).toBeDefined();
+    expect(agent.getTool('submit_answer')).toBeDefined();
   });
 
-  it('save_field handler stores data', async () => {
-    const agent = createAgent();
-    const tool = agent.getTool('save_field')!;
-    const result = await tool.execute(
-      { field_name: 'full_name', value: 'John Doe' },
-      { call_id: 'call-1' },
-    );
-    expect(result.response).toContain('saved');
-    expect(result.response).toContain('full_name');
-  });
-
-  it('save_field validates against regex string pattern', async () => {
-    const agent = createAgent();
-    const tool = agent.getTool('save_field')!;
-    const result = await tool.execute(
-      { field_name: 'email', value: 'not-an-email' },
-      { call_id: 'call-2' },
-    );
-    expect(result.response).toContain('not valid');
-  });
-
-  it('save_field validates against RegExp pattern', async () => {
-    const agent = createAgent();
-    const tool = agent.getTool('save_field')!;
-    const result = await tool.execute(
-      { field_name: 'phone', value: '123' },
-      { call_id: 'call-3' },
-    );
-    expect(result.response).toContain('not valid');
-
-    // Valid phone passes
-    const result2 = await tool.execute(
-      { field_name: 'phone', value: '5551234567' },
-      { call_id: 'call-3' },
-    );
-    expect(result2.response).toContain('saved');
-  });
-
-  it('get_status returns collected and remaining', async () => {
-    const agent = createAgent();
-    const saveTool = agent.getTool('save_field')!;
-    await saveTool.execute(
-      { field_name: 'full_name', value: 'Jane Doe' },
-      { call_id: 'call-4' },
-    );
-
-    const statusTool = agent.getTool('get_status')!;
-    const status = await statusTool.execute({}, { call_id: 'call-4' });
-    expect(status.response).toContain('full_name: Jane Doe');
-    expect(status.response).toContain('email');
-    expect(status.response).toContain('phone');
-  });
-
-  it('all required fields triggers completion message', async () => {
-    const agent = createAgent();
-    const tool = agent.getTool('save_field')!;
-    const callData = { call_id: 'call-5' };
-
-    await tool.execute({ field_name: 'full_name', value: 'Jane Doe' }, callData);
-    await tool.execute({ field_name: 'email', value: 'jane@example.com' }, callData);
-    const result = await tool.execute({ field_name: 'phone', value: '5551234567' }, callData);
-
-    expect(result.response).toContain('All required fields are now collected');
-    expect(result.response).toContain('Thank you');
-  });
-
-  it('prompt mentions field names', () => {
+  it('static mode populates global_data with questions at construction', () => {
     const agent = createAgent();
     const swml = agent.renderSwml('test-call');
-    const parsed = JSON.parse(swml);
-    const promptText = JSON.stringify(parsed);
-    expect(promptText).toContain('full_name');
-    expect(promptText).toContain('email');
-    expect(promptText).toContain('phone');
+    // questions should appear in the SWML global_data surface
+    expect(swml).toContain('full_name');
+    expect(swml).toContain('What is your full name');
   });
 
-  it('works with optional fields', async () => {
+  it('start_questions returns the first question instruction', async () => {
+    const agent = createAgent();
+    const tool = agent.getTool('start_questions')!;
+    const rawData = {
+      global_data: {
+        questions: baseQuestions,
+        question_index: 0,
+        answers: [],
+      },
+    };
+    const result = await tool.execute({}, rawData);
+    expect(result.response).toContain('What is your full name?');
+    expect(result.response).toContain('Make sure the answer fits');
+  });
+
+  it('start_questions uses confirmation instruction when confirm flag is true', async () => {
     const agent = new InfoGathererAgent({
-      fields: [
-        { name: 'name', description: 'Name', required: true },
-        { name: 'nickname', description: 'Nickname', required: false },
+      questions: [
+        { key_name: 'email', question_text: 'Email?', confirm: true },
       ],
     });
-
-    const saveTool = agent.getTool('save_field')!;
-    const callData = { call_id: 'call-6' };
-
-    // Completing only the required field should trigger completion
-    const result = await saveTool.execute({ field_name: 'name', value: 'Alice' }, callData);
-    expect(result.response).toContain('All required fields are now collected');
-
-    // get_status should mention optional field not yet collected
-    const statusTool = agent.getTool('get_status')!;
-    const status = await statusTool.execute({}, callData);
-    expect(status.response).toContain('Optional');
-    expect(status.response).toContain('nickname');
+    const tool = agent.getTool('start_questions')!;
+    const rawData = {
+      global_data: {
+        questions: [{ key_name: 'email', question_text: 'Email?', confirm: true }],
+        question_index: 0,
+        answers: [],
+      },
+    };
+    const result = await tool.execute({}, rawData);
+    expect(result.response).toContain('Insist that the user confirms');
   });
 
-  it('onComplete callback fires when all required fields collected', async () => {
-    const onComplete = vi.fn();
-    const agent = new InfoGathererAgent({
-      fields: [{ name: 'name', description: 'Name' }],
-      onComplete,
-    });
-
-    const tool = agent.getTool('save_field')!;
-    await tool.execute({ field_name: 'name', value: 'Bob' }, { call_id: 'call-7' });
-
-    expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(onComplete).toHaveBeenCalledWith({ name: 'Bob' });
-  });
-
-  it('returns error for invalid field name', async () => {
+  it('submit_answer advances to next question and updates global data', async () => {
     const agent = createAgent();
-    const tool = agent.getTool('save_field')!;
-    const result = await tool.execute(
-      { field_name: 'nonexistent', value: 'val' },
-      { call_id: 'call-8' },
+    const tool = agent.getTool('submit_answer')!;
+    const rawData = {
+      global_data: {
+        questions: baseQuestions,
+        question_index: 0,
+        answers: [],
+      },
+    };
+    const result = await tool.execute({ answer: 'Jane Doe' }, rawData);
+    expect(result.response).toContain('What is your email address?');
+    // Check global data update action is present
+    const actions = result.action as Array<Record<string, unknown>>;
+    const updateAction = actions.find(
+      (a) => a['set_global_data'] !== undefined || a['update_global_data'] !== undefined,
     );
-    expect(result.response).toContain('Unknown field');
-    expect(result.response).toContain('Available fields');
+    expect(updateAction).toBeDefined();
+  });
+
+  it('submit_answer completes the flow after the last question', async () => {
+    const agent = createAgent();
+    const tool = agent.getTool('submit_answer')!;
+    const rawData = {
+      global_data: {
+        questions: baseQuestions,
+        question_index: 2,
+        answers: [
+          { key_name: 'full_name', answer: 'Jane Doe' },
+          { key_name: 'email', answer: 'jane@example.com' },
+        ],
+      },
+    };
+    const result = await tool.execute({ answer: 'Billing issue' }, rawData);
+    expect(result.response).toContain('All questions have been answered');
+  });
+
+  it('submit_answer handles out-of-bounds index', async () => {
+    const agent = createAgent();
+    const tool = agent.getTool('submit_answer')!;
+    const rawData = {
+      global_data: {
+        questions: baseQuestions,
+        question_index: 99,
+        answers: [],
+      },
+    };
+    const result = await tool.execute({ answer: 'late answer' }, rawData);
+    expect(result.response).toContain('All questions have already been answered');
+  });
+
+  it('setQuestionCallback is callable and stored', () => {
+    const agent = new InfoGathererAgent();
+    const cb = vi.fn(() => []);
+    agent.setQuestionCallback(cb);
+    // Confirm the method returned `this` for chaining
+    const result = agent.setQuestionCallback(cb);
+    expect(result).toBe(agent);
+  });
+
+  it('dynamic mode: onSwmlRequest invokes the callback and sets global data', async () => {
+    const agent = new InfoGathererAgent();
+    const cb = vi.fn((queryParams: Record<string, string>) => {
+      if (queryParams.mode === 'support') {
+        return [
+          { key_name: 'name', question_text: 'Your name?' },
+          { key_name: 'issue', question_text: "What's the issue?" },
+        ];
+      }
+      return [{ key_name: 'name', question_text: 'What is your name?' }];
+    });
+    agent.setQuestionCallback(cb);
+
+    await agent.onSwmlRequest({ query_params: { mode: 'support' } });
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain("What's the issue?");
+    expect(swml).toContain('issue');
+  });
+
+  it('dynamic mode: falls back to default questions when no callback is registered', async () => {
+    const agent = new InfoGathererAgent();
+    await agent.onSwmlRequest({});
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('What is your name?');
+    expect(swml).toContain('How can I help you today?');
+  });
+
+  it('dynamic mode: falls back when the callback throws', async () => {
+    const agent = new InfoGathererAgent();
+    agent.setQuestionCallback(() => {
+      throw new Error('boom');
+    });
+    await agent.onSwmlRequest({});
+    const swml = agent.renderSwml('test-call');
+    // Fallback questions should be injected
+    expect(swml).toContain('What is your name?');
+  });
+
+  it('questionCallback can be passed via config', async () => {
+    const cb = vi.fn(() => [
+      { key_name: 'company', question_text: 'What company?' },
+    ]);
+    const agent = new InfoGathererAgent({ questionCallback: cb });
+    await agent.onSwmlRequest({});
+    expect(cb).toHaveBeenCalled();
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('What company?');
+  });
+
+  it('throws on missing key_name in a question', () => {
+    expect(
+      () =>
+        new InfoGathererAgent({
+          // @ts-expect-error intentionally invalid
+          questions: [{ question_text: 'Something?' }],
+        }),
+    ).toThrow(/key_name/);
+  });
+
+  it('throws on missing question_text in a question', () => {
+    expect(
+      () =>
+        new InfoGathererAgent({
+          // @ts-expect-error intentionally invalid
+          questions: [{ key_name: 'x' }],
+        }),
+    ).toThrow(/question_text/);
   });
 
   it('factory function creates agent', () => {
-    const agent = createInfoGathererAgent({ fields: baseFields });
+    const agent = createInfoGathererAgent({ questions: baseQuestions });
     expect(agent).toBeInstanceOf(InfoGathererAgent);
-    expect(agent.getTool('save_field')).toBeDefined();
-  });
-
-  it('custom name and messages are applied', () => {
-    const agent = new InfoGathererAgent({
-      name: 'CustomGatherer',
-      fields: [{ name: 'age', description: 'Age' }],
-      introMessage: 'Hi there!',
-      confirmationMessage: 'All done!',
-    });
-    const swml = agent.renderSwml('test-call');
-    expect(swml).toContain('Hi there!');
+    expect(agent.getTool('start_questions')).toBeDefined();
   });
 });
 
@@ -198,6 +236,7 @@ describe('SurveyAgent', () => {
       id: 'q1',
       text: 'How satisfied are you with our service?',
       type: 'rating' as const,
+      scale: 10,
       points: 1,
     },
     {
@@ -221,6 +260,7 @@ describe('SurveyAgent', () => {
 
   function createAgent(overrides?: Record<string, unknown>) {
     return new SurveyAgent({
+      surveyName: 'Customer Satisfaction Survey',
       questions: baseQuestions,
       ...overrides,
     });
@@ -290,7 +330,7 @@ describe('SurveyAgent', () => {
       },
     ];
 
-    const agent = new SurveyAgent({ questions: branchQuestions });
+    const agent = new SurveyAgent({ surveyName: 'Branching Survey', questions: branchQuestions });
     const tool = agent.getTool('answer_question')!;
 
     // Answer "yes" should branch to "positive"
@@ -302,7 +342,7 @@ describe('SurveyAgent', () => {
     expect(result.response).toContain('What do you love');
 
     // A separate call answering "no" should branch to "negative"
-    const agent2 = new SurveyAgent({ questions: branchQuestions });
+    const agent2 = new SurveyAgent({ surveyName: 'Branching Survey', questions: branchQuestions });
     const tool2 = agent2.getTool('answer_question')!;
     const result2 = await tool2.execute(
       { question_id: 'start', answer: 'no' },
@@ -344,9 +384,9 @@ describe('SurveyAgent', () => {
   it('survey completion triggers onComplete', async () => {
     const onComplete = vi.fn();
     const simpleQuestions = [
-      { id: 'only', text: 'Rate us', type: 'rating' as const, points: 5 },
+      { id: 'only', text: 'Rate us', type: 'rating' as const, scale: 10, points: 5 },
     ];
-    const agent = new SurveyAgent({ questions: simpleQuestions, onComplete });
+    const agent = new SurveyAgent({ surveyName: 'Tiny', questions: simpleQuestions, onComplete });
 
     const tool = agent.getTool('answer_question')!;
     await tool.execute({ question_id: 'only', answer: '9' }, { call_id: 'done-1' });
@@ -364,14 +404,14 @@ describe('SurveyAgent', () => {
       { question_id: 'q1', answer: '15' },
       { call_id: 'val-1' },
     );
-    expect(result.response).toContain('rating between 1 and 10');
+    expect(result.response).toContain('between 1 and 10');
 
     // Not a number
     const result2 = await tool.execute(
       { question_id: 'q1', answer: 'abc' },
       { call_id: 'val-2' },
     );
-    expect(result2.response).toContain('rating between 1 and 10');
+    expect(result2.response).toContain('between 1 and 10');
   });
 
   it('yes/no type normalizes answers', async () => {
@@ -404,16 +444,125 @@ describe('SurveyAgent', () => {
       { question_id: 'q3', answer: 'InvalidOption' },
       callData,
     );
-    expect(result.response).toContain('Invalid answer');
+    expect(result.response).toContain('Invalid choice');
     expect(result.response).toContain('Speed');
     expect(result.response).toContain('Price');
     expect(result.response).toContain('Support');
   });
 
   it('factory function creates agent', () => {
-    const agent = createSurveyAgent({ questions: baseQuestions });
+    const agent = createSurveyAgent({
+      surveyName: 'Factory Survey',
+      questions: baseQuestions,
+    });
     expect(agent).toBeInstanceOf(SurveyAgent);
     expect(agent.getTool('answer_question')).toBeDefined();
+  });
+
+  it('exposes Python-parity public properties', () => {
+    const agent = createAgent({
+      brandName: 'Acme',
+      maxRetries: 4,
+      introduction: 'Welcome!',
+      conclusion: 'Goodbye!',
+    });
+    expect(agent.surveyName).toBe('Customer Satisfaction Survey');
+    expect(agent.brandName).toBe('Acme');
+    expect(agent.maxRetries).toBe(4);
+    expect(agent.introduction).toBe('Welcome!');
+    expect(agent.conclusion).toBe('Goodbye!');
+    expect(agent.questions).toBe(baseQuestions);
+  });
+
+  it('brandName defaults to "Our Company"', () => {
+    const agent = createAgent();
+    expect(agent.brandName).toBe('Our Company');
+  });
+
+  it('maxRetries defaults to 2 and appears in instructions', () => {
+    const agent = createAgent();
+    expect(agent.maxRetries).toBe(2);
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('retry up to 2');
+  });
+
+  it('has validate_response and log_response tools (Python parity)', () => {
+    const agent = createAgent();
+    expect(agent.getTool('validate_response')).toBeDefined();
+    expect(agent.getTool('log_response')).toBeDefined();
+  });
+
+  it('validate_response flags rating out of configured scale', async () => {
+    const agent = createAgent();
+    const tool = agent.getTool('validate_response')!;
+    // q1 has scale: 10 — 11 should be rejected
+    const bad = await tool.execute({ question_id: 'q1', response: '11' }, {});
+    expect(bad.response).toContain('between 1 and 10');
+    // And valid
+    const ok = await tool.execute({ question_id: 'q1', response: '7' }, {});
+    expect(ok.response).toContain('is valid');
+  });
+
+  it('validate_response uses scale default of 5 for rating questions', async () => {
+    const agent = new SurveyAgent({
+      surveyName: 'Five Point',
+      questions: [{ id: 'q', text: 'Rate', type: 'rating' }],
+    });
+    const tool = agent.getTool('validate_response')!;
+    const bad = await tool.execute({ question_id: 'q', response: '6' }, {});
+    expect(bad.response).toContain('between 1 and 5');
+  });
+
+  it('validate_response checks required=true for open_ended', async () => {
+    const agent = new SurveyAgent({
+      surveyName: 'Required Survey',
+      questions: [
+        { id: 'optional_q', text: 'Optional?', type: 'open_ended', required: false },
+        { id: 'required_q', text: 'Required', type: 'open_ended', required: true },
+      ],
+    });
+    const tool = agent.getTool('validate_response')!;
+    // empty answer to required → error
+    const requiredErr = await tool.execute({ question_id: 'required_q', response: '' }, {});
+    expect(requiredErr.response).toContain('required');
+    // empty answer to optional → valid
+    const optionalOk = await tool.execute({ question_id: 'optional_q', response: '' }, {});
+    expect(optionalOk.response).toContain('is valid');
+  });
+
+  it('log_response acknowledges recording a response', async () => {
+    const agent = createAgent();
+    const tool = agent.getTool('log_response')!;
+    const result = await tool.execute(
+      { question_id: 'q1', response: '7' },
+      { call_id: 'log-1' },
+    );
+    expect(result.response).toContain('recorded');
+    expect(result.response).toContain('satisfied');
+  });
+
+  it('prompt mentions surveyName, brandName, and introduction/conclusion', () => {
+    const agent = createAgent({
+      brandName: 'Acme Corp',
+      introduction: 'Welcome to the Acme feedback line!',
+      conclusion: 'Thanks for your time.',
+    });
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('Customer Satisfaction Survey');
+    expect(swml).toContain('Acme Corp');
+    expect(swml).toContain('Welcome to the Acme feedback line!');
+    expect(swml).toContain('Thanks for your time.');
+  });
+
+  it('onSummary override is callable without throwing', async () => {
+    const agent = createAgent();
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await agent.onSummary({ survey_name: 'Customer Satisfaction Survey' }, {});
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 
@@ -460,15 +609,15 @@ describe('FAQBotAgent', () => {
     expect(parsed.sections.main).toBeDefined();
   });
 
-  it('has search_faq tool and no escalate when not configured', () => {
+  it('has search_faqs tool and no escalate when not configured', () => {
     const agent = createAgent();
-    expect(agent.getTool('search_faq')).toBeDefined();
+    expect(agent.getTool('search_faqs')).toBeDefined();
     expect(agent.getTool('escalate')).toBeUndefined();
   });
 
-  it('search_faq returns matching FAQ', async () => {
+  it('search_faqs returns matching FAQ', async () => {
     const agent = createAgent();
-    const tool = agent.getTool('search_faq')!;
+    const tool = agent.getTool('search_faqs')!;
     const result = await tool.execute({ query: 'What are your business hours?' }, {});
     expect(result.response).toContain('Monday through Friday');
     expect(result.response).toContain('9am to 5pm');
@@ -476,7 +625,7 @@ describe('FAQBotAgent', () => {
 
   it('returns no-match for unrelated query', async () => {
     const agent = createAgent({ threshold: 0.5 });
-    const tool = agent.getTool('search_faq')!;
+    const tool = agent.getTool('search_faqs')!;
     const result = await tool.execute({ query: 'quantum physics dark matter' }, {});
     expect(result.response).toContain('No FAQ matched');
   });
@@ -484,15 +633,69 @@ describe('FAQBotAgent', () => {
   it('threshold filtering works', async () => {
     // High threshold makes it hard to match
     const agent = createAgent({ threshold: 0.99 });
-    const tool = agent.getTool('search_faq')!;
+    const tool = agent.getTool('search_faqs')!;
     const result = await tool.execute({ query: 'hours open' }, {});
     expect(result.response).toContain('No FAQ matched');
 
     // Low threshold makes it easy to match
     const agent2 = createAgent({ threshold: 0.01 });
-    const tool2 = agent2.getTool('search_faq')!;
+    const tool2 = agent2.getTool('search_faqs')!;
     const result2 = await tool2.execute({ query: 'hours open' }, {});
     expect(result2.response).toContain('FAQ Match');
+  });
+
+  it('category filter narrows the FAQ pool', async () => {
+    const categorizedFaqs = [
+      {
+        question: 'What are your business hours?',
+        answer: 'Mon-Fri, 9-5.',
+        categories: ['general'],
+      },
+      {
+        question: 'How do I reset my password?',
+        answer: 'Click "Forgot Password" on the login page.',
+        categories: ['account'],
+      },
+    ];
+    const agent = new FAQBotAgent({ faqs: categorizedFaqs, threshold: 0.01 });
+    const tool = agent.getTool('search_faqs')!;
+    const result = await tool.execute(
+      { query: 'password reset', category: 'general' },
+      {},
+    );
+    // Filtered to only the "general" FAQ, so no relevant password match
+    expect(result.response).not.toContain('Forgot Password');
+  });
+
+  it('suggestRelated=false suppresses runner-up suggestions', async () => {
+    const agent = createAgent({ threshold: 0.01, suggestRelated: false });
+    const tool = agent.getTool('search_faqs')!;
+    const result = await tool.execute({ query: 'password hours open' }, {});
+    expect(result.response).not.toContain('Also related:');
+  });
+
+  it('persona overrides the default Personality section', () => {
+    const agent = createAgent({ persona: 'You are a terse and factual help desk.' });
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('terse and factual help desk');
+  });
+
+  it('exposes public faqs, suggestRelated, and persona properties', () => {
+    const agent = createAgent({ persona: 'custom persona text' });
+    expect(agent.faqs).toEqual(baseFaqs);
+    expect(agent.suggestRelated).toBe(true);
+    expect(agent.persona).toBe('custom persona text');
+  });
+
+  it('onSummary override is callable without throwing', async () => {
+    const agent = createAgent();
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await agent.onSummary({ question: 'hours' }, {});
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('escalate tool is not registered without escalation number', () => {
@@ -516,9 +719,9 @@ describe('FAQBotAgent', () => {
     expect(actions.length).toBeGreaterThan(0);
   });
 
-  it('search_faq includes escalation message when no match', async () => {
+  it('search_faqs includes escalation message when no match', async () => {
     const agent = createAgent({ escalationMessage: 'Please hold for an agent.' });
-    const tool = agent.getTool('search_faq')!;
+    const tool = agent.getTool('search_faqs')!;
     const result = await tool.execute({ query: 'completely unrelated topic xyz' }, {});
     // The escalation message is included in the no-match response
     expect(result.response).toContain('No FAQ matched');
@@ -526,7 +729,7 @@ describe('FAQBotAgent', () => {
 
   it('keywords improve matching', async () => {
     const agent = createAgent({ threshold: 0.3 });
-    const tool = agent.getTool('search_faq')!;
+    const tool = agent.getTool('search_faqs')!;
 
     // Query using keywords that match the password FAQ
     const result = await tool.execute({ query: 'forgot password reset' }, {});
@@ -545,7 +748,7 @@ describe('FAQBotAgent', () => {
   it('factory function creates agent', () => {
     const agent = createFAQBotAgent({ faqs: baseFaqs });
     expect(agent).toBeInstanceOf(FAQBotAgent);
-    expect(agent.getTool('search_faq')).toBeDefined();
+    expect(agent.getTool('search_faqs')).toBeDefined();
   });
 });
 
@@ -554,40 +757,33 @@ describe('FAQBotAgent', () => {
 // ============================================================================
 
 describe('ConciergeAgent', () => {
-  const baseDepartments = [
-    {
-      name: 'Sales',
-      description: 'Handles product inquiries and purchases.',
-      transferNumber: '+15551001001',
-      keywords: ['buy', 'purchase', 'pricing'],
-      hoursOfOperation: 'Mon-Fri 9am-5pm EST',
-    },
-    {
-      name: 'Support',
-      description: 'Handles technical issues and troubleshooting.',
-      transferNumber: '+15551002002',
-      keywords: ['help', 'issue', 'problem', 'technical'],
-      hoursOfOperation: '24/7',
-    },
-    {
-      name: 'HR',
-      description: 'Handles employment and benefits inquiries.',
-      keywords: ['employment', 'benefits', 'job'],
-      // No transferNumber
-    },
-  ];
+  const baseAmenities = {
+    pool: { hours: '7 AM - 10 PM', location: '2nd Floor' },
+    gym: { hours: '24 hours', location: '3rd Floor' },
+  };
+  const baseServices = ['room service', 'spa bookings', 'restaurant reservations'];
 
   function createAgent(overrides?: Record<string, unknown>) {
     return new ConciergeAgent({
-      departments: baseDepartments,
-      companyName: 'Acme Corp',
+      venueName: 'Grand Hotel',
+      services: baseServices,
+      amenities: baseAmenities,
       ...overrides,
     });
   }
 
-  it('creates with departments config', () => {
+  it('creates with venue config', () => {
     const agent = createAgent();
     expect(agent).toBeInstanceOf(ConciergeAgent);
+  });
+
+  it('exposes public venue properties', () => {
+    const agent = createAgent();
+    expect(agent.venueName).toBe('Grand Hotel');
+    expect(agent.services).toEqual(baseServices);
+    expect(agent.amenities).toEqual(baseAmenities);
+    expect(agent.hoursOfOperation).toEqual({ default: '9 AM - 5 PM' });
+    expect(agent.specialInstructions).toEqual([]);
   });
 
   it('renders valid SWML', () => {
@@ -598,84 +794,117 @@ describe('ConciergeAgent', () => {
     expect(parsed.sections.main).toBeDefined();
   });
 
-  it('has list_departments, get_department_info, and transfer_to_department tools', () => {
+  it('has check_availability and get_directions tools', () => {
     const agent = createAgent();
-    expect(agent.getTool('list_departments')).toBeDefined();
-    expect(agent.getTool('get_department_info')).toBeDefined();
-    expect(agent.getTool('transfer_to_department')).toBeDefined();
+    expect(agent.getTool('check_availability')).toBeDefined();
+    expect(agent.getTool('get_directions')).toBeDefined();
   });
 
-  it('list_departments returns all departments', async () => {
+  it('check_availability confirms an offered service', async () => {
     const agent = createAgent();
-    const tool = agent.getTool('list_departments')!;
-    const result = await tool.execute({}, {});
-    expect(result.response).toContain('Sales');
-    expect(result.response).toContain('Support');
-    expect(result.response).toContain('HR');
-    expect(result.response).toContain('Acme Corp');
+    const tool = agent.getTool('check_availability')!;
+    const result = await tool.execute(
+      { service: 'spa bookings', date: '2026-01-01', time: '10:00' },
+      {},
+    );
+    expect(result.response).toContain('spa bookings');
+    expect(result.response).toContain('2026-01-01');
+    expect(result.response).toContain('10:00');
+    expect(result.response).toContain('reservation');
   });
 
-  it('get_department_info returns specific department', async () => {
+  it('check_availability rejects an unknown service', async () => {
     const agent = createAgent();
-    const tool = agent.getTool('get_department_info')!;
-    const result = await tool.execute({ department_name: 'Sales' }, {});
-    expect(result.response).toContain('Sales');
-    expect(result.response).toContain('product inquiries');
-    expect(result.response).toContain('Mon-Fri 9am-5pm');
-    expect(result.response).toContain('Transfer: available');
+    const tool = agent.getTool('check_availability')!;
+    const result = await tool.execute(
+      { service: 'skydiving', date: '2026-01-01', time: '10:00' },
+      {},
+    );
+    expect(result.response).toContain("don't offer");
+    expect(result.response).toContain('Grand Hotel');
+    // Should list available services
+    expect(result.response).toContain('spa bookings');
   });
 
-  it('transfer_to_department handles missing transfer number', async () => {
+  it('get_directions looks up an amenity by name', async () => {
     const agent = createAgent();
-    const tool = agent.getTool('transfer_to_department')!;
-    const result = await tool.execute({ department_name: 'HR' }, {});
-    expect(result.response).toContain('does not have a direct transfer number');
+    const tool = agent.getTool('get_directions')!;
+    const result = await tool.execute({ location: 'pool' }, {});
+    expect(result.response).toContain('pool');
+    expect(result.response).toContain('2nd Floor');
   });
 
-  it('department lookup by keyword', async () => {
+  it('get_directions falls back for unknown locations', async () => {
     const agent = createAgent();
-    const tool = agent.getTool('get_department_info')!;
-    // "buy" is a keyword for "Sales"
-    const result = await tool.execute({ department_name: 'buy' }, {});
-    expect(result.response).toContain('Sales');
-    expect(result.response).toContain('product inquiries');
+    const tool = agent.getTool('get_directions')!;
+    const result = await tool.execute({ location: 'helipad' }, {});
+    expect(result.response).toContain("don't have specific directions");
+    expect(result.response).toContain('front desk');
   });
 
-  it('prompt mentions company name', () => {
+  it('prompt mentions the venue name and services', () => {
     const agent = createAgent();
     const swml = agent.renderSwml('test-call');
-    expect(swml).toContain('Acme Corp');
+    expect(swml).toContain('Grand Hotel');
+    expect(swml).toContain('spa bookings');
   });
 
-  it('general info is included in prompt', () => {
-    const agent = createAgent({ generalInfo: 'We are a leading technology provider.' });
+  it('renders amenities as subsections', () => {
+    const agent = createAgent();
     const swml = agent.renderSwml('test-call');
-    expect(swml).toContain('leading technology provider');
+    // Python titles the amenity names; our titleCase mirrors Python str.title()
+    expect(swml).toContain('Pool');
+    expect(swml).toContain('Gym');
+    expect(swml).toContain('2nd Floor');
   });
 
-  it('department without transfer number shows not available in list', async () => {
-    const agent = createAgent();
-    const tool = agent.getTool('list_departments')!;
-    const result = await tool.execute({}, {});
-    expect(result.response).toContain('no direct transfer available');
+  it('renders hours of operation from default or custom map', () => {
+    const agent = createAgent({
+      hoursOfOperation: { weekday: '9 AM - 9 PM', weekend: '10 AM - 6 PM' },
+    });
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('Weekday');
+    expect(swml).toContain('9 AM - 9 PM');
+    expect(swml).toContain('Weekend');
   });
 
-  it('transfer_to_department connects successfully', async () => {
+  it('appends special instructions to the Instructions section', () => {
+    const agent = createAgent({
+      specialInstructions: ['Always mention the weekly wine tasting.'],
+    });
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('wine tasting');
+  });
+
+  it('welcomeMessage sets a non-bargeable static greeting', () => {
+    const agent = createAgent({
+      welcomeMessage: 'Welcome to the Grand Hotel!',
+    });
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('Welcome to the Grand Hotel!');
+    expect(swml).toContain('static_greeting_no_barge');
+  });
+
+  it('onSummary override is callable without throwing', async () => {
     const agent = createAgent();
-    const tool = agent.getTool('transfer_to_department')!;
-    const result = await tool.execute({ department_name: 'Support' }, {});
-    expect(result.response).toContain('Transferring');
-    expect(result.response).toContain('Support');
-    // Check that a SWML connect action was produced
-    const actions = result.action as Record<string, unknown>[];
-    expect(actions).toBeDefined();
-    expect(actions.length).toBeGreaterThan(0);
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await agent.onSummary({ topic: 'pool hours' }, {});
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('factory function creates agent', () => {
-    const agent = createConciergeAgent({ departments: baseDepartments });
+    const agent = createConciergeAgent({
+      venueName: 'Seaside Inn',
+      services: ['dining'],
+      amenities: { patio: { location: 'Ground Floor' } },
+    });
     expect(agent).toBeInstanceOf(ConciergeAgent);
-    expect(agent.getTool('list_departments')).toBeDefined();
+    expect(agent.getTool('check_availability')).toBeDefined();
+    expect(agent.getTool('get_directions')).toBeDefined();
   });
 });
 
@@ -685,14 +914,13 @@ describe('ConciergeAgent', () => {
 
 describe('ReceptionistAgent', () => {
   const baseDepartments = [
-    { name: 'Engineering', extension: '1001', description: 'Software development team' },
-    { name: 'Marketing', extension: '1002', description: 'Marketing and communications' },
-    { name: 'Finance', extension: '1003' },
+    { name: 'sales', description: 'Product inquiries and pricing', number: '+15551001001' },
+    { name: 'support', description: 'Technical help and troubleshooting', number: '+15551002002' },
+    { name: 'billing', description: 'Invoices and payments', number: '+15551003003' },
   ];
 
   function createAgent(overrides?: Record<string, unknown>) {
     return new ReceptionistAgent({
-      companyName: 'TechCo',
       departments: baseDepartments,
       ...overrides,
     });
@@ -711,144 +939,150 @@ describe('ReceptionistAgent', () => {
     expect(parsed.sections.main).toBeDefined();
   });
 
-  it('has get_department_list and transfer_to_department tools', () => {
+  it('registers collect_caller_info and transfer_call (Python parity)', () => {
     const agent = createAgent();
-    expect(agent.getTool('get_department_list')).toBeDefined();
-    expect(agent.getTool('transfer_to_department')).toBeDefined();
+    expect(agent.getTool('collect_caller_info')).toBeDefined();
+    expect(agent.getTool('transfer_call')).toBeDefined();
   });
 
-  it('check_in_visitor is registered by default', () => {
+  it('collect_caller_info stores caller info via set_global_data', async () => {
     const agent = createAgent();
+    const tool = agent.getTool('collect_caller_info')!;
+    const result = await tool.execute({ name: 'Alice', reason: 'billing question' }, {});
+    expect(result.response).toContain('Thank you, Alice');
+    expect(result.response).toContain('billing question');
+    const actions = result.action as Array<Record<string, unknown>>;
+    const setGlobalData = actions.find((a) => a['set_global_data'] !== undefined);
+    expect(setGlobalData).toBeDefined();
+    const payload = (setGlobalData?.['set_global_data'] as Record<string, unknown>)['caller_info'];
+    expect(payload).toEqual({ name: 'Alice', reason: 'billing question' });
+  });
+
+  it('transfer_call connects to the department phone number with final+post_process', async () => {
+    const agent = createAgent();
+    const tool = agent.getTool('transfer_call')!;
+    const rawData = { global_data: { caller_info: { name: 'Bob' } } };
+    const result = await tool.execute({ department: 'sales' }, rawData);
+    expect(result.response).toContain('sales department');
+    expect(result.response).toContain('Bob');
+    const actions = result.action as Array<Record<string, unknown>>;
+    const connectAction = actions.find((a) => a['SWML'] !== undefined);
+    expect(connectAction).toBeDefined();
+    // final=true manifests as transfer: "true"
+    expect(connectAction?.['transfer']).toBe('true');
+    // post_process flag is serialized when post_process was enabled
+    expect(result['post_process']).toBe(true);
+  });
+
+  it('transfer_call returns an error for an unknown department', async () => {
+    const agent = createAgent();
+    const tool = agent.getTool('transfer_call')!;
+    const result = await tool.execute({ department: 'nonexistent' }, {});
+    expect(result.response).toContain("couldn't find");
+  });
+
+  it('departments enum is passed to the transfer_call parameter schema', () => {
+    const agent = createAgent();
+    const swml = agent.renderSwml('test-call');
+    const parsed = JSON.parse(swml);
+    const swmlStr = JSON.stringify(parsed);
+    expect(swmlStr).toContain('"enum"');
+    expect(swmlStr).toContain('"sales"');
+    expect(swmlStr).toContain('"support"');
+  });
+
+  it('default name is lowercase "receptionist"', () => {
+    const agent = createAgent();
+    // name shows up in the SWML agent name/route surface
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('receptionist');
+  });
+
+  it('default greeting matches Python copy', () => {
+    const agent = createAgent();
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('Thank you for calling. How can I help you today?');
+  });
+
+  it('custom greeting appears in the prompt', () => {
+    const agent = createAgent({ greeting: 'Welcome to Acme!' });
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('Welcome to Acme!');
+  });
+
+  it('voice defaults to rime.spore via addLanguage', () => {
+    const agent = createAgent();
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('rime.spore');
+  });
+
+  it('custom voice is forwarded to addLanguage', () => {
+    const agent = createAgent({ voice: 'elevenlabs.rachel' });
+    const swml = agent.renderSwml('test-call');
+    expect(swml).toContain('elevenlabs.rachel');
+  });
+
+  it('route defaults to /receptionist and is forwarded to super()', () => {
+    const agent = createAgent();
+    expect(agent.route).toBe('/receptionist');
+  });
+
+  it('custom route overrides the default', () => {
+    const agent = createAgent({ route: '/front-desk' });
+    expect(agent.route).toBe('/front-desk');
+  });
+
+  it('check_in_visitor is not registered by default', () => {
+    const agent = createAgent();
+    expect(agent.getTool('check_in_visitor')).toBeUndefined();
+  });
+
+  it('check_in_visitor is registered when checkInEnabled=true', () => {
+    const agent = createAgent({ checkInEnabled: true });
     expect(agent.getTool('check_in_visitor')).toBeDefined();
   });
 
-  it('get_department_list returns departments', async () => {
-    const agent = createAgent();
-    const tool = agent.getTool('get_department_list')!;
-    const result = await tool.execute({}, {});
-    expect(result.response).toContain('Engineering');
-    expect(result.response).toContain('1001');
-    expect(result.response).toContain('Marketing');
-    expect(result.response).toContain('1002');
-    expect(result.response).toContain('Finance');
-    expect(result.response).toContain('1003');
-    expect(result.response).toContain('TechCo');
-  });
-
-  it('transfer_to_department connects to extension', async () => {
-    const agent = createAgent();
-    const tool = agent.getTool('transfer_to_department')!;
-    const result = await tool.execute({ department_name: 'Engineering' }, {});
-    expect(result.response).toContain('Transferring');
-    expect(result.response).toContain('Engineering');
-    expect(result.response).toContain('1001');
-    // Check that a SWML connect action is present
-    const actions = result.action as Record<string, unknown>[];
-    expect(actions).toBeDefined();
-    expect(actions.length).toBeGreaterThan(0);
-  });
-
-  it('transfer_to_department returns error for unknown department', async () => {
-    const agent = createAgent();
-    const tool = agent.getTool('transfer_to_department')!;
-    const result = await tool.execute({ department_name: 'Unknown' }, {});
-    expect(result.response).toContain('not found');
-    expect(result.response).toContain('Available departments');
-  });
-
-  it('check_in_visitor records visitor data', async () => {
-    const agent = createAgent();
+  it('check_in_visitor records visitor data and fires the callback', async () => {
+    const onVisitorCheckIn = vi.fn();
+    const agent = createAgent({
+      companyName: 'TechCo',
+      checkInEnabled: true,
+      onVisitorCheckIn,
+    });
     const tool = agent.getTool('check_in_visitor')!;
     const result = await tool.execute(
       { visitor_name: 'Alice Smith', purpose: 'Interview', visiting: 'Engineering' },
       { call_id: 'check-1' },
     );
-    expect(result.response).toContain('checked in successfully');
     expect(result.response).toContain('Alice Smith');
     expect(result.response).toContain('Interview');
-    expect(result.response).toContain('Engineering');
     expect(result.response).toContain('TechCo');
-  });
-
-  it('check_in_visitor absent with checkInEnabled=false', () => {
-    const agent = new ReceptionistAgent({
-      companyName: 'TechCo',
-      departments: baseDepartments,
-      checkInEnabled: false,
-    });
-    expect(agent.getTool('check_in_visitor')).toBeUndefined();
-    // Other tools still present
-    expect(agent.getTool('get_department_list')).toBeDefined();
-    expect(agent.getTool('transfer_to_department')).toBeDefined();
-  });
-
-  it('check_in_visitor present with checkInEnabled=true', () => {
-    const agent = new ReceptionistAgent({
-      companyName: 'TechCo',
-      departments: baseDepartments,
-      checkInEnabled: true,
-    });
-    expect(agent.getTool('check_in_visitor')).toBeDefined();
-  });
-
-  it('onVisitorCheckIn callback fires when visitor checks in', async () => {
-    const onVisitorCheckIn = vi.fn();
-    const agent = new ReceptionistAgent({
-      companyName: 'TechCo',
-      departments: baseDepartments,
-      onVisitorCheckIn,
-    });
-    expect(agent).toBeInstanceOf(ReceptionistAgent);
-    const tool = agent.getTool('check_in_visitor')!;
-    expect(tool).toBeDefined();
-    await tool.execute(
-      { visitor_name: 'Bob Jones', purpose: 'Meeting', visiting: 'Marketing' },
-      { call_id: 'cb-1' },
-    );
     expect(onVisitorCheckIn).toHaveBeenCalledTimes(1);
     expect(onVisitorCheckIn).toHaveBeenCalledWith(
       expect.objectContaining({
-        visitor_name: 'Bob Jones',
-        purpose: 'Meeting',
-        visiting: 'Marketing',
+        visitor_name: 'Alice Smith',
+        purpose: 'Interview',
+        visiting: 'Engineering',
       }),
     );
   });
 
-  it('prompt mentions company name', () => {
-    const agent = createAgent();
+  it('optional companyName appears in the greeting when provided', () => {
+    const agent = createAgent({ companyName: 'TechCo' });
     const swml = agent.renderSwml('test-call');
     expect(swml).toContain('TechCo');
   });
 
-  it('works without optional config', () => {
-    const agent = new ReceptionistAgent({
-      companyName: 'MinimalCo',
-      departments: [{ name: 'General', extension: '100' }],
-    });
-    expect(agent).toBeInstanceOf(ReceptionistAgent);
-    expect(agent.getTool('get_department_list')).toBeDefined();
-    expect(agent.getTool('transfer_to_department')).toBeDefined();
-    const swml = agent.renderSwml('test-call');
-    expect(swml).toContain('MinimalCo');
+  it('throws on missing department fields', () => {
+    // @ts-expect-error intentionally invalid (missing number)
+    expect(() => new ReceptionistAgent({ departments: [{ name: 'x', description: 'y' }] })).toThrow(/number/);
+    // @ts-expect-error intentionally invalid (missing description)
+    expect(() => new ReceptionistAgent({ departments: [{ name: 'x', number: '1' }] })).toThrow(/description/);
   });
 
   it('factory function creates agent', () => {
-    const agent = createReceptionistAgent({
-      companyName: 'TechCo',
-      departments: baseDepartments,
-    });
+    const agent = createReceptionistAgent({ departments: baseDepartments });
     expect(agent).toBeInstanceOf(ReceptionistAgent);
-    expect(agent.getTool('get_department_list')).toBeDefined();
-  });
-
-  it('custom welcome message appears in SWML', () => {
-    const agent = new ReceptionistAgent({
-      companyName: 'TechCo',
-      departments: baseDepartments,
-      welcomeMessage: 'Hello and welcome to TechCo headquarters!',
-    });
-    const swml = agent.renderSwml('test-call');
-    expect(swml).toContain('Hello and welcome to TechCo headquarters!');
+    expect(agent.getTool('transfer_call')).toBeDefined();
   });
 });

--- a/tests/prefabs/prefabs.test.ts
+++ b/tests/prefabs/prefabs.test.ts
@@ -161,18 +161,20 @@ describe('InfoGathererAgent', () => {
     });
     agent.setQuestionCallback(cb);
 
-    await agent.onSwmlRequest({ query_params: { mode: 'support' } });
+    const mods = await agent.onSwmlRequest({ query_params: { mode: 'support' } });
     expect(cb).toHaveBeenCalledTimes(1);
 
-    const swml = agent.renderSwml('test-call');
+    // Python parity: onSwmlRequest returns the global_data modifications dict
+    // which the framework passes to renderSwml as the second argument.
+    const swml = agent.renderSwml('test-call', mods || undefined);
     expect(swml).toContain("What's the issue?");
     expect(swml).toContain('issue');
   });
 
   it('dynamic mode: falls back to default questions when no callback is registered', async () => {
     const agent = new InfoGathererAgent();
-    await agent.onSwmlRequest({});
-    const swml = agent.renderSwml('test-call');
+    const mods = await agent.onSwmlRequest({});
+    const swml = agent.renderSwml('test-call', mods || undefined);
     expect(swml).toContain('What is your name?');
     expect(swml).toContain('How can I help you today?');
   });
@@ -182,9 +184,9 @@ describe('InfoGathererAgent', () => {
     agent.setQuestionCallback(() => {
       throw new Error('boom');
     });
-    await agent.onSwmlRequest({});
-    const swml = agent.renderSwml('test-call');
-    // Fallback questions should be injected
+    const mods = await agent.onSwmlRequest({});
+    const swml = agent.renderSwml('test-call', mods || undefined);
+    // Fallback questions should be injected via the returned modifications dict
     expect(swml).toContain('What is your name?');
   });
 
@@ -193,9 +195,9 @@ describe('InfoGathererAgent', () => {
       { key_name: 'company', question_text: 'What company?' },
     ]);
     const agent = new InfoGathererAgent({ questionCallback: cb });
-    await agent.onSwmlRequest({});
+    const mods = await agent.onSwmlRequest({});
     expect(cb).toHaveBeenCalled();
-    const swml = agent.renderSwml('test-call');
+    const swml = agent.renderSwml('test-call', mods || undefined);
     expect(swml).toContain('What company?');
   });
 
@@ -422,8 +424,8 @@ describe('SurveyAgent', () => {
     // Answer q1 first (rating)
     await tool.execute({ question_id: 'q1', answer: '7' }, callData);
 
-    // "yeah" should be normalized to "yes"
-    await tool.execute({ question_id: 'q2', answer: 'yeah' }, callData);
+    // "y" should be normalized to "yes" (matches Python's strict yes/no/y/n set)
+    await tool.execute({ question_id: 'q2', answer: 'y' }, callData);
 
     const progressTool = agent.getTool('get_survey_progress')!;
     const progress = await progressTool.execute({}, callData);
@@ -615,19 +617,21 @@ describe('FAQBotAgent', () => {
     expect(agent.getTool('escalate')).toBeUndefined();
   });
 
-  it('search_faqs returns matching FAQ', async () => {
+  it('search_faqs returns matching FAQ question (Python parity: question text only)', async () => {
     const agent = createAgent();
     const tool = agent.getTool('search_faqs')!;
     const result = await tool.execute({ query: 'What are your business hours?' }, {});
-    expect(result.response).toContain('Monday through Friday');
-    expect(result.response).toContain('9am to 5pm');
+    // Python's search_faqs returns a numbered list of matching question text.
+    // The answer text is delivered to the AI via the prompt's FAQ Database section.
+    expect(result.response).toContain('Here are the most relevant FAQs');
+    expect(result.response).toContain('business hours');
   });
 
   it('returns no-match for unrelated query', async () => {
     const agent = createAgent({ threshold: 0.5 });
     const tool = agent.getTool('search_faqs')!;
     const result = await tool.execute({ query: 'quantum physics dark matter' }, {});
-    expect(result.response).toContain('No FAQ matched');
+    expect(result.response).toBe('No matching FAQs found.');
   });
 
   it('threshold filtering works', async () => {
@@ -635,13 +639,13 @@ describe('FAQBotAgent', () => {
     const agent = createAgent({ threshold: 0.99 });
     const tool = agent.getTool('search_faqs')!;
     const result = await tool.execute({ query: 'hours open' }, {});
-    expect(result.response).toContain('No FAQ matched');
+    expect(result.response).toBe('No matching FAQs found.');
 
     // Low threshold makes it easy to match
     const agent2 = createAgent({ threshold: 0.01 });
     const tool2 = agent2.getTool('search_faqs')!;
     const result2 = await tool2.execute({ query: 'hours open' }, {});
-    expect(result2.response).toContain('FAQ Match');
+    expect(result2.response).toContain('Here are the most relevant FAQs');
   });
 
   it('category filter narrows the FAQ pool', async () => {
@@ -719,12 +723,13 @@ describe('FAQBotAgent', () => {
     expect(actions.length).toBeGreaterThan(0);
   });
 
-  it('search_faqs includes escalation message when no match', async () => {
-    const agent = createAgent({ escalationMessage: 'Please hold for an agent.' });
+  it('search_faqs returns Python no-match message when query has no relevant FAQ', async () => {
+    const agent = createAgent();
     const tool = agent.getTool('search_faqs')!;
     const result = await tool.execute({ query: 'completely unrelated topic xyz' }, {});
-    // The escalation message is included in the no-match response
-    expect(result.response).toContain('No FAQ matched');
+    // Python parity: response is exactly "No matching FAQs found." regardless
+    // of any escalation configuration on the TS side.
+    expect(result.response).toBe('No matching FAQs found.');
   });
 
   it('keywords improve matching', async () => {
@@ -733,8 +738,8 @@ describe('FAQBotAgent', () => {
 
     // Query using keywords that match the password FAQ
     const result = await tool.execute({ query: 'forgot password reset' }, {});
-    expect(result.response).toContain('FAQ Match');
-    expect(result.response).toContain('Forgot Password');
+    expect(result.response).toContain('Here are the most relevant FAQs');
+    expect(result.response).toContain('How do I reset my password?');
   });
 
   it('prompt mentions FAQ topics', () => {


### PR DESCRIPTION
## What this PR does

Aligns all 5 prefab agents with Python — 48 gaps. Some of these required replacing the existing TS domain model with Python's (e.g. ConciergeAgent went from corporate-router to venue-concierge).

## Changes

**ConciergeAgent (14 P1):** Replaced corporate-router domain with Python venue-concierge. Added `venueName`, `services`, `amenities`, `hoursOfOperation`, `specialInstructions`, `welcomeMessage`. Tools: `check_availability`, `get_directions`. `onSummary` override.

**FAQBotAgent (9 gaps):** Added `suggestRelated`, `persona`, first-class `route`, `category` filter param, `onSummary`. Added `categories` to `FAQEntry`. Renamed tool `search_faq` → `search_faqs`. Added Python prompt sections, post-prompt, hints, global data, native functions.

**SurveyAgent (8 gaps):** Added required `surveyName`; `brandName`, `maxRetries`, `scale`, `required` fields. Renamed `introMessage`→`introduction`, `completionMessage`→`conclusion`. Added `validate_response` + `log_response` SWAIG tools. `onSummary` override.

**InfoGathererAgent (8 gaps):** Full rewrite to Python sequential index-driven model. Replaced `InfoGathererField` with `InfoGathererQuestion` (key_name/question_text/confirm). Added `setQuestionCallback` and `onSwmlRequest` override for dynamic mode. Replaced `save_field`/`get_status` with `start_questions`/`submit_answer`. State now in `global_data`.

**ReceptionistAgent (7 gaps):** Added `route` default `/receptionist`, `voice` default `rime.spore` (with `addLanguage`), `collect_caller_info` tool. Renamed `extension`→`number`, `welcomeMessage`→`greeting`, `transfer_to_department`→`transfer_call` with `post_process=true + final=true`. Lowercased default name.

## Verification

- `npm run build` passes
- 1463/1463 tests pass

## Breaking changes

This PR intentionally replaces some TS-domain-model APIs with Python's domain model to achieve behavioral parity:
- ConciergeAgent: corporate router → venue concierge (different tool surface)
- FAQBotAgent: `search_faq` → `search_faqs` rename
- SurveyAgent: `introMessage`/`completionMessage` → `introduction`/`conclusion`
- InfoGathererAgent: field-based → question-based (incompatible config shape)
- ReceptionistAgent: `extension` → `number`, `welcomeMessage` → `greeting`, `transfer_to_department` → `transfer_call`

Existing consumer code will need to update to the new shapes.

Closes #19
Closes #25
Closes #32
Closes #45
Closes #58