### PR TITLE
docs: add DevEx-focused JSDoc across public SDK surface

### DIFF
--- a/src/AgentBase.ts
+++ b/src/AgentBase.ts
@@ -46,6 +46,63 @@ export type RoutingCallback = (
 /**
  * Core agent class that composes an HTTP server, prompt management, session handling,
  * SWAIG tool registry, and 5-phase SWML rendering into a single deployable unit.
+ *
+ * A single `AgentBase` is one HTTP-servable voice agent:
+ *
+ * - `GET /` returns the SWML call-flow document
+ * - `POST /swaig` dispatches SWAIG function calls to registered tool handlers
+ * - `POST /post_prompt` receives the end-of-call summary and invokes {@link onSummary}
+ *
+ * Most user agents either (a) subclass `AgentBase` and override `defineTools()` / `onSummary()`
+ * or (b) use one of the {@link ./prefabs/index.js | prefab agents} (e.g. `ReceptionistAgent`).
+ *
+ * @example Subclass with a custom tool
+ * ```ts
+ * import { AgentBase, FunctionResult } from '@signalwire/sdk';
+ *
+ * class WeatherAgent extends AgentBase {
+ *   static override PROMPT_SECTIONS = [
+ *     { title: 'Role', body: 'You are a weather assistant.' },
+ *   ];
+ *
+ *   protected override defineTools(): void {
+ *     this.defineTool({
+ *       name: 'get_forecast',
+ *       description: 'Return the forecast for a city.',
+ *       parameters: {
+ *         type: 'object',
+ *         properties: { city: { type: 'string' } },
+ *         required: ['city'],
+ *       },
+ *       handler: async ({ city }) => {
+ *         const forecast = await fetchForecast(city as string);
+ *         return new FunctionResult(forecast);
+ *       },
+ *     });
+ *   }
+ * }
+ *
+ * const agent = new WeatherAgent({ name: 'weather', route: '/' });
+ * await agent.serve({ port: 3000 });
+ * ```
+ *
+ * @example Imperative usage (no subclass)
+ * ```ts
+ * const agent = new AgentBase({ name: 'hello', route: '/' });
+ * agent.setPromptText('You are a friendly greeter.');
+ * agent.defineTool({
+ *   name: 'say_hi',
+ *   description: 'Respond with a greeting.',
+ *   parameters: { type: 'object', properties: {} },
+ *   handler: () => new FunctionResult('Hello from SignalWire!'),
+ * });
+ * await agent.serve();
+ * ```
+ *
+ * @see {@link FunctionResult} — builder for tool handler responses
+ * @see {@link ContextBuilder} — multi-step conversation state machines
+ * @see {@link DataMap} — server-side tools without webhooks
+ * @see {@link AgentServer} — host multiple agents on one HTTP server
  */
 export class AgentBase {
   /** Display name of this agent. */
@@ -1495,8 +1552,24 @@ export class AgentBase {
 
   /**
    * Set a callback invoked on each SWML request to dynamically modify an ephemeral agent copy.
-   * @param cb - The dynamic configuration callback.
+   *
+   * The callback receives a clone of this agent — mutations apply only to the current
+   * request, so you can vary prompt, tools, languages, params, or global data per call
+   * without affecting the long-lived agent instance.
+   *
+   * @param cb - Callback receiving `(queryParams, bodyParams, headers, agent)` where
+   *   `agent` is the ephemeral `AgentBase` copy to mutate. May be async.
    * @returns This agent instance for chaining.
+   *
+   * @example
+   * ```ts
+   * agent.setDynamicConfigCallback((query, body, headers, agent) => {
+   *   const lang = query.lang ?? 'en';
+   *   if (lang === 'es') {
+   *     (agent as AgentBase).setPromptText('Eres un asistente útil.');
+   *   }
+   * });
+   * ```
    */
   setDynamicConfigCallback(cb: DynamicConfigCallback): this {
     this.dynamicConfigCallback = cb;
@@ -1667,8 +1740,29 @@ export class AgentBase {
 
   /**
    * Lifecycle hook called when a post-prompt summary is received. Override in subclasses.
-   * @param _summary - Parsed summary object, or null if extraction failed.
-   * @param _rawData - The full raw post-prompt payload.
+   *
+   * Invoked once at the end of a call when the AI has produced a structured summary
+   * (configured via `setPostPrompt()` / `setPostPromptJson()`). Use this hook to persist
+   * call data, notify other systems, or trigger follow-up workflows.
+   *
+   * @param _summary - Parsed summary object (JSON when the post-prompt requests
+   *   structured output), or `null` if extraction/parsing failed.
+   * @param _rawData - Full raw post-prompt payload received from the platform,
+   *   including call metadata, conversation history, and the summary text.
+   *
+   * @example
+   * ```ts
+   * class MyAgent extends AgentBase {
+   *   async onSummary(summary, rawData) {
+   *     if (!summary) return;
+   *     await db.calls.insert({
+   *       callSid: rawData.call_id,
+   *       summary,
+   *       endedAt: new Date(),
+   *     });
+   *   }
+   * }
+   * ```
    */
   onSummary(_summary: Record<string, unknown> | null, _rawData: Record<string, unknown>): void | Promise<void> {
     // Default no-op
@@ -2363,7 +2457,22 @@ export class AgentBase {
 
   /**
    * Start the HTTP server and begin listening for requests.
-   * @returns A promise that resolves once the server is running.
+   *
+   * Uses `@hono/node-server` under the hood. When run in CLI mode
+   * (`SWAIG_CLI_MODE=true`, set automatically by `npx swaig-test`), this is a
+   * no-op so agent config can be inspected without starting a server.
+   *
+   * @param opts - Optional host/port overrides. Defaults to the values provided
+   *   in the constructor options or the `PORT` environment variable.
+   * @returns A promise that resolves once the server has begun listening.
+   *
+   * @example
+   * ```ts
+   * const agent = new AgentBase({ name: 'demo', port: 3000 });
+   * await agent.serve();
+   * // Or override at runtime:
+   * await agent.serve({ port: 8080, host: '127.0.0.1' });
+   * ```
    */
   async serve(opts?: { host?: string; port?: number }): Promise<void> {
     // When loaded by the CLI tool, skip server startup — only the agent config is needed.

--- a/src/AgentServer.ts
+++ b/src/AgentServer.ts
@@ -44,7 +44,29 @@ const MIME_TYPES: Record<string, string> = {
   '.gz': 'application/gzip',
 };
 
-/** Multi-agent HTTP server that hosts multiple AgentBase instances on distinct route prefixes. */
+/**
+ * Multi-agent HTTP server that hosts multiple AgentBase instances on distinct route prefixes.
+ *
+ * Use `AgentServer` when one process should serve more than one agent — each with its own
+ * prompt, tools, and route. Internally, each agent's Hono router is mounted under its own
+ * path. Static assets can also be served from a configured directory.
+ *
+ * @example Host two agents on one port
+ * ```ts
+ * import { AgentServer, AgentBase } from '@signalwire/sdk';
+ *
+ * const salesAgent = new AgentBase({ name: 'sales', route: '/sales' });
+ * const supportAgent = new AgentBase({ name: 'support', route: '/support' });
+ *
+ * const server = new AgentServer({ host: '0.0.0.0', port: 3000 });
+ * server.register(salesAgent);
+ * server.register(supportAgent);
+ *
+ * await server.run();
+ * ```
+ *
+ * @see {@link AgentBase}
+ */
 export class AgentServer {
   /** Hostname the server binds to. */
   host: string;

--- a/src/AgentServer.ts
+++ b/src/AgentServer.ts
@@ -407,10 +407,15 @@ export class AgentServer {
    *
    * This method handles server mode only. For serverless deployments
    * (AWS Lambda, Google Cloud Functions, Azure Functions), use
-   * {@link ServerlessAdapter} instead.
+   * {@link ServerlessAdapter} instead. When `SWAIG_CLI_MODE=true` is set in
+   * the environment, the call is a no-op so agent config can be inspected
+   * without starting a server.
    *
-   * @param host - Override the configured hostname.
-   * @param port - Override the configured port.
+   * @param host - Override the configured hostname. Defaults to the
+   *   constructor value.
+   * @param port - Override the configured port. Defaults to the constructor
+   *   value.
+   * @returns Resolves once the underlying Hono server has begun listening.
    */
   async run(host?: string, port?: number): Promise<void> {
     // When loaded by the CLI tool, skip server startup — only the agent config is needed.

--- a/src/ContextBuilder.ts
+++ b/src/ContextBuilder.ts
@@ -984,8 +984,12 @@ export class ContextBuilder {
 
   /**
    * Adds a new named context to the builder.
-   * @param name - The unique context name.
-   * @returns The newly created Context for further configuration.
+   *
+   * @param name - The unique context name. A single-context flow must name
+   *   its only context `"default"`.
+   * @returns The newly created {@link Context} for further configuration.
+   * @throws {Error} When the max-context limit is exceeded or a context with
+   *   the same name already exists.
    */
   addContext(name: string): Context {
     if (this.contexts.size >= MAX_CONTEXTS) {

--- a/src/ContextBuilder.ts
+++ b/src/ContextBuilder.ts
@@ -926,6 +926,33 @@ export class Context {
  *   - gather_info questions are non-empty and have unique keys
  *   - gather_info completion_action targets a reachable step
  *   - No user-defined SWAIG tool collides with a reserved native name
+ *
+ * @example Two-step support bot
+ * ```ts
+ * import { AgentBase, ContextBuilder } from '@signalwire/sdk';
+ *
+ * const agent = new AgentBase({ name: 'support', route: '/' });
+ *
+ * const contexts = new ContextBuilder();
+ * const flow = contexts.addContext('default');
+ *
+ * flow.addStep('greeting')
+ *   .setText("Greet the caller and ask if they're an existing customer.")
+ *   .setValidSteps(['existing', 'new']);
+ *
+ * flow.addStep('existing')
+ *   .setText('Ask for the account number and read it back to confirm.');
+ *
+ * flow.addStep('new')
+ *   .setText('Collect name, email, and reason for calling.');
+ *
+ * agent.defineContexts(contexts);
+ * ```
+ *
+ * @see {@link Context}
+ * @see {@link Step}
+ * @see {@link GatherInfo}
+ * @see {@link AgentBase.defineContexts}
  */
 export class ContextBuilder {
   private contexts: Map<string, Context> = new Map();

--- a/src/DataMap.ts
+++ b/src/DataMap.ts
@@ -60,8 +60,36 @@ function expandEnvInObject(obj: unknown, allowedPrefixes: string[]): unknown {
 /**
  * Fluent builder for SWAIG data_map configurations.
  *
- * Creates server-side tool definitions that execute on SignalWire
- * without requiring webhook endpoints.
+ * Creates server-side tool definitions that execute on SignalWire's infrastructure
+ * **without** requiring a webhook endpoint in your application. Ideal for simple
+ * third-party API integrations (REST calls + pattern-matched response shaping).
+ *
+ * @example Simple webhook-driven tool (no handler needed)
+ * ```ts
+ * import { DataMap, FunctionResult } from '@signalwire/sdk';
+ *
+ * const weather = new DataMap('get_weather')
+ *   .purpose('Look up the current weather for a city')
+ *   .parameter('city', 'string', 'The city name', true)
+ *   .webhook('GET', 'https://api.example.com/weather?city=${args.city}')
+ *   .output(new FunctionResult('In ${city} it is ${response.temp}°F and ${response.condition}.'));
+ *
+ * // Register onto an agent:
+ * agent.registerSwaigFunction(weather.toSwaigFunction());
+ * ```
+ *
+ * @example Expression-based tool (no webhook, pattern matching only)
+ * ```ts
+ * new DataMap('classify_intent')
+ *   .purpose('Route callers to the right department.')
+ *   .parameter('utterance', 'string', 'What the caller said', true)
+ *   .expression('${args.utterance}', /billing|invoice|charge/i, new FunctionResult('billing'))
+ *   .expression('${args.utterance}', /tech|broken|error/i, new FunctionResult('support'));
+ * ```
+ *
+ * @see {@link FunctionResult} — response shape used in `.output()` / `.expression()`
+ * @see {@link createSimpleApiTool} — one-liner helper for REST API tools
+ * @see {@link AgentBase.defineTool} — alternative for tools that run in your process
  */
 export class DataMap {
   /** The name of the SWAIG function this data map defines. */

--- a/src/FunctionResult.ts
+++ b/src/FunctionResult.ts
@@ -36,8 +36,42 @@ export interface PaymentParameter {
 /**
  * Builder for SWAIG function responses.
  *
- * Carries response text and a list of structured actions (connect, hangup, SMS, etc.).
- * Every mutating method returns `this` for fluent chaining.
+ * Carries response text (what the AI says to the caller) and a list of structured
+ * actions (connect, hangup, SMS, record, transfer, etc.) that the SignalWire platform
+ * executes after the AI speaks. Every mutating method returns `this` for fluent chaining.
+ *
+ * Return an instance (or a promise that resolves to one) from any SWAIG tool handler.
+ *
+ * @example Simple text response
+ * ```ts
+ * agent.defineTool({
+ *   name: 'say_hi',
+ *   description: 'Say hello.',
+ *   parameters: { type: 'object', properties: {} },
+ *   handler: () => new FunctionResult('Hello there!'),
+ * });
+ * ```
+ *
+ * @example Response plus a call-control action
+ * ```ts
+ * agent.defineTool({
+ *   name: 'transfer_to_sales',
+ *   description: 'Forward the caller to sales.',
+ *   parameters: { type: 'object', properties: {} },
+ *   handler: () =>
+ *     new FunctionResult('Connecting you to sales now.').connect('+15551112222'),
+ * });
+ * ```
+ *
+ * @example Chained actions
+ * ```ts
+ * new FunctionResult("Thanks, you're all set.")
+ *   .sendSms({ toNumber: '+15551234567', fromNumber: '+15559998888', body: 'Confirmation!' })
+ *   .hangup();
+ * ```
+ *
+ * @see {@link AgentBase.defineTool} — where handlers return a `FunctionResult`
+ * @see {@link DataMap} — alternative for purely data-driven (no handler) tools
  */
 export class FunctionResult {
   /** The text response returned to the AI agent. */

--- a/src/FunctionResult.ts
+++ b/src/FunctionResult.ts
@@ -477,8 +477,11 @@ export class FunctionResult {
 
   /**
    * Send an SMS or MMS message from within the call flow.
-   * @param opts - SMS parameters including to/from numbers and body or media.
+   *
+   * @param opts - SMS parameters. Must include either `body` (text SMS) or
+   *   `media` (MMS) — supplying neither throws.
    * @returns This instance for chaining.
+   * @throws {Error} When neither `body` nor `media` is provided.
    */
   sendSms(opts: {
     toNumber: string;

--- a/src/PomBuilder.ts
+++ b/src/PomBuilder.ts
@@ -201,7 +201,35 @@ export class PomSection {
   }
 }
 
-/** Builds a structured prompt by composing named POM sections, with Markdown and dict export. */
+/**
+ * Builds a structured prompt by composing named POM sections, with Markdown and dict export.
+ *
+ * The Prompt Object Model lets you assemble a large system prompt from reusable,
+ * named sections (Role, Objective, Constraints, etc.) instead of a single string.
+ * This plays well with {@link AgentBase} methods like `promptAddSection()` and
+ * `promptAddToSection()` that let user code and skills add prompt content
+ * incrementally.
+ *
+ * @example Build a structured prompt
+ * ```ts
+ * import { PomBuilder } from '@signalwire/sdk';
+ *
+ * const pom = new PomBuilder()
+ *   .addSection('Role', { body: 'You are a friendly customer service agent.' })
+ *   .addSection('Objectives', { bullets: [
+ *     'Identify the customer politely',
+ *     'Resolve their issue in under 3 turns if possible',
+ *   ]})
+ *   .addSection('Constraints', { bullets: [
+ *     'Never reveal internal tool names',
+ *   ]});
+ *
+ * const systemPrompt = pom.renderMarkdown();
+ * ```
+ *
+ * @see {@link PomSection}
+ * @see {@link AgentBase.promptAddSection}
+ */
 export class PomBuilder {
   private sections: PomSection[] = [];
   private sectionMap: Map<string, PomSection> = new Map();

--- a/src/SWMLService.ts
+++ b/src/SWMLService.ts
@@ -666,11 +666,20 @@ export class SWMLService {
 
   /**
    * Start the HTTP server.
-   * Matches Python's `serve()` parameters including SSL options.
    *
-   * @param host - Hostname (default: this.host or '0.0.0.0').
-   * @param port - Port (default: this.port or 3000).
+   * Matches Python's `serve()` parameters including SSL options. When
+   * `SWAIG_CLI_MODE=true` is set in the environment (e.g. while running the
+   * `swaig-test` CLI) the call is a no-op.
+   *
+   * @param host - Hostname. Defaults to `this.host` (constructor value) or
+   *   `'0.0.0.0'`.
+   * @param port - Port. Defaults to `this.port` (constructor value) or `3000`.
    * @param opts - Optional SSL/TLS configuration overrides.
+   * @param opts.sslCert - Path to the PEM certificate file.
+   * @param opts.sslKey - Path to the PEM private key file.
+   * @param opts.sslEnabled - When `true`, serve over HTTPS.
+   * @param opts.domain - Domain used for HSTS header configuration.
+   * @returns Resolves once the server has begun listening.
    */
   async run(
     host?: string,
@@ -716,11 +725,12 @@ export class SWMLService {
   }
 
   /**
-   * Start the HTTP server. Alias for `run()` provided for cross-SDK
+   * Start the HTTP server. Alias for {@link run} provided for cross-SDK
    * consistency with Python's `serve()` method — callers porting from
    * Python can use this name without changes.
    *
-   * All parameters are forwarded unchanged to `run()`.
+   * @param args - Forwarded unchanged to {@link run}.
+   * @returns Resolves once the server has begun listening.
    */
   async serve(...args: Parameters<SWMLService['run']>): Promise<void> {
     return this.run(...args);

--- a/src/SWMLService.ts
+++ b/src/SWMLService.ts
@@ -174,7 +174,29 @@ export interface SWMLServiceOptions {
 
 // ── SWMLService class ──────────────────────────────────────────────────
 
-/** HTTP service that serves non-AI SWML documents built from verb methods. */
+/**
+ * HTTP service that serves non-AI SWML documents built from verb methods.
+ *
+ * Use `SWMLService` when you need a SignalWire call flow but don't need AI —
+ * plain call routing, IVR-style trees, recording workflows, static playback, etc.
+ * For AI-powered voice agents, use {@link AgentBase} instead.
+ *
+ * @example Static greeting that plays a file and hangs up
+ * ```ts
+ * import { SWMLService } from '@signalwire/sdk';
+ *
+ * const service = new SWMLService({ name: 'greeter', route: '/', port: 3000 });
+ * service.builder
+ *   .answer()
+ *   .play({ url: 'https://cdn.example.com/welcome.mp3' })
+ *   .hangup();
+ *
+ * await service.serve();
+ * ```
+ *
+ * @see {@link SwmlBuilder} — the underlying SWML document builder
+ * @see {@link AgentBase} — AI-powered alternative
+ */
 export class SWMLService {
   /** Service display name. */
   readonly name: string;

--- a/src/ServerlessAdapter.ts
+++ b/src/ServerlessAdapter.ts
@@ -42,7 +42,26 @@ export interface ServerlessResponse {
   body: string;
 }
 
-/** Adapts a Hono application for deployment on AWS Lambda, Google Cloud Functions, Azure Functions, or CGI. */
+/**
+ * Adapts a Hono application for deployment on AWS Lambda, Google Cloud Functions, Azure Functions, or CGI.
+ *
+ * Accepts the provider's native event shape (`APIGatewayProxyEvent`, Google Functions `Request`,
+ * Azure function arguments, CGI env + stdin) and returns a provider-native response.
+ *
+ * @example AWS Lambda handler
+ * ```ts
+ * import { AgentBase, ServerlessAdapter } from '@signalwire/sdk';
+ *
+ * const agent = new AgentBase({ name: 'lambda', route: '/' });
+ * agent.setPromptText('You are a helpful assistant.');
+ *
+ * const adapter = new ServerlessAdapter('aws');
+ *
+ * export const handler = async (event: any) => {
+ *   return adapter.handleRequest(agent.asRouter(), event);
+ * };
+ * ```
+ */
 export class ServerlessAdapter {
   private platform: ServerlessPlatform;
 

--- a/src/SwmlBuilder.ts
+++ b/src/SwmlBuilder.ts
@@ -29,7 +29,32 @@ export interface SwmlBuilderOptions {
   schemaPath?: string;
 }
 
-/** Builds SWML documents composed of verb instructions organized into named sections. */
+/**
+ * Builds SWML documents composed of verb instructions organized into named sections.
+ *
+ * Verb methods (`.answer()`, `.play()`, `.hangup()`, `.transfer()`, etc.) are
+ * auto-installed from the bundled SWML schema and all return `this` for fluent chaining.
+ *
+ * Most users don't instantiate `SwmlBuilder` directly — `AgentBase` uses it internally
+ * and exposes higher-level helpers. Use this class directly for `SWMLService` (non-AI
+ * call flows) or to hand-craft SWML returned from a route handler.
+ *
+ * @example Simple SWML document
+ * ```ts
+ * import { SwmlBuilder } from '@signalwire/sdk';
+ *
+ * const swml = new SwmlBuilder()
+ *   .answer()
+ *   .play({ url: 'https://cdn.example.com/greeting.mp3' })
+ *   .hangup()
+ *   .build();
+ *
+ * // swml is JSON ready to return from a SignalWire webhook.
+ * ```
+ *
+ * @see {@link SWMLService} — HTTP service that serves a built SWML document
+ * @see {@link AgentBase} — for AI-driven call flows
+ */
 export class SwmlBuilder {
   private _document: { version: string; sections: Record<string, unknown[]> };
   private static _schemaUtils: SchemaUtils | null = null;

--- a/src/TypeInference.ts
+++ b/src/TypeInference.ts
@@ -30,7 +30,10 @@ export interface InferredSchema {
  * Parse function parameter names and default values from source code.
  *
  * Handles arrow functions, regular functions, and method shorthand.
- * Returns an array of { name, defaultValue? } objects.
+ *
+ * @param source - The function source text, typically from `fn.toString()`.
+ * @returns An array of `{ name, defaultValue? }` records in declaration order.
+ *   Returns an empty array if no parameter list is present.
  */
 export function parseFunctionParams(source: string): ParsedParam[] {
   // Extract the parameter list between the first set of parens
@@ -91,12 +94,19 @@ function extractParamName(expr: string): string {
 /**
  * Infer a JSON Schema from a function's parameters.
  *
- * Returns null if the function appears to be an old-style `(args, rawData)` handler.
- * Otherwise, extracts parameter names and infers types from default values:
- * - Number literals → "integer" (for integers) or "number" (for floats)
- * - String literals → "string"
- * - Boolean literals → "boolean"
- * - No default → "string" (and marked required)
+ * Extracts parameter names and infers JSON Schema types from default-value
+ * literals:
+ *
+ * - Number literals → `"integer"` (whole numbers) or `"number"` (decimals)
+ * - String literals → `"string"`
+ * - Boolean literals → `"boolean"`
+ * - No default → `"string"` (and the parameter is marked required)
+ *
+ * @param fn - The function to inspect. Arrow functions, regular functions, and
+ *   method shorthand all work.
+ * @returns An {@link InferredSchema} describing the parameters, or `null` when
+ *   the function looks like an old-style `(args, rawData)` SWAIG handler (in
+ *   which case no inference is attempted).
  */
 export function inferSchema(fn: Function): InferredSchema | null {
   const source = fn.toString();
@@ -163,8 +173,16 @@ function inferTypeFromDefault(defaultValue?: string): string {
  * Create a wrapper function that adapts a typed handler to the standard
  * `(args, rawData) => result` SWAIG handler signature.
  *
- * The wrapper extracts named parameters from the args dict and passes
- * them as positional arguments to the original function.
+ * The wrapper extracts named parameters from the args dict and passes them
+ * as positional arguments to the original function.
+ *
+ * @param fn - The typed handler whose parameters match `paramNames` in order.
+ * @param paramNames - Ordered list of parameter names extracted from `fn`,
+ *   produced by {@link inferSchema}.
+ * @param hasRawData - When `true`, the raw-data record is appended as the
+ *   final positional argument to mirror the old-style handler shape.
+ * @returns A {@link SwaigHandler} suitable for registration with
+ *   {@link AgentBase.defineTool}.
  */
 export function createTypedHandlerWrapper(
   fn: Function,

--- a/src/WebService.ts
+++ b/src/WebService.ts
@@ -237,10 +237,15 @@ export class WebService {
 
   /**
    * Start the HTTP(S) service.
-   * @param host - Bind address. Default: '0.0.0.0'.
-   * @param port - Port override. Default: this.port.
-   * @param sslCert - Path to SSL certificate file (overrides SslConfig).
-   * @param sslKey - Path to SSL key file (overrides SslConfig).
+   *
+   * When `SWAIG_CLI_MODE=true` is set in the environment, the call is a
+   * no-op so config can be inspected without binding a port.
+   *
+   * @param host - Bind address. Defaults to `'0.0.0.0'`.
+   * @param port - Port override. Defaults to `this.port`.
+   * @param sslCert - Path to SSL certificate file (overrides `SslConfig`).
+   * @param sslKey - Path to SSL key file (overrides `SslConfig`).
+   * @returns Resolves once the server has begun listening.
    */
   async start(
     host?: string,

--- a/src/WebService.ts
+++ b/src/WebService.ts
@@ -98,7 +98,24 @@ function formatSize(bytes: number): string {
  *
  * Provides configurable static file hosting with per-route directory mounting,
  * extension filtering, file size limits, HTTP Basic Auth, CORS, directory
- * browsing, and optional SSL/TLS. Mirrors the Python SDK's WebService class.
+ * browsing, and optional SSL/TLS. Mirrors the Python SDK's `WebService` class.
+ *
+ * Useful when an agent or prefab needs to serve supporting assets — prompts, audio
+ * files, images — from the same process without running a separate nginx / CDN.
+ *
+ * @example Serve a directory of audio files
+ * ```ts
+ * import { WebService } from '@signalwire/sdk';
+ *
+ * const web = new WebService({
+ *   port: 8080,
+ *   directories: { '/audio': './public/audio' },
+ *   allowedExtensions: ['.mp3', '.wav'],
+ * });
+ *
+ * await web.serve();
+ * // GET http://host:8080/audio/greeting.mp3
+ * ```
  */
 export class WebService {
   /** Port the service binds to. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,60 @@
 /**
- * SignalWire AI Agents SDK for TypeScript
+ * SignalWire AI Agents SDK for TypeScript / Node.js.
  *
- * Build AI voice agents as HTTP microservices that serve SWML documents
- * and handle SWAIG function callbacks.
+ * Build AI voice agents as HTTP microservices that serve
+ * [SWML](https://developer.signalwire.com/sdks/reference/swml/) documents
+ * and handle SWAIG function callbacks from the SignalWire platform.
+ *
+ * @example Minimal agent
+ * ```ts
+ * import { AgentBase, FunctionResult } from '@signalwire/sdk';
+ *
+ * const agent = new AgentBase({ name: 'simple', route: '/' });
+ *
+ * agent.setPromptText("You are a helpful assistant.");
+ *
+ * agent.defineTool({
+ *   name: 'get_time',
+ *   description: 'Return the current server time.',
+ *   parameters: { type: 'object', properties: {} },
+ *   handler: () => new FunctionResult(`Time is ${new Date().toISOString()}`),
+ * });
+ *
+ * await agent.serve({ port: 3000 });
+ * ```
+ *
+ * @example Pre-built agent (prefab)
+ * ```ts
+ * import { ReceptionistAgent } from '@signalwire/sdk';
+ *
+ * const receptionist = new ReceptionistAgent({
+ *   name: 'front-desk',
+ *   departments: [
+ *     { name: 'sales', description: 'New customers', number: '+15551112222' },
+ *     { name: 'support', description: 'Existing customers', number: '+15553334444' },
+ *   ],
+ * });
+ *
+ * await receptionist.serve({ port: 3000 });
+ * ```
+ *
+ * @example REST API client
+ * ```ts
+ * import { RestClient } from '@signalwire/sdk';
+ *
+ * const client = new RestClient(); // reads SIGNALWIRE_* env vars
+ * const calls = await client.compat.calls.list();
+ * ```
+ *
+ * @see {@link AgentBase} — core agent class
+ * @see {@link FunctionResult} — fluent builder for SWAIG tool responses
+ * @see {@link ContextBuilder} — multi-step conversation workflows
+ * @see {@link DataMap} — server-side tools (no webhook infrastructure required)
+ * @see {@link SkillBase} — base class for writing custom skills
+ * @see {@link RelayClient} — real-time WebSocket call/message control
+ * @see {@link RestClient} — typed HTTP access to SignalWire platform APIs
+ *
+ * @packageDocumentation
  */
 
 // Core agent

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,8 +192,18 @@ import type { AgentBase as _AgentBase } from './AgentBase.js';
  *
  * Equivalent to Python's `start_agent(agent)`. Delegates to `agent.serve(options)`.
  *
- * @param agent   The AgentBase instance to start.
- * @param options Optional host/port overrides.
+ * @param agent - The {@link AgentBase} instance to start.
+ * @param options - Optional host / port overrides. When omitted, values come
+ *   from the agent's constructor options or the `PORT` environment variable.
+ * @returns Resolves once the HTTP server has begun listening.
+ *
+ * @example
+ * ```ts
+ * import { AgentBase, startAgent } from '@signalwire/sdk';
+ *
+ * const agent = new AgentBase({ name: 'demo' });
+ * await startAgent(agent, { port: 3000 });
+ * ```
  */
 export async function startAgent(
   agent: _AgentBase,
@@ -208,8 +218,12 @@ export async function startAgent(
  * Alias for {@link startAgent} — equivalent to Python's `run_agent(agent)`.
  * Delegates to `agent.serve(options)`.
  *
- * @param agent   The AgentBase instance to run.
- * @param options Optional host/port overrides.
+ * @param agent - The {@link AgentBase} instance to run.
+ * @param options - Optional host / port overrides. When omitted, values come
+ *   from the agent's constructor options or the `PORT` environment variable.
+ * @returns Resolves once the HTTP server has begun listening.
+ *
+ * @see {@link startAgent}
  */
 export async function runAgent(
   agent: _AgentBase,

--- a/src/livewire/index.ts
+++ b/src/livewire/index.ts
@@ -117,7 +117,32 @@ export interface FunctionTool {
 // Agent
 // ---------------------------------------------------------------------------
 
-/** Mirrors a LiveKit voice.Agent -- holds instructions and tool definitions. */
+/**
+ * Mirrors a LiveKit `voice.Agent` — holds instructions and tool definitions.
+ *
+ * Pipeline options (`stt`, `tts`, `vad`, `llm`, `turnDetection`) are accepted
+ * for API parity but are **no-ops** — SignalWire's control plane handles the
+ * entire AI pipeline server-side. Set instructions and tools; everything else
+ * just logs once and continues.
+ *
+ * @example Minimal LiveKit-compatible agent
+ * ```ts
+ * import { livewire } from '@signalwire/sdk';
+ *
+ * const timeTool = livewire.tool({
+ *   description: 'Return the current time.',
+ *   execute: () => new Date().toISOString(),
+ * });
+ *
+ * const agent = new livewire.Agent({
+ *   instructions: 'You are a friendly helper.',
+ *   tools: [{ ...timeTool, name: 'time' }],
+ * });
+ *
+ * const session = new livewire.AgentSession();
+ * await session.start({ agent });
+ * ```
+ */
 export class Agent<UserData = any> {
   instructions: string;
   tools: Record<string, FunctionTool>;
@@ -278,7 +303,10 @@ export class Agent<UserData = any> {
 // RunContext
 // ---------------------------------------------------------------------------
 
-/** Mirrors a LiveKit RunContext -- available inside tool handlers. */
+/**
+ * Mirrors a LiveKit `RunContext` — passed to tool handlers so they can
+ * read the current session, call handle, and user data.
+ */
 export class RunContext<UserData = any> {
   session?: AgentSession<UserData>;
   speechHandle?: unknown;
@@ -302,7 +330,13 @@ export class RunContext<UserData = any> {
 // AgentSession
 // ---------------------------------------------------------------------------
 
-/** Mirrors a LiveKit AgentSession -- binds an Agent to SignalWire. */
+/**
+ * Mirrors a LiveKit `AgentSession` — binds an {@link Agent} to SignalWire.
+ *
+ * Call {@link AgentSession.start} with an `Agent` to construct an internal
+ * {@link AgentBase} and begin serving SWML. Pipeline-related options are
+ * accepted for API parity but are no-ops server-side.
+ */
 export class AgentSession<UserData = any> {
   private _llm: any;
   private _tools: FunctionTool[];

--- a/src/livewire/index.ts
+++ b/src/livewire/index.ts
@@ -39,6 +39,10 @@ function printBanner(): void {
 // "Did You Know?" Tips
 // ---------------------------------------------------------------------------
 
+/**
+ * Rotating "Did you know?" tips printed to stderr by the LiveWire banner.
+ * Exported for tests; reorder or extend to change what's displayed.
+ */
 export const tips: string[] = [
   "SignalWire agents support DataMap tools that execute server-side — no webhook infrastructure needed. See: docs/datamap-guide.md",
   "SignalWire Contexts & Steps give you mechanical state control over conversations — no prompt engineering needed. See: docs/contexts-guide.md",
@@ -68,6 +72,12 @@ function printTip(): void {
 class NoopTracker {
   private logged = new Set<string>();
 
+  /**
+   * Log the given message the first time this key is seen.
+   *
+   * @param key - Dedup key. Subsequent calls with the same key are silent.
+   * @param message - Message to write to stderr on first occurrence.
+   */
   once(key: string, message: string): void {
     if (this.logged.has(key)) return;
     this.logged.add(key);
@@ -96,8 +106,11 @@ export { NoopTracker, globalNoop };
 
 /** Voice configuration options passed through to the SignalWire AI config. */
 export interface VoiceOptions {
+  /** TTS voice identifier (e.g. `"en-US-Standard-A"`). */
   voice: string;
+  /** TTS engine identifier (e.g. `"google"`, `"elevenlabs"`). */
   engine: string;
+  /** BCP-47 language code (e.g. `"en-US"`). */
   language: string;
 }
 
@@ -105,11 +118,15 @@ export interface VoiceOptions {
 // FunctionTool
 // ---------------------------------------------------------------------------
 
-/** A tool definition that can be registered on an Agent. */
+/** A tool definition that can be registered on an {@link Agent}. */
 export interface FunctionTool {
+  /** Tool name. Populated when the tool is attached to an `Agent.tools` map. */
   name: string;
+  /** Human-readable description shown to the LLM. */
   description: string;
+  /** JSON schema (or Zod schema passthrough) for the tool's parameters. */
   parameters?: Record<string, unknown>;
+  /** Handler invoked by the platform when the LLM calls this tool. */
   execute: (params: any, context: { ctx: RunContext }) => any;
 }
 
@@ -144,8 +161,11 @@ export interface FunctionTool {
  * ```
  */
 export class Agent<UserData = any> {
+  /** System instructions passed through to the SignalWire AI prompt. */
   instructions: string;
+  /** Registered tools keyed by name. Mutated by {@link updateTools}. */
   tools: Record<string, FunctionTool>;
+  /** Arbitrary per-session user data passed to tool handlers via {@link RunContext.userData}. */
   userData?: UserData;
 
   /** @internal Pipeline hint stored for AgentSession mapping. */
@@ -231,6 +251,7 @@ export class Agent<UserData = any> {
   // session property
   // ------------------------------------------------------------------
 
+  /** The currently-bound {@link AgentSession}, or `undefined` until {@link AgentSession.start} is called. */
   get session(): AgentSession<UserData> | undefined {
     return this._session;
   }
@@ -243,20 +264,39 @@ export class Agent<UserData = any> {
   // Lifecycle hooks (override in subclass)
   // ------------------------------------------------------------------
 
-  /** Called when the agent enters. Override in subclass. */
+  /**
+   * Lifecycle hook called when the agent enters an active call.
+   * Override in a subclass to run setup logic — the default is a no-op.
+   */
   async onEnter(): Promise<void> {}
 
-  /** Called when the agent exits. Override in subclass. */
+  /**
+   * Lifecycle hook called when the agent exits (call ended or handoff).
+   * Override in a subclass to run teardown logic — the default is a no-op.
+   */
   async onExit(): Promise<void> {}
 
-  /** Called when the user finishes speaking. Override in subclass. */
+  /**
+   * Lifecycle hook called when the user finishes speaking.
+   * Override in a subclass to inspect / mutate the turn context before the
+   * LLM responds — the default is a no-op.
+   *
+   * @param _turnCtx - Turn context (LiveKit shape; passed through opaquely).
+   * @param _newMessage - Newly-captured user message.
+   */
   async onUserTurnCompleted(_turnCtx?: unknown, _newMessage?: unknown): Promise<void> {}
 
   // ------------------------------------------------------------------
   // Pipeline nodes -- all noop + log (SignalWire handles these)
   // ------------------------------------------------------------------
 
-  /** Noop -- SignalWire handles STT in its control plane. */
+  /**
+   * LiveKit-compatible STT node. **No-op** on SignalWire — the control plane
+   * handles speech recognition server-side.
+   *
+   * @param _audio - Audio input (ignored).
+   * @param _modelSettings - Model settings (ignored).
+   */
   async sttNode(_audio?: unknown, _modelSettings?: unknown): Promise<void> {
     globalNoop.once(
       'stt_node',
@@ -264,7 +304,14 @@ export class Agent<UserData = any> {
     );
   }
 
-  /** Noop -- SignalWire handles LLM in its control plane. */
+  /**
+   * LiveKit-compatible LLM node. **No-op** on SignalWire — the control plane
+   * handles LLM inference server-side.
+   *
+   * @param _chatCtx - Chat context (ignored).
+   * @param _tools - Tool list (ignored).
+   * @param _modelSettings - Model settings (ignored).
+   */
   async llmNode(_chatCtx?: unknown, _tools?: unknown, _modelSettings?: unknown): Promise<void> {
     globalNoop.once(
       'llm_node',
@@ -272,7 +319,13 @@ export class Agent<UserData = any> {
     );
   }
 
-  /** Noop -- SignalWire handles TTS in its control plane. */
+  /**
+   * LiveKit-compatible TTS node. **No-op** on SignalWire — the control plane
+   * handles text-to-speech server-side.
+   *
+   * @param _text - Text to synthesise (ignored).
+   * @param _modelSettings - Model settings (ignored).
+   */
   async ttsNode(_text?: unknown, _modelSettings?: unknown): Promise<void> {
     globalNoop.once(
       'tts_node',
@@ -284,12 +337,25 @@ export class Agent<UserData = any> {
   // Dynamic updates
   // ------------------------------------------------------------------
 
-  /** Update the agent's instructions mid-session. */
+  /**
+   * Update the agent's instructions mid-session.
+   *
+   * @param instructions - New system-instructions string for the agent.
+   */
   async updateInstructions(instructions: string): Promise<void> {
     this.instructions = instructions;
   }
 
-  /** Update the agent's tool list mid-session. */
+  /**
+   * Update the agent's tool list mid-session.
+   *
+   * Replaces the current tool record with one built from the given array,
+   * keyed by `tool.name`. Useful for dynamic tool injection based on
+   * conversation state.
+   *
+   * @param tools - Ordered array of {@link FunctionTool} definitions. Each
+   *   tool's `name` is used as its map key.
+   */
   async updateTools(tools: FunctionTool[]): Promise<void> {
     const record: Record<string, FunctionTool> = {};
     for (const t of tools) {
@@ -308,10 +374,19 @@ export class Agent<UserData = any> {
  * read the current session, call handle, and user data.
  */
 export class RunContext<UserData = any> {
+  /** The owning {@link AgentSession}, when one is bound. */
   session?: AgentSession<UserData>;
+  /** Opaque speech-turn handle (LiveKit shape; passed through untouched). */
   speechHandle?: unknown;
+  /** Opaque function-call descriptor (LiveKit shape; passed through untouched). */
   functionCall?: unknown;
 
+  /**
+   * @param session - Owning session, when available.
+   * @param options - Optional pass-through values.
+   * @param options.speechHandle - Opaque LiveKit speech handle.
+   * @param options.functionCall - Opaque LiveKit function-call descriptor.
+   */
   constructor(
     session?: AgentSession<UserData>,
     options?: { speechHandle?: unknown; functionCall?: unknown },
@@ -321,6 +396,11 @@ export class RunContext<UserData = any> {
     this.functionCall = options?.functionCall;
   }
 
+  /**
+   * Per-session user data, or an empty object when no session is bound.
+   *
+   * @returns The {@link AgentSession.userData} payload cast to `UserData`.
+   */
   get userData(): UserData {
     return (this.session?.userData ?? {}) as UserData;
   }
@@ -417,7 +497,20 @@ export class AgentSession<UserData = any> {
     }
   }
 
-  /** Start the session by binding the agent to a SignalWire AgentBase. */
+  /**
+   * Start the session by binding the agent to a freshly-constructed
+   * {@link AgentBase}, mapping LiveKit-style options onto SignalWire AI params.
+   *
+   * Must be called before any other method on this session. The underlying
+   * `AgentBase` is not started here — use {@link runApp} or an `AgentServer`
+   * to serve it.
+   *
+   * @param params - Start parameters.
+   * @param params.agent - The {@link Agent} to bind.
+   * @param params.room - LiveKit room placeholder; ignored on SignalWire.
+   * @param params.record - Call-recording flag placeholder; ignored on SignalWire.
+   * @returns Resolves once the underlying `AgentBase` has been built.
+   */
   async start(params: { agent: Agent<UserData>; room?: any; record?: boolean }): Promise<void> {
     this._agent = params.agent;
     params.agent.session = this;
@@ -497,7 +590,15 @@ export class AgentSession<UserData = any> {
     this._swAgent = swAgent;
   }
 
-  /** Queue text to be spoken by the agent. */
+  /**
+   * Queue text to be spoken by the agent.
+   *
+   * Before {@link start} is called, text is buffered and injected at start
+   * time as the agent's initial greeting. After start, text is added as an
+   * additional prompt section.
+   *
+   * @param text - Line for the agent to speak.
+   */
   say(text: string): void {
     // If the session is already started, inject directly into the SWML flow.
     // Otherwise queue the text so it is replayed when start() is called.
@@ -508,19 +609,35 @@ export class AgentSession<UserData = any> {
     }
   }
 
-  /** Trigger the agent to generate a reply, optionally with extra instructions. */
+  /**
+   * Trigger the agent to generate a reply, optionally with extra instructions.
+   *
+   * @param options - Generation options.
+   * @param options.instructions - Extra instructions injected as a new prompt
+   *   section before the next LLM turn.
+   */
   generateReply(options?: { instructions?: string }): void {
     if (options?.instructions && this._swAgent) {
       this._swAgent.promptAddSection('Initial Greeting', { body: options.instructions });
     }
   }
 
-  /** Interrupt current speech -- noop on SignalWire (barge-in is automatic). */
+  /**
+   * Interrupt current speech. **No-op** on SignalWire — barge-in is handled
+   * automatically by the control plane.
+   */
   interrupt(): void {
     this.noop.once('interrupt', "Interrupt(): SignalWire handles barge-in automatically via its control plane");
   }
 
-  /** Update the agent bound to this session. */
+  /**
+   * Swap the {@link Agent} bound to this session.
+   *
+   * Preserves the underlying `AgentBase` but replaces its prompt with the new
+   * agent's instructions.
+   *
+   * @param agent - Replacement agent.
+   */
   updateAgent(agent: Agent<UserData>): void {
     this._agent = agent;
     agent.session = this;
@@ -529,6 +646,7 @@ export class AgentSession<UserData = any> {
     }
   }
 
+  /** Current per-session user data. Set by the constructor or via the setter. */
   get userData(): UserData {
     return this._userData;
   }
@@ -537,12 +655,17 @@ export class AgentSession<UserData = any> {
     this._userData = val;
   }
 
-  /** Conversation history entries. */
+  /** Conversation history entries captured over the session's lifetime. */
   get history(): Array<Record<string, string>> {
     return this._history;
   }
 
-  /** Return the underlying SignalWire AgentBase (for testing / advanced use). */
+  /**
+   * Return the underlying SignalWire {@link AgentBase}. Useful for tests and
+   * advanced use cases that need to reach past the LiveKit facade.
+   *
+   * @returns The wrapped `AgentBase`, or `undefined` before {@link start}.
+   */
   getSwAgent(): AgentBase | undefined {
     return this._swAgent;
   }
@@ -553,9 +676,17 @@ export class AgentSession<UserData = any> {
 // ---------------------------------------------------------------------------
 
 /**
- * Create a tool definition -- mirrors llm.tool() from @livekit/agents-js.
- * Accepts a description, optional parameters (Zod or JSON schema), and an
- * execute function.
+ * Create a tool definition — mirrors `llm.tool()` from `@livekit/agents-js`.
+ *
+ * The returned tool has an empty `name` — the caller assigns it when the tool
+ * is attached to an agent's tools map (see the {@link Agent} example).
+ *
+ * @typeParam P - Parameter type passed into `execute`.
+ * @param options - Tool configuration.
+ * @param options.description - Human-readable tool description exposed to the LLM.
+ * @param options.parameters - JSON Schema or Zod schema describing the tool's inputs.
+ * @param options.execute - Handler invoked when the LLM calls the tool.
+ * @returns A {@link FunctionTool} ready to be attached to an agent.
  */
 export function tool<P = any>(options: {
   description: string;
@@ -586,7 +717,15 @@ export function tool<P = any>(options: {
 // handoff()
 // ---------------------------------------------------------------------------
 
-/** Create an AgentHandoff descriptor for multi-agent scenarios. */
+/**
+ * Create an {@link AgentHandoff} descriptor for multi-agent scenarios.
+ *
+ * @param options - Handoff parameters.
+ * @param options.agent - Agent to transfer control to.
+ * @param options.returns - Optional string returned to the current agent when
+ *   the handoff completes.
+ * @returns A handoff descriptor that can be returned from a tool handler.
+ */
 export function handoff(options: { agent: Agent; returns?: string }): AgentHandoff {
   const h = new AgentHandoff();
   h.agent = options.agent;
@@ -600,12 +739,17 @@ export function handoff(options: { agent: Agent; returns?: string }): AgentHando
 
 /** Signals a handoff to another agent in multi-agent scenarios. */
 export class AgentHandoff {
+  /** Target agent that should take over the conversation. */
   agent!: Agent;
+  /** Optional return value surfaced when the handoff completes. */
   returns?: string;
 }
 
 /** Signals that a tool should not trigger another LLM reply. */
 export class StopResponse extends Error {
+  /**
+   * @param message - Optional error message. Defaults to `"StopResponse"`.
+   */
   constructor(message?: string) {
     super(message ?? 'StopResponse');
     this.name = 'StopResponse';
@@ -614,6 +758,9 @@ export class StopResponse extends Error {
 
 /** Error thrown from a tool to signal failure back to the LLM. */
 export class ToolError extends Error {
+  /**
+   * @param message - Error message surfaced to the LLM.
+   */
   constructor(message: string) {
     super(message);
     this.name = 'ToolError';
@@ -624,8 +771,14 @@ export class ToolError extends Error {
 // JobProcess
 // ---------------------------------------------------------------------------
 
-/** Mirrors a LiveKit JobProcess -- used for prewarm/setup. */
+/**
+ * Mirrors a LiveKit `JobProcess` — placeholder for prewarm / setup hooks.
+ *
+ * On SignalWire the control plane pre-warms infrastructure at scale, so this
+ * class carries no real state beyond the LiveKit-compatible `userData` bag.
+ */
 export class JobProcess {
+  /** Mutable bag shared across prewarm and entry-point callbacks. */
   userData: Record<string, any> = {};
 }
 
@@ -633,8 +786,14 @@ export class JobProcess {
 // Room
 // ---------------------------------------------------------------------------
 
-/** Stub -- SignalWire doesn't use the LiveKit room abstraction. */
+/**
+ * Stub `Room` — SignalWire does not use the LiveKit room abstraction.
+ *
+ * Present purely for API parity so LiveKit-shaped code compiles; its only
+ * meaningful attribute is the constant name.
+ */
 export class Room {
+  /** Always `"livewire-room"` — SignalWire has no per-call room identity. */
   readonly name: string = 'livewire-room';
 }
 
@@ -642,9 +801,14 @@ export class Room {
 // JobContext
 // ---------------------------------------------------------------------------
 
-/** Mirrors a LiveKit JobContext -- provides room and connection info. */
+/**
+ * Mirrors a LiveKit `JobContext` — provides room and connection info to the
+ * entry-point callback registered via {@link defineAgent}.
+ */
 export class JobContext {
+  /** Placeholder {@link Room} (see class docs). */
   room: Room;
+  /** Shared {@link JobProcess} instance for prewarm-to-entry data passing. */
   proc: JobProcess;
   /** @internal */
   _swAgent?: AgentBase;
@@ -654,7 +818,12 @@ export class JobContext {
     this.proc = new JobProcess();
   }
 
-  /** Connect is a noop on SignalWire -- the platform handles connection lifecycle. */
+  /**
+   * Connect to the platform. **No-op** on SignalWire — the control plane
+   * manages connection lifecycle automatically.
+   *
+   * @returns Resolves immediately.
+   */
   async connect(): Promise<void> {
     globalNoop.once(
       'connect',
@@ -662,7 +831,15 @@ export class JobContext {
     );
   }
 
-  /** Wait for a participant -- noop on SignalWire. */
+  /**
+   * Wait for a participant to join. **No-op** on SignalWire — returns an
+   * immediate stub participant.
+   *
+   * @param options - Participant match options.
+   * @param options.identity - Requested identity; echoed back in the stub.
+   *   Defaults to `"caller"`.
+   * @returns A stub participant `{ identity }` record.
+   */
   async waitForParticipant(options?: { identity?: string }): Promise<any> {
     return { identity: options?.identity ?? 'caller' };
   }
@@ -673,8 +850,17 @@ export class JobContext {
 // ---------------------------------------------------------------------------
 
 /**
- * Mirrors @livekit/agents defineAgent().
- * Wraps an entry function (and optional prewarm) for later execution by runApp.
+ * Mirrors `@livekit/agents.defineAgent()`.
+ *
+ * Packages an entry function (plus an optional prewarm hook) for later
+ * execution by {@link runApp}. Pass-through — no side effects.
+ *
+ * @param agent - Entry and (optional) prewarm functions.
+ * @param agent.entry - Main callback invoked with a {@link JobContext} when
+ *   the agent runs.
+ * @param agent.prewarm - Optional prewarm callback invoked with a
+ *   {@link JobProcess} before `entry`.
+ * @returns The same record (pass-through), typed consistently.
  */
 export function defineAgent(agent: {
   entry: (ctx: JobContext) => Promise<void>;
@@ -688,14 +874,20 @@ export function defineAgent(agent: {
 // ---------------------------------------------------------------------------
 
 /**
- * Mirrors cli.runApp() from @livekit/agents-js.
+ * Mirrors `cli.runApp()` from `@livekit/agents-js`.
  *
  * 1. Prints the LiveWire banner
- * 2. Prints a random tip
- * 3. Creates a SignalWire AgentBase from the LiveKit-style config
- * 4. Calls the entry function with a fake JobContext
- * 5. Maps tools from llm.tool() format to SignalWire defineTool format
- * 6. Starts the agent with agent.run()
+ * 2. Runs the registered prewarm callback (if any) with a fresh {@link JobProcess}
+ * 3. Creates a fresh {@link JobContext}
+ * 4. Prints a random tip
+ * 5. Invokes the entry function with the context
+ * 6. Starts the underlying SignalWire `AgentBase` once the entry function
+ *    binds one (via an `AgentSession.start()` call)
+ *
+ * Accepts either an object `{ entry, prewarm? }`, a bare entry function, or
+ * an {@link AgentServer} instance.
+ *
+ * @param options - Agent descriptor, entry function, or `AgentServer`.
  */
 export function runApp(options: any): void {
   printBanner();
@@ -742,13 +934,25 @@ export function runApp(options: any): void {
 // WorkerOptions / ServerOptions
 // ---------------------------------------------------------------------------
 
-/** Stub for LiveKit WorkerOptions. */
+/**
+ * Stub class mirroring LiveKit's `WorkerOptions`.
+ *
+ * Accepts any configuration for source-compatibility with LiveKit code;
+ * SignalWire ignores these settings.
+ */
 export class WorkerOptions {
+  /** @param _opts - LiveKit-shaped worker options (ignored). */
   constructor(_opts?: any) {}
 }
 
-/** Stub for LiveKit ServerOptions. */
+/**
+ * Stub class mirroring LiveKit's `ServerOptions`.
+ *
+ * Accepts any configuration for source-compatibility with LiveKit code;
+ * SignalWire ignores these settings.
+ */
 export class ServerOptions {
+  /** @param _opts - LiveKit-shaped server options (ignored). */
   constructor(_opts?: any) {}
 }
 
@@ -857,9 +1061,17 @@ export class AgentServer {
 // Plugin stubs
 // ---------------------------------------------------------------------------
 
-/** Stub providers matching common LiveKit plugin packages. */
+/**
+ * Stub providers matching common LiveKit plugin packages.
+ *
+ * None of these do anything — they exist so LiveKit code that imports and
+ * constructs these classes still compiles and runs under SignalWire. The
+ * first construction of each logs an advisory to stderr.
+ */
 export namespace plugins {
+  /** LiveKit Deepgram-STT plugin stub. No-op on SignalWire. */
   export class DeepgramSTT {
+    /** @param _opts - Deepgram options (ignored). */
     constructor(_opts?: any) {
       globalNoop.once(
         'stt_plugin',
@@ -868,8 +1080,16 @@ export namespace plugins {
     }
   }
 
+  /**
+   * LiveKit OpenAI-LLM plugin stub.
+   *
+   * The `model` string is captured and mapped to the SignalWire AI `model`
+   * param by {@link AgentSession.start}. Other options are ignored.
+   */
   export class OpenAILLM {
+    /** Model identifier captured from the constructor options. */
     model: string;
+    /** @param _opts - OpenAI options. `_opts.model` is captured; everything else ignored. */
     constructor(_opts?: any) {
       this.model = ((_opts as any)?.model as string) ?? '';
       globalNoop.once(
@@ -879,7 +1099,9 @@ export namespace plugins {
     }
   }
 
+  /** LiveKit Cartesia-TTS plugin stub. No-op on SignalWire. */
   export class CartesiaTTS {
+    /** @param _opts - Cartesia options (ignored). */
     constructor(_opts?: any) {
       globalNoop.once(
         'cartesia_tts',
@@ -888,7 +1110,9 @@ export namespace plugins {
     }
   }
 
+  /** LiveKit ElevenLabs-TTS plugin stub. No-op on SignalWire. */
   export class ElevenLabsTTS {
+    /** @param _opts - ElevenLabs options (ignored). */
     constructor(_opts?: any) {
       globalNoop.once(
         'elevenlabs_tts',
@@ -897,9 +1121,19 @@ export namespace plugins {
     }
   }
 
+  /** LiveKit Silero-VAD plugin stub. No-op on SignalWire. */
   export class SileroVAD {
+    /** @param _opts - Silero VAD options (ignored). */
     constructor(_opts?: Record<string, unknown>) {}
 
+    /**
+     * Load a Silero VAD model.
+     *
+     * **No-op** on SignalWire — returns a fresh stub instance and emits a
+     * one-time advisory to stderr.
+     *
+     * @returns A new `SileroVAD` stub.
+     */
     static load(): SileroVAD {
       globalNoop.once(
         'vad_plugin',
@@ -914,10 +1148,22 @@ export namespace plugins {
 // Inference module stubs
 // ---------------------------------------------------------------------------
 
-/** Stub inference types matching LiveKit's inference namespace. */
+/**
+ * Stub inference types matching LiveKit's `inference` namespace.
+ *
+ * None of these run inference on the client — SignalWire performs STT / LLM /
+ * TTS in its control plane. These classes exist so LiveKit code that imports
+ * and instantiates them still compiles.
+ */
 export namespace inference {
+  /** LiveKit inference-STT stub. Captures the model name; runs no inference locally. */
   export class STT {
+    /** Model identifier captured from the constructor. */
     model: string;
+    /**
+     * @param model - Model identifier (captured).
+     * @param _opts - Additional options (ignored).
+     */
     constructor(model: string = '', _opts?: any) {
       this.model = model;
       globalNoop.once(
@@ -927,15 +1173,27 @@ export namespace inference {
     }
   }
 
+  /** LiveKit inference-LLM stub. Captures the model name; runs no inference locally. */
   export class LLM {
+    /** Model identifier captured from the constructor. */
     model: string;
+    /**
+     * @param model - Model identifier (captured).
+     * @param _opts - Additional options (ignored).
+     */
     constructor(model: string = '', _opts?: any) {
       this.model = model;
     }
   }
 
+  /** LiveKit inference-TTS stub. Captures the model name; runs no inference locally. */
   export class TTS {
+    /** Model identifier captured from the constructor. */
     model: string;
+    /**
+     * @param model - Model identifier (captured).
+     * @param _opts - Additional options (ignored).
+     */
     constructor(model: string = '', _opts?: any) {
       this.model = model;
       globalNoop.once(
@@ -957,10 +1215,20 @@ export const voice = {
   AgentSessionEventTypes: {} as Record<string, string>,
 };
 
-/** Minimal ChatContext matching livekit ChatContext. */
+/** Minimal `ChatContext` matching LiveKit's `ChatContext`. */
 export class ChatContext {
+  /** Ordered chat messages, each `{ role, content }`. */
   messages: Array<Record<string, string>> = [];
 
+  /**
+   * Append a chat message.
+   *
+   * @param options - Message content.
+   * @param options.role - Speaker role (`"user"`, `"assistant"`, or `"system"`).
+   *   Defaults to `"user"`.
+   * @param options.text - Message text. Defaults to `""`.
+   * @returns This instance for chaining.
+   */
   append(options: { role?: string; text?: string }): this {
     this.messages.push({ role: options.role ?? 'user', content: options.text ?? '' });
     return this;

--- a/src/prefabs/ConciergeAgent.ts
+++ b/src/prefabs/ConciergeAgent.ts
@@ -12,6 +12,7 @@ import type { AgentOptions } from '../types.js';
 
 // ── Config types ────────────────────────────────────────────────────────────
 
+/** Configuration for the {@link ConciergeAgent}. */
 export interface ConciergeConfig {
   /** Name of the venue or business (required). */
   venueName: string;

--- a/src/prefabs/ConciergeAgent.ts
+++ b/src/prefabs/ConciergeAgent.ts
@@ -38,6 +38,27 @@ export interface ConciergeConfig {
 /**
  * Prefab agent that acts as a virtual concierge for a venue, providing information
  * about services, amenities, hours of operation, availability, and directions.
+ *
+ * @example Hotel concierge
+ * ```ts
+ * import { ConciergeAgent } from '@signalwire/sdk';
+ *
+ * const agent = new ConciergeAgent({
+ *   venueName: 'The Park Hotel',
+ *   services: ['Room service', 'Valet parking', 'Spa', 'Restaurant'],
+ *   hoursOfOperation: {
+ *     restaurant: '7 AM - 10 PM daily',
+ *     spa: '9 AM - 9 PM daily',
+ *     default: '24 hours',
+ *   },
+ *   amenities: {
+ *     pool: { location: 'Rooftop', hours: '6 AM - 10 PM' },
+ *     gym: { location: 'Floor 2', hours: '24 hours' },
+ *   },
+ * });
+ *
+ * await agent.serve({ port: 3000 });
+ * ```
  */
 export class ConciergeAgent extends AgentBase {
   /** Name of the venue or business. */

--- a/src/prefabs/FAQBotAgent.ts
+++ b/src/prefabs/FAQBotAgent.ts
@@ -48,7 +48,36 @@ export interface FAQBotConfig {
 
 // ── Agent ───────────────────────────────────────────────────────────────────
 
-/** Prefab agent that answers frequently asked questions using keyword matching with optional escalation to a live agent. */
+/**
+ * Prefab agent that answers frequently asked questions using keyword matching with optional escalation to a live agent.
+ *
+ * Pass an array of `{ question, answer, keywords }` entries and the agent will
+ * fuzzy-match inbound utterances against them. If no match crosses the confidence
+ * threshold, the call can optionally escalate to a configured phone number.
+ *
+ * @example
+ * ```ts
+ * import { FAQBotAgent } from '@signalwire/sdk';
+ *
+ * const agent = new FAQBotAgent({
+ *   faqs: [
+ *     {
+ *       question: 'What are your business hours?',
+ *       answer: "We're open 9 AM to 5 PM Pacific, Monday through Friday.",
+ *       keywords: ['hours', 'open', 'closed', 'time'],
+ *     },
+ *     {
+ *       question: 'Where are you located?',
+ *       answer: 'Our headquarters are in San Francisco, California.',
+ *       keywords: ['location', 'address', 'office'],
+ *     },
+ *   ],
+ *   escalationNumber: '+15551234567',
+ * });
+ *
+ * await agent.serve({ port: 3000 });
+ * ```
+ */
 export class FAQBotAgent extends AgentBase {
   /** The configured FAQ entries. */
   public faqs: FAQEntry[];

--- a/src/prefabs/FAQBotAgent.ts
+++ b/src/prefabs/FAQBotAgent.ts
@@ -14,6 +14,7 @@ import type { AgentOptions } from '../types.js';
 
 // ── Config types ────────────────────────────────────────────────────────────
 
+/** A single frequently-asked-question entry consumed by {@link FAQBotAgent}. */
 export interface FAQEntry {
   /** The representative question text. */
   question: string;
@@ -25,6 +26,7 @@ export interface FAQEntry {
   categories?: string[];
 }
 
+/** Configuration for the {@link FAQBotAgent}. */
 export interface FAQBotConfig {
   /** Agent display name (defaults to `"faq_bot"`). */
   name?: string;

--- a/src/prefabs/InfoGathererAgent.ts
+++ b/src/prefabs/InfoGathererAgent.ts
@@ -63,7 +63,47 @@ const FALLBACK_QUESTIONS: InfoGathererQuestion[] = [
   { key_name: 'message', question_text: 'How can I help you today?' },
 ];
 
-/** Prefab agent that gathers caller information one question at a time. */
+/**
+ * Prefab agent that gathers caller information one question at a time.
+ *
+ * Supports two modes:
+ *
+ * - **Static** — provide `questions` at construction; the same questions are
+ *   asked on every call.
+ * - **Dynamic** — leave `questions` unset and register a callback via
+ *   `questionCallback` (or `setQuestionCallback()`); the callback decides which
+ *   questions to ask per incoming call based on query params, body, or headers.
+ *
+ * @example Static questions
+ * ```ts
+ * import { InfoGathererAgent } from '@signalwire/sdk';
+ *
+ * const agent = new InfoGathererAgent({
+ *   questions: [
+ *     { key_name: 'name', question_text: 'What is your name?' },
+ *     { key_name: 'email', question_text: 'What is your email address?', confirm: true },
+ *     { key_name: 'issue', question_text: 'How can we help?' },
+ *   ],
+ * });
+ *
+ * await agent.serve({ port: 3000 });
+ * ```
+ *
+ * @example Dynamic questions per request
+ * ```ts
+ * const agent = new InfoGathererAgent({
+ *   questionCallback: async (query) => {
+ *     if (query.intake === 'medical') {
+ *       return [
+ *         { key_name: 'dob', question_text: 'Date of birth?' },
+ *         { key_name: 'insurance_id', question_text: 'Insurance member ID?' },
+ *       ];
+ *     }
+ *     return [{ key_name: 'message', question_text: 'How can I help?' }];
+ *   },
+ * });
+ * ```
+ */
 export class InfoGathererAgent extends AgentBase {
   private staticQuestions: InfoGathererQuestion[] | null;
   private questionCallback: InfoGathererQuestionCallback | null = null;

--- a/src/prefabs/ReceptionistAgent.ts
+++ b/src/prefabs/ReceptionistAgent.ts
@@ -13,6 +13,7 @@ import type { AgentOptions } from '../types.js';
 
 // ── Config types ────────────────────────────────────────────────────────────
 
+/** A department the receptionist can route callers to. */
 export interface ReceptionistDepartment {
   /** Department identifier (e.g. `"sales"`, `"support"`). */
   name: string;
@@ -22,6 +23,7 @@ export interface ReceptionistDepartment {
   number: string;
 }
 
+/** Configuration for the {@link ReceptionistAgent}. */
 export interface ReceptionistConfig {
   /** Departments the agent can transfer callers to. */
   departments: ReceptionistDepartment[];

--- a/src/prefabs/ReceptionistAgent.ts
+++ b/src/prefabs/ReceptionistAgent.ts
@@ -51,7 +51,34 @@ interface CheckInSession {
 
 // ── Agent ───────────────────────────────────────────────────────────────────
 
-/** Prefab agent that greets callers, collects basic information, and transfers them to the correct department. */
+/**
+ * Prefab agent that greets callers, collects basic information, and transfers them to the correct department.
+ *
+ * Optionally supports visitor check-in — when enabled, the agent can collect a visitor's name
+ * and purpose-of-visit and invoke a callback (e.g., notify reception via Slack, write to a
+ * database). If not transferring, the call ends after check-in.
+ *
+ * @example
+ * ```ts
+ * import { ReceptionistAgent } from '@signalwire/sdk';
+ *
+ * const agent = new ReceptionistAgent({
+ *   companyName: 'Acme Co',
+ *   greeting: 'Thanks for calling Acme! How can I direct your call?',
+ *   departments: [
+ *     { name: 'sales', description: 'New customer inquiries', number: '+15551112222' },
+ *     { name: 'support', description: 'Existing customer help', number: '+15553334444' },
+ *     { name: 'billing', description: 'Billing and payments', number: '+15555556666' },
+ *   ],
+ *   checkInEnabled: true,
+ *   onVisitorCheckIn: async (visitor) => {
+ *     await notifyFrontDesk(visitor);
+ *   },
+ * });
+ *
+ * await agent.serve({ port: 3000 });
+ * ```
+ */
 export class ReceptionistAgent extends AgentBase {
   private readonly greeting: string;
   private readonly departments: ReceptionistDepartment[];

--- a/src/prefabs/SurveyAgent.ts
+++ b/src/prefabs/SurveyAgent.ts
@@ -82,7 +82,30 @@ interface SurveySession {
 
 // ── Agent ───────────────────────────────────────────────────────────────────
 
-/** Prefab agent that conducts surveys with branching logic, answer scoring, and conditional question flow. */
+/**
+ * Prefab agent that conducts surveys with branching logic, answer scoring, and conditional question flow.
+ *
+ * Each survey question declares its response type (rating, yes/no, open text, etc.), an optional
+ * set of conditional follow-ups, and a scoring map. The agent walks the question tree, tallies a
+ * total score, and exposes the full response map at call end via `onSummary()`.
+ *
+ * @example Customer satisfaction survey
+ * ```ts
+ * import { SurveyAgent } from '@signalwire/sdk';
+ *
+ * const agent = new SurveyAgent({
+ *   surveyName: 'CSAT',
+ *   brandName: 'Acme Co',
+ *   questions: [
+ *     { id: 'q1', text: 'How satisfied were you with our service?', type: 'rating', scale: 5 },
+ *     { id: 'q2', text: 'Would you recommend us to a friend?', type: 'yesno' },
+ *     { id: 'q3', text: 'Anything else you want to share?', type: 'open' },
+ *   ],
+ * });
+ *
+ * await agent.serve({ port: 3000 });
+ * ```
+ */
 export class SurveyAgent extends AgentBase {
   /** Human-readable survey name. */
   public surveyName: string;

--- a/src/prefabs/SurveyAgent.ts
+++ b/src/prefabs/SurveyAgent.ts
@@ -13,6 +13,7 @@ import type { AgentOptions } from '../types.js';
 
 // ── Config types ────────────────────────────────────────────────────────────
 
+/** A single survey question consumed by {@link SurveyAgent}. */
 export interface SurveyQuestion {
   /** Unique question identifier. */
   id: string;
@@ -47,6 +48,7 @@ export interface SurveyQuestion {
   points?: number | Record<string, number>;
 }
 
+/** Configuration for the {@link SurveyAgent}. */
 export interface SurveyConfig {
   /** Human-readable survey name, used in prompts and global data. */
   surveyName: string;

--- a/src/relay/Action.ts
+++ b/src/relay/Action.ts
@@ -34,13 +34,32 @@ export interface CallLike {
 
 // ─── Base Action ─────────────────────────────────────────────────────
 
+/**
+ * Async handle for a controllable call operation (play, record, tap, detect, etc.).
+ *
+ * An Action is returned from the async variants on {@link Call} (e.g. `call.playAsync`).
+ * It resolves when the server emits a terminal event for its `controlId`. Use
+ * {@link Action.wait} to await completion, or register an `onCompleted` callback.
+ *
+ * @example
+ * ```ts
+ * const play = await call.playAsync({ play: [{ type: 'tts', text: 'Hello!' }] });
+ * // do other work while the greeting plays...
+ * const event = await play.wait(10); // seconds
+ * console.log('Playback finished with state', event.params.state);
+ * ```
+ */
 export class Action {
+  /** Reference to the owning call. */
   readonly call: CallLike;
+  /** Unique control ID used by the server to route events back to this action. */
   readonly controlId: string;
   protected readonly _terminalEvent: string;
   protected readonly _terminalStates: readonly string[];
   /** @internal */ readonly _done: Deferred<RelayEvent>;
+  /** Final event once the action terminates, or `null` while still running. */
   result: RelayEvent | null = null;
+  /** Whether the action has reached a terminal state. */
   completed = false;
   /** @internal */ _onCompleted: CompletedCallback | null = null;
 

--- a/src/relay/Action.ts
+++ b/src/relay/Action.ts
@@ -27,7 +27,10 @@ import type { CompletedCallback } from './types.js';
 
 const logger = getLogger('relay_action');
 
-// Forward-reference to Call to avoid circular imports
+/**
+ * Structural subset of {@link Call} that an Action needs — avoids a circular
+ * import between `Call.ts` and `Action.ts`.
+ */
 export interface CallLike {
   _execute(method: string, extraParams?: Record<string, unknown>): Promise<Record<string, unknown>>;
 }
@@ -63,6 +66,12 @@ export class Action {
   completed = false;
   /** @internal */ _onCompleted: CompletedCallback | null = null;
 
+  /**
+   * @param call - Owning call (via the structural {@link CallLike} interface).
+   * @param controlId - Unique control ID the server will echo on events.
+   * @param terminalEvent - Event type that carries terminal state transitions.
+   * @param terminalStates - State values that mark this action as completed.
+   */
   constructor(
     call: CallLike,
     controlId: string,
@@ -106,8 +115,12 @@ export class Action {
   }
 
   /**
-   * Wait for the action to complete. Returns the terminal event.
-   * @param timeout - Maximum time to wait in seconds (matches Python SDK convention).
+   * Wait for the action to complete.
+   *
+   * @param timeout - Maximum time to wait in **seconds** (matches the Python
+   *   SDK convention — not milliseconds).
+   * @returns The terminal {@link RelayEvent} for this action.
+   * @throws {Error} When the optional timeout elapses before the action ends.
    */
   async wait(timeout?: number): Promise<RelayEvent> {
     if (timeout != null) {
@@ -116,16 +129,22 @@ export class Action {
         const timer = setTimeout(() => {
           reject(new Error(`Action wait timed out after ${timeout}s`));
         }, ms);
-
         this._done.promise.then(
-          (v) => { clearTimeout(timer); resolve(v); },
-          (e) => { clearTimeout(timer); reject(e); },
+          (v) => {
+            clearTimeout(timer);
+            resolve(v);
+          },
+          (e) => {
+            clearTimeout(timer);
+            reject(e);
+          },
         );
       });
     }
     return this._done.promise;
   }
 
+  /** True once the action has reached a terminal state. */
   get isDone(): boolean {
     return this._done.settled;
   }
@@ -133,23 +152,49 @@ export class Action {
 
 // ─── PlayAction ──────────────────────────────────────────────────────
 
+/** Async handle for a `calling.call.play` action — controls playback in progress. */
 export class PlayAction extends Action {
   constructor(call: CallLike, controlId: string) {
     super(call, controlId, EVENT_CALL_PLAY, [PLAY_STATE_FINISHED, PLAY_STATE_ERROR]);
   }
 
+  /**
+   * Stop the playback.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute('play.stop', { control_id: this.controlId });
   }
 
+  /**
+   * Pause active playback (resumable with {@link resume}).
+   *
+   * @returns The platform's pause response.
+   * @throws {RelayError} When the pause command is rejected.
+   */
   async pause(): Promise<Record<string, unknown>> {
     return this.call._execute('play.pause', { control_id: this.controlId });
   }
 
+  /**
+   * Resume playback paused by {@link pause}.
+   *
+   * @returns The platform's resume response.
+   * @throws {RelayError} When the resume command is rejected.
+   */
   async resume(): Promise<Record<string, unknown>> {
     return this.call._execute('play.resume', { control_id: this.controlId });
   }
 
+  /**
+   * Adjust playback volume.
+   *
+   * @param volume - Volume adjustment in dB.
+   * @returns The platform's volume response.
+   * @throws {RelayError} When the volume command is rejected.
+   */
   async volume(volume: number): Promise<Record<string, unknown>> {
     return this.call._execute('play.volume', { control_id: this.controlId, volume });
   }
@@ -157,21 +202,42 @@ export class PlayAction extends Action {
 
 // ─── RecordAction ────────────────────────────────────────────────────
 
+/** Async handle for a `calling.call.record` action — controls recording in progress. */
 export class RecordAction extends Action {
   constructor(call: CallLike, controlId: string) {
     super(call, controlId, EVENT_CALL_RECORD, [RECORD_STATE_FINISHED, RECORD_STATE_NO_INPUT]);
   }
 
+  /**
+   * Stop the recording and finalise the file.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute('record.stop', { control_id: this.controlId });
   }
 
+  /**
+   * Pause the recording (resumable with {@link resume}).
+   *
+   * @param behavior - Optional behaviour hint (e.g. `"silence"`) controlling
+   *   what is recorded in place of paused audio.
+   * @returns The platform's pause response.
+   * @throws {RelayError} When the pause command is rejected.
+   */
   async pause(behavior?: string): Promise<Record<string, unknown>> {
     const params: Record<string, unknown> = { control_id: this.controlId };
     if (behavior) params.behavior = behavior;
     return this.call._execute('record.pause', params);
   }
 
+  /**
+   * Resume recording paused by {@link pause}.
+   *
+   * @returns The platform's resume response.
+   * @throws {RelayError} When the resume command is rejected.
+   */
   async resume(): Promise<Record<string, unknown>> {
     return this.call._execute('record.resume', { control_id: this.controlId });
   }
@@ -179,6 +245,7 @@ export class RecordAction extends Action {
 
 // ─── DetectAction ────────────────────────────────────────────────────
 
+/** Async handle for a `calling.call.detect` action (machine / fax / digit). */
 export class DetectAction extends Action {
   constructor(call: CallLike, controlId: string) {
     super(call, controlId, EVENT_CALL_DETECT, ['finished', 'error']);
@@ -193,6 +260,12 @@ export class DetectAction extends Action {
     }
   }
 
+  /**
+   * Stop detection before the timeout elapses.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute('detect.stop', { control_id: this.controlId });
   }
@@ -200,6 +273,7 @@ export class DetectAction extends Action {
 
 // ─── CollectAction ───────────────────────────────────────────────────
 
+/** Async handle for a `play_and_collect` action (combined playback + input collection). */
 export class CollectAction extends Action {
   constructor(call: CallLike, controlId: string) {
     super(call, controlId, EVENT_CALL_COLLECT, ['finished', 'error', 'no_input', 'no_match']);
@@ -219,14 +293,34 @@ export class CollectAction extends Action {
     }
   }
 
+  /**
+   * Stop the play_and_collect operation.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute('play_and_collect.stop', { control_id: this.controlId });
   }
 
+  /**
+   * Adjust playback volume of the prompt audio mid-collect.
+   *
+   * @param volume - Volume adjustment in dB.
+   * @returns The platform's volume response.
+   * @throws {RelayError} When the volume command is rejected.
+   */
   async volume(volume: number): Promise<Record<string, unknown>> {
     return this.call._execute('play_and_collect.volume', { control_id: this.controlId, volume });
   }
 
+  /**
+   * Start the collect input timers (useful when `initial_timeout` should be
+   * reset after an async side effect completes).
+   *
+   * @returns The platform's start_input_timers response.
+   * @throws {RelayError} When the command is rejected.
+   */
   async startInputTimers(): Promise<Record<string, unknown>> {
     return this.call._execute('collect.start_input_timers', { control_id: this.controlId });
   }
@@ -234,6 +328,7 @@ export class CollectAction extends Action {
 
 // ─── StandaloneCollectAction ─────────────────────────────────────────
 
+/** Async handle for a bare `calling.call.collect` action (no accompanying play). */
 export class StandaloneCollectAction extends Action {
   constructor(call: CallLike, controlId: string) {
     super(call, controlId, EVENT_CALL_COLLECT, ['finished', 'error', 'no_input', 'no_match']);
@@ -248,10 +343,22 @@ export class StandaloneCollectAction extends Action {
     }
   }
 
+  /**
+   * Stop the collect operation before input is received.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute('collect.stop', { control_id: this.controlId });
   }
 
+  /**
+   * Start the collect input timers.
+   *
+   * @returns The platform's start_input_timers response.
+   * @throws {RelayError} When the command is rejected.
+   */
   async startInputTimers(): Promise<Record<string, unknown>> {
     return this.call._execute('collect.start_input_timers', { control_id: this.controlId });
   }
@@ -259,6 +366,7 @@ export class StandaloneCollectAction extends Action {
 
 // ─── FaxAction ───────────────────────────────────────────────────────
 
+/** Async handle for a `send_fax` or `receive_fax` action. */
 export class FaxAction extends Action {
   private _methodPrefix: string;
 
@@ -267,6 +375,12 @@ export class FaxAction extends Action {
     this._methodPrefix = methodPrefix;
   }
 
+  /**
+   * Stop the fax transfer mid-stream.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute(`${this._methodPrefix}.stop`, { control_id: this.controlId });
   }
@@ -274,11 +388,18 @@ export class FaxAction extends Action {
 
 // ─── TapAction ───────────────────────────────────────────────────────
 
+/** Async handle for a `calling.call.tap` action (media mirroring). */
 export class TapAction extends Action {
   constructor(call: CallLike, controlId: string) {
     super(call, controlId, EVENT_CALL_TAP, ['finished']);
   }
 
+  /**
+   * Stop the media tap.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute('tap.stop', { control_id: this.controlId });
   }
@@ -286,11 +407,18 @@ export class TapAction extends Action {
 
 // ─── StreamAction ────────────────────────────────────────────────────
 
+/** Async handle for a `calling.call.stream` action (outbound media stream). */
 export class StreamAction extends Action {
   constructor(call: CallLike, controlId: string) {
     super(call, controlId, EVENT_CALL_STREAM, ['finished']);
   }
 
+  /**
+   * Stop the outbound stream.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute('stream.stop', { control_id: this.controlId });
   }
@@ -298,11 +426,18 @@ export class StreamAction extends Action {
 
 // ─── PayAction ───────────────────────────────────────────────────────
 
+/** Async handle for a `calling.call.pay` action (PCI-compliant payment collection). */
 export class PayAction extends Action {
   constructor(call: CallLike, controlId: string) {
     super(call, controlId, EVENT_CALL_PAY, ['finished', 'error']);
   }
 
+  /**
+   * Cancel the payment collection before it completes.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute('pay.stop', { control_id: this.controlId });
   }
@@ -310,11 +445,18 @@ export class PayAction extends Action {
 
 // ─── TranscribeAction ────────────────────────────────────────────────
 
+/** Async handle for a `calling.call.transcribe` action (real-time transcription). */
 export class TranscribeAction extends Action {
   constructor(call: CallLike, controlId: string) {
     super(call, controlId, EVENT_CALL_TRANSCRIBE, ['finished']);
   }
 
+  /**
+   * Stop the transcription.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute('transcribe.stop', { control_id: this.controlId });
   }
@@ -322,11 +464,18 @@ export class TranscribeAction extends Action {
 
 // ─── AIAction ────────────────────────────────────────────────────────
 
+/** Async handle for a `calling.call.ai` action (on-call AI agent session). */
 export class AIAction extends Action {
   constructor(call: CallLike, controlId: string) {
     super(call, controlId, 'calling.call.ai', ['finished', 'error']);
   }
 
+  /**
+   * Stop the AI agent session.
+   *
+   * @returns The platform's stop response.
+   * @throws {RelayError} When the stop command is rejected.
+   */
   async stop(): Promise<Record<string, unknown>> {
     return this.call._execute('ai.stop', { control_id: this.controlId });
   }

--- a/src/relay/Call.ts
+++ b/src/relay/Call.ts
@@ -135,7 +135,16 @@ export class Call {
 
   // ─── Event Plumbing ──────────────────────────────────────────────
 
-  /** Register an event listener for this call. */
+  /**
+   * Register an event listener for this call.
+   *
+   * Multiple listeners for the same event type are supported. Listener errors
+   * are logged but do not disrupt dispatch to other listeners.
+   *
+   * @param eventType - Fully-qualified event type (e.g.
+   *   `"calling.call.state"`, `"calling.call.play"`).
+   * @param handler - Callback invoked for each matching event.
+   */
   on(eventType: string, handler: EventHandler): void {
     const handlers = this._listeners.get(eventType) ?? [];
     handlers.push(handler);
@@ -179,7 +188,19 @@ export class Call {
     }
   }
 
-  /** Wait for a specific event, optionally filtered by predicate. */
+  /**
+   * Wait for a specific event, optionally filtered by predicate.
+   *
+   * Registers a one-shot listener that is removed after resolving (or after
+   * the timeout elapses). Useful for awaiting a specific state transition.
+   *
+   * @param eventType - Event type to wait for.
+   * @param predicate - Optional filter — only events for which this returns
+   *   `true` resolve the wait.
+   * @param timeout - Optional timeout in milliseconds. Omit to wait forever.
+   * @returns The first matching {@link RelayEvent}.
+   * @throws {Error} When the optional timeout elapses before a match.
+   */
   async waitFor(
     eventType: string,
     predicate?: (event: RelayEvent) => boolean,
@@ -218,7 +239,13 @@ export class Call {
     }
   }
 
-  /** Wait for the call to reach the ended state. */
+  /**
+   * Wait for the call to reach the `ended` state.
+   *
+   * @param timeout - Optional timeout in milliseconds.
+   * @returns The terminating `calling.call.state` {@link RelayEvent}.
+   * @throws {Error} When the optional timeout elapses before the call ends.
+   */
   async waitForEnded(timeout?: number): Promise<RelayEvent> {
     if (timeout != null) {
       return new Promise<RelayEvent>((resolve, reject) => {
@@ -275,24 +302,63 @@ export class Call {
 
   // ─── Call Lifecycle Methods ──────────────────────────────────────
 
-  /** Answer an inbound call. */
+  /**
+   * Answer an inbound call.
+   *
+   * @param extra - Optional additional params merged into the answer request
+   *   (e.g. SIP headers, codec hints).
+   * @returns The platform's answer response.
+   * @throws {RelayError} When the answer command is rejected.
+   */
   async answer(extra?: Record<string, unknown>): Promise<Record<string, unknown>> {
     return this._execute('answer', extra);
   }
 
-  /** End/hang up the call. */
+  /**
+   * End / hang up the call.
+   *
+   * @param reason - Hangup reason delivered to the platform. Defaults to
+   *   `"hangup"`.
+   * @returns The platform's end response.
+   * @throws {RelayError} When the end command is rejected.
+   */
   async hangup(reason = 'hangup'): Promise<Record<string, unknown>> {
     return this._execute('end', { reason });
   }
 
-  /** Decline control of an inbound call, returning it to routing. */
+  /**
+   * Decline control of an inbound call, returning it to routing.
+   *
+   * Use instead of {@link answer} when you want the call to fall through to
+   * the next matching route rather than be handled by this client.
+   *
+   * @returns The platform's pass response.
+   * @throws {RelayError} When the pass command is rejected.
+   */
   async pass(): Promise<Record<string, unknown>> {
     return this._execute('pass');
   }
 
   // ─── Audio Playback ──────────────────────────────────────────────
 
-  /** Play audio content. Returns a PlayAction for stop/pause/resume/wait. */
+  /**
+   * Play audio content on the call.
+   *
+   * Returns immediately with a {@link PlayAction} — `await action.wait()` to
+   * block until playback finishes, or call `stop()` / `pause()` / `resume()`
+   * / `volume()` on it to control playback.
+   *
+   * @param media - Platform-shaped play items (TTS, audio URLs, silence, etc.).
+   * @param options - Optional playback controls.
+   * @param options.volume - Volume adjustment in dB.
+   * @param options.direction - `"speak"`, `"hear"`, or `"both"`.
+   * @param options.loop - Number of times to loop the playback.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.onCompleted - Callback fired when playback reaches a
+   *   terminal state.
+   * @returns A {@link PlayAction} for control and completion tracking.
+   * @throws {RelayError} When the play command is rejected.
+   */
   async play(
     media: Record<string, unknown>[],
     options: {
@@ -314,7 +380,18 @@ export class Call {
 
   // ─── Recording ───────────────────────────────────────────────────
 
-  /** Record audio from the call. Returns a RecordAction. */
+  /**
+   * Record audio from the call.
+   *
+   * @param audio - Platform-shaped audio recording options (direction, codec,
+   *   timeouts, etc.). Defaults to `{}`.
+   * @param options - Recording behaviour.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.onCompleted - Callback fired when the recording reaches a
+   *   terminal state.
+   * @returns A {@link RecordAction} for control and completion tracking.
+   * @throws {RelayError} When the record command is rejected.
+   */
   async record(
     audio?: Record<string, unknown>,
     options: {
@@ -331,7 +408,20 @@ export class Call {
 
   // ─── Input Collection ────────────────────────────────────────────
 
-  /** Play audio and collect digit/speech input. Returns a CollectAction. */
+  /**
+   * Play audio and collect digit / speech input in a single operation.
+   *
+   * Convenient for IVR prompts — playback stops as soon as input is received.
+   *
+   * @param media - Audio items to play while collecting.
+   * @param collect - Platform-shaped collect config (`digits`, `speech`, etc.).
+   * @param options - Playback and collection behaviour.
+   * @param options.volume - Playback volume adjustment in dB.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.onCompleted - Callback fired when collect completes.
+   * @returns A {@link CollectAction} for the combined play-and-collect flow.
+   * @throws {RelayError} When the play_and_collect command is rejected.
+   */
   async playAndCollect(
     media: Record<string, unknown>[],
     collect: Record<string, unknown>,
@@ -352,7 +442,22 @@ export class Call {
     return this._startAction(action, 'play_and_collect', params, options.onCompleted);
   }
 
-  /** Collect digit/speech input without playing media. Returns a StandaloneCollectAction. */
+  /**
+   * Collect digit / speech input without playing media.
+   *
+   * @param options - Collect configuration.
+   * @param options.digits - DTMF digit-collection config.
+   * @param options.speech - Speech-recognition config.
+   * @param options.initialTimeout - Seconds to wait for the first input.
+   * @param options.partialResults - Emit partial (interim) results.
+   * @param options.continuous - Keep collecting until explicitly stopped.
+   * @param options.sendStartOfInput - Emit a start-of-input event when detected.
+   * @param options.startInputTimers - Start input timers immediately.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.onCompleted - Callback fired when collect completes.
+   * @returns A {@link StandaloneCollectAction} for control and completion tracking.
+   * @throws {RelayError} When the collect command is rejected.
+   */
   async collect(options: {
     digits?: Record<string, unknown>;
     speech?: Record<string, unknown>;
@@ -379,7 +484,20 @@ export class Call {
 
   // ─── Bridging & Connectivity ─────────────────────────────────────
 
-  /** Bridge the call to one or more destinations. */
+  /**
+   * Bridge the call to one or more destinations.
+   *
+   * @param devices - Serial/parallel dial plan — outer array of serial groups,
+   *   inner arrays dialled in parallel.
+   * @param options - Connect behaviour.
+   * @param options.ringback - Ringback media played to the originating party.
+   * @param options.tag - Tag for event correlation.
+   * @param options.maxDuration - Maximum connect duration in seconds.
+   * @param options.maxPricePerMinute - Price cap per minute.
+   * @param options.statusUrl - Webhook URL for status events.
+   * @returns The platform's connect response.
+   * @throws {RelayError} When the connect command is rejected.
+   */
   async connect(
     devices: Record<string, unknown>[][],
     options: {
@@ -399,14 +517,26 @@ export class Call {
     return this._execute('connect', params);
   }
 
-  /** Disconnect (unbridge) a connected call. */
+  /**
+   * Disconnect (unbridge) a connected call.
+   *
+   * @returns The platform's disconnect response.
+   * @throws {RelayError} When the disconnect command is rejected.
+   */
   async disconnect(): Promise<Record<string, unknown>> {
     return this._execute('disconnect');
   }
 
   // ─── DTMF ────────────────────────────────────────────────────────
 
-  /** Send DTMF digits on the call. */
+  /**
+   * Send DTMF digits on the call.
+   *
+   * @param digits - The DTMF digit string to send (e.g. `"1234#"`, `"ww*9"`).
+   * @param controlId - Explicit control ID. Auto-generated when omitted.
+   * @returns The platform's send-digits response.
+   * @throws {RelayError} When the send_digits command is rejected.
+   */
   async sendDigits(digits: string, controlId?: string): Promise<Record<string, unknown>> {
     const cid = controlId ?? randomUUID();
     return this._execute('send_digits', { control_id: cid, digits });
@@ -414,7 +544,17 @@ export class Call {
 
   // ─── Detection ───────────────────────────────────────────────────
 
-  /** Start audio detection (machine, fax, digit). Returns a DetectAction. */
+  /**
+   * Start audio detection (answering machine, fax, DTMF).
+   *
+   * @param detect - Platform-shaped detect configuration.
+   * @param options - Detection behaviour.
+   * @param options.timeout - Detection timeout in seconds.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.onCompleted - Callback fired when detection completes.
+   * @returns A {@link DetectAction} for control and completion tracking.
+   * @throws {RelayError} When the detect command is rejected.
+   */
   async detect(
     detect: Record<string, unknown>,
     options: {
@@ -432,7 +572,15 @@ export class Call {
 
   // ─── SIP Refer ───────────────────────────────────────────────────
 
-  /** Transfer a SIP call via REFER. */
+  /**
+   * Transfer a SIP call via REFER.
+   *
+   * @param device - Platform-shaped SIP target device descriptor.
+   * @param options - Optional REFER behaviour.
+   * @param options.statusUrl - Webhook URL for REFER status events.
+   * @returns The platform's refer response.
+   * @throws {RelayError} When the refer command is rejected.
+   */
   async refer(
     device: Record<string, unknown>,
     options: { statusUrl?: string } = {},
@@ -444,7 +592,16 @@ export class Call {
 
   // ─── Payment ─────────────────────────────────────────────────────
 
-  /** Start a payment collection. Returns a PayAction. */
+  /**
+   * Start a PCI-compliant payment collection flow.
+   *
+   * @param paymentConnectorUrl - URL of the configured payment connector to
+   *   tokenise the card with.
+   * @param options - Payment configuration — card-type filters, prompts,
+   *   charge amount, etc. See the SignalWire pay documentation for field details.
+   * @returns A {@link PayAction} tracking the payment-collection flow.
+   * @throws {RelayError} When the pay command is rejected.
+   */
   async pay(
     paymentConnectorUrl: string,
     options: {
@@ -497,7 +654,18 @@ export class Call {
 
   // ─── Faxing ──────────────────────────────────────────────────────
 
-  /** Send a fax document. Returns a FaxAction. */
+  /**
+   * Send a fax document.
+   *
+   * @param document - URL of the document to fax (TIFF or PDF).
+   * @param options - Fax behaviour.
+   * @param options.identity - Caller identity string sent in the fax header.
+   * @param options.headerInfo - Additional fax header text.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.onCompleted - Callback fired when the fax completes.
+   * @returns A {@link FaxAction} for control and completion tracking.
+   * @throws {RelayError} When the send_fax command is rejected.
+   */
   async sendFax(
     document: string,
     options: {
@@ -515,7 +683,15 @@ export class Call {
     return this._startAction(action, 'send_fax', params, options.onCompleted);
   }
 
-  /** Receive a fax. Returns a FaxAction. */
+  /**
+   * Receive a fax and save it server-side.
+   *
+   * @param options - Fax reception behaviour.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.onCompleted - Callback fired when the fax completes.
+   * @returns A {@link FaxAction} for control and completion tracking.
+   * @throws {RelayError} When the receive_fax command is rejected.
+   */
   async receiveFax(
     options: {
       controlId?: string;
@@ -530,7 +706,17 @@ export class Call {
 
   // ─── Tap (Media Interception) ────────────────────────────────────
 
-  /** Intercept call media and stream it. Returns a TapAction. */
+  /**
+   * Intercept call media and stream it to an external destination.
+   *
+   * @param tap - Platform-shaped tap configuration (direction, codec, etc.).
+   * @param device - Destination device descriptor (WebSocket URL, etc.).
+   * @param options - Tap behaviour.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.onCompleted - Callback fired when the tap completes.
+   * @returns A {@link TapAction} for control and completion tracking.
+   * @throws {RelayError} When the tap command is rejected.
+   */
   async tap(
     tap: Record<string, unknown>,
     device: Record<string, unknown>,
@@ -547,7 +733,24 @@ export class Call {
 
   // ─── Streaming ───────────────────────────────────────────────────
 
-  /** Start streaming call audio to a WebSocket endpoint. Returns a StreamAction. */
+  /**
+   * Start streaming call audio to a WebSocket endpoint.
+   *
+   * @param url - WebSocket URL to stream audio to.
+   * @param options - Stream behaviour.
+   * @param options.name - Friendly name for the stream.
+   * @param options.codec - Audio codec (e.g. `"PCMU"`, `"PCMA"`).
+   * @param options.track - Which track to send: `"inbound"`, `"outbound"`, or
+   *   `"both"`.
+   * @param options.statusUrl - Webhook URL for stream status events.
+   * @param options.statusUrlMethod - HTTP method for `statusUrl` requests.
+   * @param options.authorizationBearerToken - Bearer token sent to the stream endpoint.
+   * @param options.customParameters - Extra parameters forwarded to the stream endpoint.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.onCompleted - Callback fired when the stream completes.
+   * @returns A {@link StreamAction} for control and completion tracking.
+   * @throws {RelayError} When the stream command is rejected.
+   */
   async stream(
     url: string,
     options: {
@@ -577,7 +780,14 @@ export class Call {
 
   // ─── Transfer ────────────────────────────────────────────────────
 
-  /** Transfer call control to another RELAY app or SWML script. */
+  /**
+   * Transfer call control to another RELAY app or SWML script.
+   *
+   * @param dest - Destination identifier (RELAY context, SWML URL, etc.).
+   * @param extra - Optional additional params merged into the transfer request.
+   * @returns The platform's transfer response.
+   * @throws {RelayError} When the transfer command is rejected.
+   */
   async transfer(dest: string, extra?: Record<string, unknown>): Promise<Record<string, unknown>> {
     const params: Record<string, unknown> = { dest, ...extra };
     return this._execute('transfer', params);
@@ -585,7 +795,14 @@ export class Call {
 
   // ─── Conference ──────────────────────────────────────────────────
 
-  /** Join an ad-hoc audio conference. */
+  /**
+   * Join an ad-hoc audio conference.
+   *
+   * @param name - Conference name. Participants on the same name hear each other.
+   * @param options - Conference behaviour (muting, recording, status callbacks, etc.).
+   * @returns The platform's join-conference response.
+   * @throws {RelayError} When the join_conference command is rejected.
+   */
   async joinConference(
     name: string,
     options: {
@@ -633,38 +850,74 @@ export class Call {
     return this._execute('join_conference', params);
   }
 
-  /** Leave an audio conference. */
+  /**
+   * Leave an audio conference.
+   *
+   * @param conferenceId - Identifier of the conference to leave.
+   * @param extra - Optional additional params merged into the request.
+   * @returns The platform's leave-conference response.
+   * @throws {RelayError} When the leave_conference command is rejected.
+   */
   async leaveConference(conferenceId: string, extra?: Record<string, unknown>): Promise<Record<string, unknown>> {
     return this._execute('leave_conference', { conference_id: conferenceId, ...extra });
   }
 
   // ─── Hold / Unhold ───────────────────────────────────────────────
 
-  /** Put the call on hold. */
+  /**
+   * Put the call on hold.
+   *
+   * @returns The platform's hold response.
+   * @throws {RelayError} When the hold command is rejected.
+   */
   async hold(): Promise<Record<string, unknown>> {
     return this._execute('hold');
   }
 
-  /** Release the call from hold. */
+  /**
+   * Release the call from hold.
+   *
+   * @returns The platform's unhold response.
+   * @throws {RelayError} When the unhold command is rejected.
+   */
   async unhold(): Promise<Record<string, unknown>> {
     return this._execute('unhold');
   }
 
   // ─── Denoise ─────────────────────────────────────────────────────
 
-  /** Start noise reduction on the call. */
+  /**
+   * Start noise reduction on the call.
+   *
+   * @returns The platform's denoise response.
+   * @throws {RelayError} When the denoise command is rejected.
+   */
   async denoise(): Promise<Record<string, unknown>> {
     return this._execute('denoise');
   }
 
-  /** Stop noise reduction on the call. */
+  /**
+   * Stop noise reduction on the call.
+   *
+   * @returns The platform's denoise-stop response.
+   * @throws {RelayError} When the denoise.stop command is rejected.
+   */
   async denoiseStop(): Promise<Record<string, unknown>> {
     return this._execute('denoise.stop');
   }
 
   // ─── Transcribe ──────────────────────────────────────────────────
 
-  /** Start transcribing the call. Returns a TranscribeAction. */
+  /**
+   * Start transcribing the call.
+   *
+   * @param options - Transcription behaviour.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.statusUrl - Webhook URL for transcription status events.
+   * @param options.onCompleted - Callback fired when transcription completes.
+   * @returns A {@link TranscribeAction} for control and completion tracking.
+   * @throws {RelayError} When the transcribe command is rejected.
+   */
   async transcribe(
     options: {
       controlId?: string;
@@ -681,7 +934,15 @@ export class Call {
 
   // ─── Echo ────────────────────────────────────────────────────────
 
-  /** Echo audio back to the caller (useful for testing). */
+  /**
+   * Echo audio back to the caller (useful for testing network round-trip).
+   *
+   * @param options - Echo behaviour.
+   * @param options.timeout - How long to echo, in seconds.
+   * @param options.statusUrl - Webhook URL for echo status events.
+   * @returns The platform's echo response.
+   * @throws {RelayError} When the echo command is rejected.
+   */
   async echo(options: { timeout?: number; statusUrl?: string } = {}): Promise<Record<string, unknown>> {
     const params: Record<string, unknown> = {};
     if (options.timeout != null) params.timeout = options.timeout;
@@ -691,7 +952,19 @@ export class Call {
 
   // ─── Digit Bindings ──────────────────────────────────────────────
 
-  /** Bind a DTMF digit sequence to trigger a RELAY method. */
+  /**
+   * Bind a DTMF digit sequence to trigger a RELAY method automatically when
+   * the caller presses it.
+   *
+   * @param digits - DTMF sequence that triggers the binding (e.g. `"*9"`).
+   * @param bindMethod - RELAY method to invoke when the sequence is detected.
+   * @param options - Binding behaviour.
+   * @param options.bindParams - Params forwarded to `bindMethod` on trigger.
+   * @param options.realm - Optional realm label so bindings can be cleared in groups.
+   * @param options.maxTriggers - Maximum number of times the binding can fire.
+   * @returns The platform's bind_digit response.
+   * @throws {RelayError} When the bind_digit command is rejected.
+   */
   async bindDigit(
     digits: string,
     bindMethod: string,
@@ -711,7 +984,13 @@ export class Call {
     return this._execute('bind_digit', params);
   }
 
-  /** Clear all digit bindings, optionally filtered by realm. */
+  /**
+   * Clear all digit bindings, optionally filtered by realm.
+   *
+   * @param realm - When provided, only bindings with this realm label are cleared.
+   * @returns The platform's clear_digit_bindings response.
+   * @throws {RelayError} When the clear_digit_bindings command is rejected.
+   */
   async clearDigitBindings(realm?: string): Promise<Record<string, unknown>> {
     const params: Record<string, unknown> = {};
     if (realm != null) params.realm = realm;
@@ -720,12 +999,29 @@ export class Call {
 
   // ─── Live Transcribe / Translate ─────────────────────────────────
 
-  /** Start or stop live transcription on the call. */
+  /**
+   * Start or stop live transcription on the call.
+   *
+   * @param action - Platform-shaped action block (`start` or `stop` plus
+   *   configuration).
+   * @param extra - Optional additional params merged into the request.
+   * @returns The platform's live_transcribe response.
+   * @throws {RelayError} When the live_transcribe command is rejected.
+   */
   async liveTranscribe(action: Record<string, unknown>, extra?: Record<string, unknown>): Promise<Record<string, unknown>> {
     return this._execute('live_transcribe', { action, ...extra });
   }
 
-  /** Start or stop live translation on the call. */
+  /**
+   * Start or stop live translation on the call.
+   *
+   * @param action - Platform-shaped action block (`start` or `stop` plus
+   *   source/target languages).
+   * @param options - Live-translate behaviour.
+   * @param options.statusUrl - Webhook URL for translation status events.
+   * @returns The platform's live_translate response.
+   * @throws {RelayError} When the live_translate command is rejected.
+   */
   async liveTranslate(
     action: Record<string, unknown>,
     options: { statusUrl?: string } = {},
@@ -737,7 +1033,15 @@ export class Call {
 
   // ─── Room ────────────────────────────────────────────────────────
 
-  /** Join a video/audio room. */
+  /**
+   * Join a video / audio room.
+   *
+   * @param name - Room name — callers on the same name share the same room.
+   * @param options - Room behaviour.
+   * @param options.statusUrl - Webhook URL for room status events.
+   * @returns The platform's join_room response.
+   * @throws {RelayError} When the join_room command is rejected.
+   */
   async joinRoom(
     name: string,
     options: { statusUrl?: string } = {},
@@ -747,14 +1051,26 @@ export class Call {
     return this._execute('join_room', params);
   }
 
-  /** Leave the current room. */
+  /**
+   * Leave the current room.
+   *
+   * @param extra - Optional additional params merged into the request.
+   * @returns The platform's leave_room response.
+   * @throws {RelayError} When the leave_room command is rejected.
+   */
   async leaveRoom(extra?: Record<string, unknown>): Promise<Record<string, unknown>> {
     return this._execute('leave_room', extra);
   }
 
   // ─── AI Agent ────────────────────────────────────────────────────
 
-  /** Start an AI agent session on the call. Returns an AIAction. */
+  /**
+   * Start an AI agent session on the call.
+   *
+   * @param options - AI configuration — prompts, voices, tools, languages, etc.
+   * @returns An {@link AIAction} for control and completion tracking.
+   * @throws {RelayError} When the ai command is rejected.
+   */
   async ai(options: {
     controlId?: string;
     agent?: string;
@@ -789,7 +1105,19 @@ export class Call {
     return this._startAction(action, 'ai', params, options.onCompleted);
   }
 
-  /** Connect to an Amazon Bedrock AI agent. */
+  /**
+   * Connect the call to an Amazon Bedrock AI agent.
+   *
+   * @param options - Bedrock agent configuration.
+   * @param options.prompt - Prompt to send to the Bedrock agent.
+   * @param options.SWAIG - SWAIG configuration (functions, includes, etc.).
+   * @param options.aiParams - AI engine parameters.
+   * @param options.globalData - Global-data object available to SWAIG tools.
+   * @param options.postPrompt - Post-prompt configuration.
+   * @param options.postPromptUrl - URL to POST the final summary to.
+   * @returns The platform's amazon_bedrock response.
+   * @throws {RelayError} When the amazon_bedrock command is rejected.
+   */
   async amazonBedrock(options: {
     prompt?: unknown;
     SWAIG?: Record<string, unknown>;
@@ -808,7 +1136,17 @@ export class Call {
     return this._execute('amazon_bedrock', params);
   }
 
-  /** Send a message to an active AI agent session. */
+  /**
+   * Send a message into an active AI agent session.
+   *
+   * @param options - Message parameters.
+   * @param options.messageText - Text content to inject into the conversation.
+   * @param options.role - Speaker role (`"system"`, `"user"`, or `"assistant"`).
+   * @param options.reset - Reset directives for the conversation state.
+   * @param options.globalData - Global-data updates to merge.
+   * @returns The platform's ai_message response.
+   * @throws {RelayError} When the ai_message command is rejected.
+   */
   async aiMessage(options: {
     messageText?: string;
     role?: string;
@@ -823,7 +1161,15 @@ export class Call {
     return this._execute('ai_message', params);
   }
 
-  /** Put an AI agent session on hold. */
+  /**
+   * Put the AI agent session on hold (pause turn-taking).
+   *
+   * @param options - Hold behaviour.
+   * @param options.timeout - Maximum hold duration.
+   * @param options.prompt - Prompt played to the caller during the hold.
+   * @returns The platform's ai_hold response.
+   * @throws {RelayError} When the ai_hold command is rejected.
+   */
   async aiHold(options: { timeout?: string; prompt?: string } = {}): Promise<Record<string, unknown>> {
     const params: Record<string, unknown> = {};
     if (options.timeout != null) params.timeout = options.timeout;
@@ -831,7 +1177,14 @@ export class Call {
     return this._execute('ai_hold', Object.keys(params).length ? params : undefined);
   }
 
-  /** Resume an AI agent session from hold. */
+  /**
+   * Resume an AI agent session from hold.
+   *
+   * @param options - Unhold behaviour.
+   * @param options.prompt - Prompt played to the caller on resume.
+   * @returns The platform's ai_unhold response.
+   * @throws {RelayError} When the ai_unhold command is rejected.
+   */
   async aiUnhold(options: { prompt?: string } = {}): Promise<Record<string, unknown>> {
     const params: Record<string, unknown> = {};
     if (options.prompt != null) params.prompt = options.prompt;
@@ -840,7 +1193,14 @@ export class Call {
 
   // ─── User Events ─────────────────────────────────────────────────
 
-  /** Send a custom user-defined event. */
+  /**
+   * Emit a custom user-defined event on the call for your webhooks.
+   *
+   * @param options - Freeform event payload. Set `options.event` for the
+   *   event name and include any additional fields your webhook expects.
+   * @returns The platform's user_event response.
+   * @throws {RelayError} When the user_event command is rejected.
+   */
   async userEvent(options: { event?: string } & Record<string, unknown> = {}): Promise<Record<string, unknown>> {
     const params: Record<string, unknown> = {};
     if (options.event != null) params.event = options.event;
@@ -849,7 +1209,16 @@ export class Call {
 
   // ─── Queue ───────────────────────────────────────────────────────
 
-  /** Place the call in a queue. */
+  /**
+   * Place the call into a named queue.
+   *
+   * @param queueName - Name of the queue to enter.
+   * @param options - Queue-entry behaviour.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.statusUrl - Webhook URL for queue status events.
+   * @returns The platform's queue.enter response.
+   * @throws {RelayError} When the queue.enter command is rejected.
+   */
   async queueEnter(
     queueName: string,
     options: { controlId?: string; statusUrl?: string } = {},
@@ -863,7 +1232,17 @@ export class Call {
     return this._execute('queue.enter', params);
   }
 
-  /** Remove the call from a queue. */
+  /**
+   * Remove the call from a queue.
+   *
+   * @param queueName - Name of the queue to leave.
+   * @param options - Queue-exit behaviour.
+   * @param options.controlId - Explicit control ID. Auto-generated when omitted.
+   * @param options.queueId - Queue ID override (when multiple queues share a name).
+   * @param options.statusUrl - Webhook URL for queue status events.
+   * @returns The platform's queue.leave response.
+   * @throws {RelayError} When the queue.leave command is rejected.
+   */
   async queueLeave(
     queueName: string,
     options: { controlId?: string; queueId?: string; statusUrl?: string } = {},
@@ -880,6 +1259,11 @@ export class Call {
 
   // ─── Repr ────────────────────────────────────────────────────────
 
+  /**
+   * Return a human-readable diagnostic string.
+   *
+   * @returns `<Call id=... state=... direction=...>` — handy for log output.
+   */
   toString(): string {
     return `<Call id=${this.callId} state=${this.state} direction=${this.direction}>`;
   }

--- a/src/relay/Call.ts
+++ b/src/relay/Call.ts
@@ -35,16 +35,48 @@ export interface RelayClientLike {
   execute(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>>;
 }
 
+/**
+ * Live RELAY call with command methods.
+ *
+ * Don't construct directly — `Call` instances are created by {@link RelayClient}
+ * for inbound calls (delivered to your `onCall` handler) and for outbound dials.
+ *
+ * Each command method (`answer()`, `play()`, `record()`, etc.) returns when the
+ * platform acknowledges the command; event-driven completion is exposed via
+ * {@link Action} objects returned from the async "play/record/..." variants.
+ *
+ * @example Inside an onCall handler
+ * ```ts
+ * client.onCall(async (call) => {
+ *   await call.answer();
+ *   const play = await call.playAsync({ play: [{ type: 'tts', text: 'Hello!' }] });
+ *   await play.wait();
+ *   await call.hangup();
+ * });
+ * ```
+ *
+ * @see {@link RelayClient}
+ * @see {@link Action}
+ */
 export class Call {
   /** @internal */ readonly _client: RelayClientLike;
+  /** Unique call identifier assigned by the platform. */
   callId: string;
+  /** RELAY node that owns this call. */
   nodeId: string;
+  /** SignalWire project ID. */
   projectId: string;
+  /** RELAY context this call was received on. */
   context: string;
+  /** Opaque correlation tag attached at dial time. */
   tag: string;
+  /** `"inbound"` or `"outbound"`. */
   direction: string;
+  /** Device descriptor the call is associated with (phone, SIP, etc.). */
   device: Record<string, any>;
+  /** Current call state (e.g. `"created"`, `"answered"`, `"ended"`). */
   state: string;
+  /** Call segment ID used for event correlation. */
   segmentId: string;
 
   /** @internal */ readonly _listeners: Map<string, EventHandler[]> = new Map();

--- a/src/relay/Deferred.ts
+++ b/src/relay/Deferred.ts
@@ -21,8 +21,15 @@ export interface Deferred<T> {
 }
 
 /**
- * Create a Deferred<T> with externalized resolve/reject and a settled flag.
- * The `settled` property is true once resolve() or reject() has been called.
+ * Create a {@link Deferred} with externalised `resolve` / `reject` and a
+ * `settled` flag.
+ *
+ * The returned object exposes the promise plus its resolve and reject
+ * functions so callers outside the executor can settle it. Later calls to
+ * `resolve` or `reject` are idempotent.
+ *
+ * @typeParam T - Resolution value type of the wrapped promise.
+ * @returns A fresh `Deferred<T>` in pending state.
  */
 export function createDeferred<T>(): Deferred<T> {
   let _resolve!: (value: T | PromiseLike<T>) => void;
@@ -53,8 +60,15 @@ export function createDeferred<T>(): Deferred<T> {
 }
 
 /**
- * Race a promise against a timeout. Rejects with an Error if the timeout
- * expires before the promise settles.
+ * Race a promise against a timeout.
+ *
+ * @typeParam T - Resolution value type of the input promise.
+ * @param promise - Promise to race against the timeout.
+ * @param ms - Timeout in milliseconds.
+ * @param label - Label used in the timeout error message. Defaults to
+ *   `"Operation"`.
+ * @returns A new promise that resolves with `promise`'s value if it settles
+ *   before the timeout, and rejects with a timeout `Error` otherwise.
  */
 export function withTimeout<T>(
   promise: Promise<T>,

--- a/src/relay/Deferred.ts
+++ b/src/relay/Deferred.ts
@@ -4,10 +4,19 @@
  * Uses a manual promise constructor for Node 18+ compatibility.
  */
 
+/**
+ * A promise with externalised `resolve`/`reject` and a `settled` flag,
+ * used by the RELAY client to bridge server-push events back to in-flight
+ * JSON-RPC request callers.
+ */
 export interface Deferred<T> {
+  /** The wrapped promise. */
   promise: Promise<T>;
+  /** Resolve the promise idempotently (later calls are ignored). */
   resolve: (value: T | PromiseLike<T>) => void;
+  /** Reject the promise idempotently (later calls are ignored). */
   reject: (reason?: unknown) => void;
+  /** True once either `resolve` or `reject` has been called. */
   readonly settled: boolean;
 }
 

--- a/src/relay/Message.ts
+++ b/src/relay/Message.ts
@@ -101,14 +101,27 @@ export class Message {
 
   private _result: RelayEvent | undefined;
 
-  /** Register an event listener for state changes on this message. */
+  /**
+   * Register an event listener for state changes on this message.
+   *
+   * The handler fires every time the server emits a `messaging.state` event
+   * for this message (multiple listeners are supported). Listener errors are
+   * logged but do not disrupt dispatch.
+   *
+   * @param handler - Callback invoked for each state-change event.
+   */
   on(handler: EventHandler): void {
     this._listeners.push(handler);
   }
 
   /**
-   * Wait for the message to reach a terminal state.
-   * @param timeout - Maximum time to wait in seconds (matches Python SDK convention).
+   * Wait for the message to reach a terminal state (`delivered`, `failed`,
+   * `undelivered`, etc.).
+   *
+   * @param timeout - Maximum time to wait in **seconds** (matches the Python
+   *   SDK convention — not milliseconds).
+   * @returns The final `messaging.state` {@link RelayEvent}.
+   * @throws {Error} When the optional timeout elapses before a terminal state.
    */
   async wait(timeout?: number): Promise<RelayEvent> {
     if (timeout != null) {
@@ -174,6 +187,12 @@ export class Message {
     }
   }
 
+  /**
+   * Return a human-readable diagnostic string.
+   *
+   * @returns `Message(id=..., direction=..., state=..., from=..., to=...)` —
+   *   handy for log output.
+   */
   toString(): string {
     return `Message(id=${this.messageId}, direction=${this.direction}, state=${this.state}, from=${this.fromNumber}, to=${this.toNumber})`;
   }

--- a/src/relay/Message.ts
+++ b/src/relay/Message.ts
@@ -14,17 +14,47 @@ import type { CompletedCallback, EventHandler } from './types.js';
 
 const logger = getLogger('relay_message');
 
+/**
+ * SMS/MMS message in the RELAY messaging namespace.
+ *
+ * Outbound messages progress through `queued` → `initiated` → `sent` → `delivered`
+ * (or `undelivered` / `failed`). Inbound messages arrive with state `received`.
+ * Call {@link Message.wait} to await a terminal state.
+ *
+ * @example Wait for delivery confirmation
+ * ```ts
+ * const msg = await client.sendMessage({
+ *   to: '+15551234567',
+ *   from: '+15557654321',
+ *   body: 'Your code is 4242',
+ * });
+ *
+ * const final = await msg.wait(30); // seconds
+ * console.log('Final state:', final.params.message_state);
+ * ```
+ */
 export class Message {
+  /** Unique message identifier assigned by the platform. */
   messageId: string;
+  /** RELAY context the message belongs to. */
   context: string;
+  /** `"inbound"` or `"outbound"`. */
   direction: string;
+  /** Sender phone number in E.164 format. */
   fromNumber: string;
+  /** Destination phone number in E.164 format. */
   toNumber: string;
+  /** Plain-text message body. */
   body: string;
+  /** Media URLs attached to the message (MMS). */
   media: string[];
+  /** Number of segments the carrier split the message into. */
   segments: number;
+  /** Current message state (e.g. `"sent"`, `"delivered"`, `"failed"`). */
   state: string;
+  /** Failure / undelivery reason when `state` is non-successful. */
   reason: string;
+  /** Opaque tags attached to the message. */
   tags: string[];
 
   private _done: Deferred<RelayEvent>;
@@ -58,10 +88,12 @@ export class Message {
     this._done = createDeferred<RelayEvent>();
   }
 
+  /** True once the message has reached a terminal state. */
   get isDone(): boolean {
     return this._done.settled;
   }
 
+  /** Final event that terminated the message, or `null` if still in-flight. */
   get result(): RelayEvent | null {
     // We can't synchronously get the result from a promise, so we track it
     return this._result ?? null;

--- a/src/relay/RelayClient.ts
+++ b/src/relay/RelayClient.ts
@@ -238,13 +238,32 @@ export class RelayClient {
 
   // ─── Handler Registration ──────────────────────────────────────
 
-  /** Register the inbound call handler. Returns the handler to support decorator usage. */
+  /**
+   * Register the inbound call handler.
+   *
+   * The handler is invoked once per inbound call, with a fully-formed
+   * {@link Call} already in state `"created"`. Answer, reject, or forward
+   * the call from inside the handler.
+   *
+   * @param handler - Callback invoked for each inbound call. May return a
+   *   promise; errors are logged but do not tear down the client.
+   * @returns The same handler, to support decorator-style usage.
+   */
   onCall(handler: CallHandler): CallHandler {
     this._onCallHandler = handler;
     return handler;
   }
 
-  /** Register the inbound message handler. Returns the handler to support decorator usage. */
+  /**
+   * Register the inbound message handler.
+   *
+   * The handler is invoked once per inbound SMS/MMS delivered to a subscribed
+   * context, with a {@link Message} already in state `"received"`.
+   *
+   * @param handler - Callback invoked for each inbound message. May return a
+   *   promise; errors are logged but do not tear down the client.
+   * @returns The same handler, to support decorator-style usage.
+   */
   onMessage(handler: MessageHandler): MessageHandler {
     this._onMessageHandler = handler;
     return handler;
@@ -252,7 +271,18 @@ export class RelayClient {
 
   // ─── Connection Lifecycle ──────────────────────────────────────
 
-  /** Connect to RELAY and authenticate. */
+  /**
+   * Connect to RELAY and authenticate.
+   *
+   * Opens the WebSocket, runs the JSON-RPC `signalwire.connect` handshake,
+   * and starts the client-side ping loop. Safe to call again after a
+   * `disconnect()` to reconnect; the process-wide concurrent-connection limit
+   * is enforced here.
+   *
+   * @returns Resolves once the client is connected and authenticated.
+   * @throws {Error} When the process-wide connection limit is reached,
+   *   authentication fails, or the WebSocket cannot be opened.
+   */
   async connect(): Promise<void> {
     // Guard against connection leaks — enforce per-process limit.
     // Don't count ourselves (allows reconnect without double-counting).
@@ -371,7 +401,15 @@ export class RelayClient {
     logger.debug(`Auth response: protocol=${this._relayProtocol} identity=${this._identity}`);
   }
 
-  /** Cleanly close the connection. */
+  /**
+   * Cleanly close the connection.
+   *
+   * Stops the ping loop, drops the WebSocket, rejects every pending request
+   * and dial with a `Connection closed` {@link RelayError}, and removes the
+   * client from the process-wide active set. Safe to call repeatedly.
+   *
+   * @returns Resolves once all resources have been released.
+   */
   async disconnect(): Promise<void> {
     this._closing = true;
     this._connected = false;
@@ -414,18 +452,40 @@ export class RelayClient {
 
   // ─── Public RPC Interface ──────────────────────────────────────
 
-  /** Send a JSON-RPC request and await the response. */
+  /**
+   * Send a JSON-RPC request and await the response.
+   *
+   * This is the low-level escape hatch for calling RELAY methods that don't
+   * yet have a higher-level helper on this class. Queued if the client is
+   * currently disconnected; sent immediately otherwise.
+   *
+   * @param method - Fully-qualified JSON-RPC method name (e.g. `"calling.play"`).
+   * @param params - Method-specific params object.
+   * @returns The `result` field of the JSON-RPC response.
+   * @throws {RelayError} When the server returns a non-2xx code.
+   */
   async execute(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
     return this._sendRequest(method, params);
   }
 
   /**
-   * Initiate an outbound call. Returns a Call when answered.
+   * Initiate an outbound call.
    *
-   * @param devices - Array of device lists (serial/parallel dial).
-   * @param options.tag - Client-provided tag for event correlation. Auto-generated if not supplied.
-   * @param options.maxDuration - Optional max call duration in minutes.
-   * @param options.dialTimeout - How long (seconds) to wait for the dial to complete. Defaults to 120.
+   * Accepts a "dial plan" — an outer array of serial groups, each containing
+   * an inner array of devices dialled in parallel. Resolves when any device
+   * answers; rejects if no device answers within `dialTimeout`.
+   *
+   * @param devices - Serial/parallel dial plan. `[[A], [B, C]]` dials A first,
+   *   then B and C in parallel.
+   * @param options - Optional dial behaviour overrides.
+   * @param options.tag - Client-provided tag for event correlation.
+   *   Auto-generated (UUID) when omitted.
+   * @param options.maxDuration - Maximum call duration in minutes.
+   * @param options.dialTimeout - Seconds to wait for the dial to complete.
+   *   Defaults to `120`.
+   * @returns A {@link Call} representing the answered leg.
+   * @throws {Error} When the dial times out.
+   * @throws {RelayError} When the server rejects the dial request.
    */
   async dial(
     devices: Record<string, unknown>[][],
@@ -476,16 +536,25 @@ export class RelayClient {
   }
 
   /**
-   * Send an outbound SMS/MMS message. Returns a Message.
+   * Send an outbound SMS / MMS message.
    *
+   * The method returns as soon as the server has accepted the send; track the
+   * message's terminal state with {@link Message.wait} or the `onCompleted`
+   * callback.
+   *
+   * @param options - Send parameters.
    * @param options.toNumber - Destination phone number in E.164 format.
    * @param options.fromNumber - Sender phone number in E.164 format.
-   * @param options.context - Context for receiving state events. Defaults to the relay protocol.
+   * @param options.context - Context for receiving state events. Defaults to
+   *   the negotiated relay protocol.
    * @param options.body - Text body of the message.
    * @param options.media - List of media URLs for MMS.
-   * @param options.tags - Optional tags for the message.
-   * @param options.region - Optional origination region.
-   * @param options.onCompleted - Optional callback fired when a terminal state is reached.
+   * @param options.tags - Tags attached to the message for correlation.
+   * @param options.region - Origination region override.
+   * @param options.onCompleted - Optional callback fired when the message
+   *   reaches a terminal state (delivered / failed / undelivered).
+   * @returns A {@link Message} tracking the outbound send.
+   * @throws {RelayError} When the server rejects the send request.
    */
   async sendMessage(options: {
     toNumber: string;
@@ -536,14 +605,30 @@ export class RelayClient {
     return message;
   }
 
-  /** Subscribe to additional contexts. */
+  /**
+   * Subscribe to additional RELAY contexts on an already-connected client.
+   *
+   * Inbound calls and messages on any of the listed contexts will be delivered
+   * to the `onCall` / `onMessage` handlers. A no-op when `contexts` is empty.
+   *
+   * @param contexts - Context names to subscribe to.
+   * @returns Resolves once the server has confirmed the subscription.
+   * @throws {RelayError} When the server rejects the subscribe request.
+   */
   async receive(contexts: string[]): Promise<void> {
     if (!contexts.length) return;
     await this._sendRequest(METHOD_SIGNALWIRE_RECEIVE, { contexts });
     logger.info(`Subscribed to contexts: ${contexts}`);
   }
 
-  /** Unsubscribe from contexts. */
+  /**
+   * Unsubscribe from contexts previously passed to {@link receive} (or the
+   * constructor). A no-op when `contexts` is empty.
+   *
+   * @param contexts - Context names to unsubscribe from.
+   * @returns Resolves once the server has confirmed the unsubscribe.
+   * @throws {RelayError} When the server rejects the unsubscribe request.
+   */
   async unreceive(contexts: string[]): Promise<void> {
     if (!contexts.length) return;
     await this._sendRequest(METHOD_SIGNALWIRE_UNRECEIVE, { contexts });
@@ -552,7 +637,18 @@ export class RelayClient {
 
   // ─── Run (auto-reconnect loop) ────────────────────────────────
 
-  /** Blocking entry point — connects and maintains connection with auto-reconnect. */
+  /**
+   * Blocking entry point — connects and maintains the connection with
+   * auto-reconnect, returning only after a clean shutdown (Ctrl+C, SIGTERM,
+   * or {@link disconnect} from another scope).
+   *
+   * Installs `SIGINT` / `SIGTERM` handlers, so typically only one `RelayClient`
+   * per process should call `run()`.
+   *
+   * @returns Resolves once a shutdown has been requested and cleanup completes.
+   * @throws {Error} Only on unrecoverable startup failures — normal
+   *   disconnects are handled internally by the reconnect loop.
+   */
   async run(): Promise<void> {
     this._closing = false;
     this._shutdownDeferred = createDeferred<void>();

--- a/src/relay/RelayClient.ts
+++ b/src/relay/RelayClient.ts
@@ -84,11 +84,57 @@ type WsLike = {
   ping?(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
 };
 
+/**
+ * Real-time WebSocket client for SignalWire RELAY.
+ *
+ * One instance = one persistent JSON-RPC 2.0 WebSocket connection. Lets you
+ * place / receive calls and SMS, play/record media, run TTS, conference calls
+ * together, and subscribe to platform events — all without HTTP polling.
+ *
+ * Authentication supports either a project/token pair or a JWT.
+ *
+ * @example Inbound-call handler
+ * ```ts
+ * import { RelayClient } from '@signalwire/sdk';
+ *
+ * const client = new RelayClient({
+ *   project: process.env.SIGNALWIRE_PROJECT_ID!,
+ *   token: process.env.SIGNALWIRE_API_TOKEN!,
+ *   host: 'example.signalwire.com',
+ *   contexts: ['office'],
+ * });
+ *
+ * client.onCall(async (call) => {
+ *   await call.answer();
+ *   await call.playTTS({ text: 'Thanks for calling!' });
+ *   await call.hangup();
+ * });
+ *
+ * await client.connect();
+ * ```
+ *
+ * @example Outbound dial + SMS
+ * ```ts
+ * await client.connect();
+ * const call = await client.dial({
+ *   devices: [[{ type: 'phone', to: '+15551234567', from: '+15557654321' }]],
+ * });
+ * await client.sendMessage({ to: '+15551234567', from: '+15557654321', body: 'Hi!' });
+ * ```
+ *
+ * @see {@link Call}
+ * @see {@link Message}
+ */
 export class RelayClient {
+  /** Project ID used for Basic Auth. */
   readonly project: string;
+  /** API token used for Basic Auth. */
   readonly token: string;
+  /** JWT used instead of project/token if provided. */
   readonly jwtToken: string;
+  /** Hostname of the RELAY endpoint (e.g. `example.signalwire.com`). */
   readonly host: string;
+  /** Contexts this client subscribes to for inbound events. */
   readonly contexts: string[];
 
   private _ws: WsLike | null = null;
@@ -127,6 +173,12 @@ export class RelayClient {
    */
   _wsFactory: ((url: string) => WsLike) | null = null;
 
+  /**
+   * Create a new RELAY client.
+   * Credentials fall back to the `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_API_TOKEN`,
+   * `SIGNALWIRE_JWT_TOKEN`, and `SIGNALWIRE_SPACE` env vars when omitted.
+   * @param options - Optional client configuration.
+   */
   constructor(options: RelayClientOptions = {}) {
     this.project = options.project ?? process.env.SIGNALWIRE_PROJECT_ID ?? '';
     this.token = options.token ?? process.env.SIGNALWIRE_API_TOKEN ?? '';
@@ -158,6 +210,7 @@ export class RelayClient {
     }
   }
 
+  /** The protocol name the server assigned to this client after `connect()`. */
   get relayProtocol(): string {
     return this._relayProtocol;
   }

--- a/src/relay/RelayError.ts
+++ b/src/relay/RelayError.ts
@@ -1,11 +1,17 @@
 /**
  * Custom error class for RELAY protocol errors.
  *
- * Mirrors the Python SDK signature: `RelayError(code, message)`.
+ * Thrown when the server returns a non-2xx JSON-RPC result code. Mirrors the
+ * Python SDK signature: `RelayError(code, message)`.
  */
 export class RelayError extends Error {
+  /** Numeric RELAY result code returned by the server. */
   readonly code: number;
 
+  /**
+   * @param code - Numeric RELAY result code (e.g. `404`, `503`).
+   * @param message - Human-readable error message from the server.
+   */
   constructor(code: number, message: string) {
     super(`RELAY error ${code}: ${message}`);
     this.name = 'RelayError';

--- a/src/relay/RelayEvent.ts
+++ b/src/relay/RelayEvent.ts
@@ -9,12 +9,30 @@
 
 // ─── Base Event ──────────────────────────────────────────────────────
 
+/**
+ * Base class for all typed RELAY events.
+ *
+ * Raw events arrive as `signalwire.event` JSON-RPC notifications; the client
+ * looks up the correct subclass in {@link EVENT_CLASS_MAP} and invokes
+ * {@link RelayEvent.fromPayload} to build a typed wrapper. Handlers receive
+ * this wrapper; they can always read the original dict from `params`.
+ */
 export class RelayEvent {
+  /** Fully-qualified event type (e.g. `"calling.call.state"`). */
   readonly eventType: string;
+  /** Raw params dict from the RELAY notification. */
   readonly params: Record<string, any>;
+  /** Call ID associated with the event, or `""` for non-call events. */
   readonly callId: string;
+  /** Server timestamp (epoch seconds) at which the event was emitted. */
   readonly timestamp: number;
 
+  /**
+   * @param eventType - Fully-qualified event type.
+   * @param params - Raw event params dict.
+   * @param callId - Call ID (if applicable).
+   * @param timestamp - Server-side event timestamp.
+   */
   constructor(
     eventType: string,
     params: Record<string, any>,
@@ -27,6 +45,12 @@ export class RelayEvent {
     this.timestamp = timestamp;
   }
 
+  /**
+   * Factory that builds a typed event from a raw `signalwire.event` payload.
+   * Subclasses override this to populate their specialised fields; the base
+   * implementation returns a minimal `RelayEvent` used as the fallback for
+   * unrecognised event types.
+   */
   static fromPayload(payload: Record<string, any>): RelayEvent {
     const eventType = payload.event_type ?? '';
     const params = payload.params ?? {};
@@ -54,6 +78,7 @@ function baseFields(payload: Record<string, any>) {
 
 // ─── Call Events ─────────────────────────────────────────────────────
 
+/** `calling.call.state` — fires on every lifecycle transition (created, ringing, answered, ending, ended). */
 export class CallStateEvent extends RelayEvent {
   readonly callState: string;
   readonly endReason: string;
@@ -89,6 +114,7 @@ export class CallStateEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.receive` — fires when an inbound call arrives on a subscribed context. */
 export class CallReceiveEvent extends RelayEvent {
   readonly callState: string;
   readonly direction: string;
@@ -140,6 +166,7 @@ export class CallReceiveEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.play` — play-media action state change (`playing`, `paused`, `finished`, `error`). */
 export class PlayEvent extends RelayEvent {
   readonly controlId: string;
   readonly state: string;
@@ -167,6 +194,7 @@ export class PlayEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.record` — recording state change with final URL, duration, and size when finished. */
 export class RecordEvent extends RelayEvent {
   readonly controlId: string;
   readonly state: string;
@@ -211,6 +239,7 @@ export class RecordEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.collect` — caller input (DTMF or speech) collected by a collect action. */
 export class CollectEvent extends RelayEvent {
   readonly controlId: string;
   readonly state: string;
@@ -246,6 +275,7 @@ export class CollectEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.connect` — state transition when one call connects to another (dialplan/bridge). */
 export class ConnectEvent extends RelayEvent {
   readonly connectState: string;
   readonly peer: Record<string, any>;
@@ -273,6 +303,7 @@ export class ConnectEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.detect` — answering-machine / fax / DTMF detection result. */
 export class DetectEvent extends RelayEvent {
   readonly controlId: string;
   readonly detect: Record<string, any>;
@@ -300,6 +331,7 @@ export class DetectEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.fax` — fax send/receive progress update. */
 export class FaxEvent extends RelayEvent {
   readonly controlId: string;
   readonly fax: Record<string, any>;
@@ -327,6 +359,7 @@ export class FaxEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.tap` — media tap state change (audio mirror to an external endpoint). */
 export class TapEvent extends RelayEvent {
   readonly controlId: string;
   readonly state: string;
@@ -362,6 +395,7 @@ export class TapEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.stream` — outbound media stream state change (e.g. RTMP/WebSocket streaming). */
 export class StreamEvent extends RelayEvent {
   readonly controlId: string;
   readonly state: string;
@@ -397,6 +431,7 @@ export class StreamEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.send_digits` — progress update for DTMF digits sent out on a call. */
 export class SendDigitsEvent extends RelayEvent {
   readonly controlId: string;
   readonly state: string;
@@ -424,6 +459,7 @@ export class SendDigitsEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.dial` — outbound dial progress (answered, failed, no-answer, etc.). */
 export class DialEvent extends RelayEvent {
   readonly tag: string;
   readonly dialState: string;
@@ -455,6 +491,7 @@ export class DialEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.refer` — SIP REFER result (off-platform transfer response codes). */
 export class ReferEvent extends RelayEvent {
   readonly state: string;
   readonly sipReferTo: string;
@@ -490,6 +527,7 @@ export class ReferEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.denoise` — noise-reduction on/off confirmation. */
 export class DenoiseEvent extends RelayEvent {
   readonly denoised: boolean;
 
@@ -513,6 +551,7 @@ export class DenoiseEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.pay` — PCI-compliant payment collection progress update. */
 export class PayEvent extends RelayEvent {
   readonly controlId: string;
   readonly state: string;
@@ -540,6 +579,7 @@ export class PayEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.queue` — call-queue position update (queued, waiting, member answered, timed out). */
 export class QueueEvent extends RelayEvent {
   readonly controlId: string;
   readonly status: string;
@@ -583,6 +623,7 @@ export class QueueEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.echo` — test/diagnostic echo reflection from the server. */
 export class EchoEvent extends RelayEvent {
   readonly state: string;
 
@@ -606,6 +647,7 @@ export class EchoEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.transcribe` — transcription state change and final URL/duration when finished. */
 export class TranscribeEvent extends RelayEvent {
   readonly controlId: string;
   readonly state: string;
@@ -649,6 +691,7 @@ export class TranscribeEvent extends RelayEvent {
   }
 }
 
+/** `calling.call.hold` — hold/unhold state change on the call. */
 export class HoldEvent extends RelayEvent {
   readonly state: string;
 
@@ -672,6 +715,7 @@ export class HoldEvent extends RelayEvent {
   }
 }
 
+/** `calling.conference` — conference lifecycle change (created, active, ended). */
 export class ConferenceEvent extends RelayEvent {
   readonly conferenceId: string;
   readonly name: string;
@@ -703,6 +747,7 @@ export class ConferenceEvent extends RelayEvent {
   }
 }
 
+/** `calling.error` — platform-emitted error against the calling namespace. */
 export class CallingErrorEvent extends RelayEvent {
   readonly code: string;
   readonly message: string;
@@ -732,6 +777,7 @@ export class CallingErrorEvent extends RelayEvent {
 
 // ─── Messaging Events ────────────────────────────────────────────────
 
+/** `messaging.receive` — inbound SMS/MMS received on a subscribed context. */
 export class MessageReceiveEvent extends RelayEvent {
   readonly messageId: string;
   readonly context: string;
@@ -791,6 +837,7 @@ export class MessageReceiveEvent extends RelayEvent {
   }
 }
 
+/** `messaging.state` — state change for an outbound message (queued → sent → delivered/failed). */
 export class MessageStateEvent extends RelayEvent {
   readonly messageId: string;
   readonly context: string;
@@ -856,8 +903,13 @@ export class MessageStateEvent extends RelayEvent {
 
 // ─── Event Class Map & Parser ────────────────────────────────────────
 
+/** Structural type for an event class that exposes a `fromPayload` factory. */
 export type EventClass = { fromPayload(payload: Record<string, any>): RelayEvent };
 
+/**
+ * Maps RELAY `event_type` strings to the typed event subclass that builds
+ * its wrapper. Used by {@link parseEvent} to dispatch raw payloads.
+ */
 export const EVENT_CLASS_MAP: Record<string, EventClass> = {
   'calling.call.state': CallStateEvent,
   'calling.call.receive': CallReceiveEvent,

--- a/src/rest/HttpClient.ts
+++ b/src/rest/HttpClient.ts
@@ -26,6 +26,14 @@ export class HttpClient {
   private readonly _authHeader: string;
   private readonly _fetch: typeof globalThis.fetch;
 
+  /**
+   * Build a new HTTP client.
+   *
+   * @param options - Connection options. Either `host` (bare hostname;
+   *   `https://` is prepended automatically) or `baseUrl` (fully-qualified)
+   *   must be provided along with `project` + `token`.
+   * @throws {Error} When neither `host` nor `baseUrl` is supplied.
+   */
   constructor(options: HttpClientOptions) {
     if (!options.host && !options.baseUrl) {
       throw new Error('HttpClientOptions requires either "host" or "baseUrl".');
@@ -89,27 +97,67 @@ export class HttpClient {
     return JSON.parse(text) as T;
   }
 
-  /** Perform an authenticated HTTP GET and return the parsed JSON response. */
+  /**
+   * Perform an authenticated HTTP GET and return the parsed JSON response.
+   *
+   * @typeParam T - Expected response body type.
+   * @param path - Absolute URL or path relative to {@link HttpClient.baseUrl}.
+   * @param params - Optional query parameters; `undefined` values are skipped.
+   * @returns The parsed JSON body, or `{}` on `204 No Content`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async get<T = any>(path: string, params?: QueryParams): Promise<T> {
     return this._request<T>('GET', path, undefined, params);
   }
 
-  /** Perform an authenticated HTTP POST and return the parsed JSON response. */
+  /**
+   * Perform an authenticated HTTP POST and return the parsed JSON response.
+   *
+   * @typeParam T - Expected response body type.
+   * @param path - Absolute URL or path relative to {@link HttpClient.baseUrl}.
+   * @param body - JSON-serialisable request body. Omit to send no body.
+   * @param params - Optional query parameters appended to the URL.
+   * @returns The parsed JSON body, or `{}` on `204 No Content`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async post<T = any>(path: string, body?: any, params?: QueryParams): Promise<T> {
     return this._request<T>('POST', path, body, params);
   }
 
-  /** Perform an authenticated HTTP PUT and return the parsed JSON response. */
+  /**
+   * Perform an authenticated HTTP PUT and return the parsed JSON response.
+   *
+   * @typeParam T - Expected response body type.
+   * @param path - Absolute URL or path relative to {@link HttpClient.baseUrl}.
+   * @param body - JSON-serialisable request body.
+   * @returns The parsed JSON body, or `{}` on `204 No Content`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async put<T = any>(path: string, body?: any): Promise<T> {
     return this._request<T>('PUT', path, body);
   }
 
-  /** Perform an authenticated HTTP PATCH and return the parsed JSON response. */
+  /**
+   * Perform an authenticated HTTP PATCH and return the parsed JSON response.
+   *
+   * @typeParam T - Expected response body type.
+   * @param path - Absolute URL or path relative to {@link HttpClient.baseUrl}.
+   * @param body - JSON-serialisable partial request body.
+   * @returns The parsed JSON body, or `{}` on `204 No Content`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async patch<T = any>(path: string, body?: any): Promise<T> {
     return this._request<T>('PATCH', path, body);
   }
 
-  /** Perform an authenticated HTTP DELETE and return the parsed JSON response. */
+  /**
+   * Perform an authenticated HTTP DELETE and return the parsed JSON response.
+   *
+   * @typeParam T - Expected response body type.
+   * @param path - Absolute URL or path relative to {@link HttpClient.baseUrl}.
+   * @returns The parsed JSON body, or `{}` on `204 No Content`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete<T = any>(path: string): Promise<T> {
     return this._request<T>('DELETE', path);
   }

--- a/src/rest/HttpClient.ts
+++ b/src/rest/HttpClient.ts
@@ -13,7 +13,15 @@ import type { HttpClientOptions, QueryParams } from './types.js';
 
 const logger = getLogger('rest_client');
 
+/**
+ * Low-level HTTP client used by every REST namespace resource.
+ *
+ * Handles Basic Auth, JSON encoding/decoding, and error normalisation
+ * ({@link RestError} on non-2xx). Normally you do not instantiate this
+ * directly — construct a {@link RestClient} instead.
+ */
 export class HttpClient {
+  /** Fully-qualified base URL (no trailing slash). */
   readonly baseUrl: string;
   private readonly _authHeader: string;
   private readonly _fetch: typeof globalThis.fetch;
@@ -81,22 +89,27 @@ export class HttpClient {
     return JSON.parse(text) as T;
   }
 
+  /** Perform an authenticated HTTP GET and return the parsed JSON response. */
   async get<T = any>(path: string, params?: QueryParams): Promise<T> {
     return this._request<T>('GET', path, undefined, params);
   }
 
+  /** Perform an authenticated HTTP POST and return the parsed JSON response. */
   async post<T = any>(path: string, body?: any, params?: QueryParams): Promise<T> {
     return this._request<T>('POST', path, body, params);
   }
 
+  /** Perform an authenticated HTTP PUT and return the parsed JSON response. */
   async put<T = any>(path: string, body?: any): Promise<T> {
     return this._request<T>('PUT', path, body);
   }
 
+  /** Perform an authenticated HTTP PATCH and return the parsed JSON response. */
   async patch<T = any>(path: string, body?: any): Promise<T> {
     return this._request<T>('PATCH', path, body);
   }
 
+  /** Perform an authenticated HTTP DELETE and return the parsed JSON response. */
   async delete<T = any>(path: string): Promise<T> {
     return this._request<T>('DELETE', path);
   }

--- a/src/rest/RestError.ts
+++ b/src/rest/RestError.ts
@@ -6,11 +6,25 @@
  * `SignalWireRestError` behavior.
  */
 export class RestError extends Error {
+  /** HTTP status code returned by the server (e.g. `404`, `500`). */
   readonly statusCode: number;
+  /**
+   * Parsed response body. An object when the server returned valid JSON,
+   * otherwise the raw response text as a string.
+   */
   readonly body: string | Record<string, unknown>;
+  /** Fully-qualified URL that produced the error. */
   readonly url: string;
+  /** HTTP method that produced the error (`GET`, `POST`, etc.). */
   readonly method: string;
 
+  /**
+   * @param statusCode - HTTP status code returned by the server.
+   * @param body - Response body — an object if JSON-parseable, otherwise the
+   *   raw response text.
+   * @param url - Fully-qualified URL that produced the error.
+   * @param method - HTTP method that produced the error. Defaults to `"GET"`.
+   */
   constructor(
     statusCode: number,
     body: string | Record<string, unknown>,

--- a/src/rest/base/BaseResource.ts
+++ b/src/rest/base/BaseResource.ts
@@ -1,5 +1,9 @@
 /**
  * Abstract base class for all REST resources.
+ *
+ * Every namespace resource (e.g. `PhoneNumbersResource`, `VideoRooms`) extends
+ * this class to get a typed reference to the shared {@link HttpClient} and a
+ * small path-building helper.
  */
 import type { HttpClient } from '../HttpClient.js';
 

--- a/src/rest/base/BaseResource.ts
+++ b/src/rest/base/BaseResource.ts
@@ -1,22 +1,31 @@
+import type { HttpClient } from '../HttpClient.js';
+
 /**
  * Abstract base class for all REST resources.
  *
- * Every namespace resource (e.g. `PhoneNumbersResource`, `VideoRooms`) extends
- * this class to get a typed reference to the shared {@link HttpClient} and a
- * small path-building helper.
+ * Every namespace resource (e.g. {@link PhoneNumbersResource}, {@link VideoRooms})
+ * extends this class to get a typed reference to the shared {@link HttpClient}
+ * and a small path-building helper. Not exported for direct use — subclass it.
  */
-import type { HttpClient } from '../HttpClient.js';
-
 export abstract class BaseResource {
   protected readonly _http: HttpClient;
   protected readonly _basePath: string;
 
+  /**
+   * @param http - Shared HTTP client to issue requests through.
+   * @param basePath - Absolute path prefix (e.g. `'/api/relay/rest/phone_numbers'`).
+   */
   constructor(http: HttpClient, basePath: string) {
     this._http = http;
     this._basePath = basePath;
   }
 
-  /** Build a sub-resource path by joining parts onto the base path. */
+  /**
+   * Build a sub-resource path by joining parts onto the base path.
+   *
+   * @param parts - String or numeric path segments to append.
+   * @returns The joined path (no trailing slash).
+   */
   protected _path(...parts: (string | number)[]): string {
     return [this._basePath, ...parts.map(String)].join('/');
   }

--- a/src/rest/base/CrudResource.ts
+++ b/src/rest/base/CrudResource.ts
@@ -34,22 +34,50 @@ export class CrudResource<
     super(http, basePath);
   }
 
-  /** List resources with optional query parameters. */
+  /**
+   * List resources with optional query parameters.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns The paginated list response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<TList> {
     return this._http.get<TList>(this._basePath, params);
   }
 
-  /** Create a new resource. */
+  /**
+   * Create a new resource.
+   *
+   * @param body - Request body describing the resource to create.
+   * @returns The newly-created resource.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async create(body: TCreate): Promise<TItem> {
     return this._http.post<TItem>(this._basePath, body);
   }
 
-  /** Get a single resource by ID. */
+  /**
+   * Fetch a single resource by ID.
+   *
+   * @param resourceId - Unique identifier of the resource.
+   * @returns The resource record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(resourceId: string): Promise<TItem> {
     return this._http.get<TItem>(this._path(resourceId));
   }
 
-  /** Update a resource by ID. */
+  /**
+   * Update a resource by ID.
+   *
+   * Uses HTTP `PATCH` by default; subclasses may set `_updateMethod = 'PUT'`
+   * when the remote API requires a full-replacement semantics.
+   *
+   * @param resourceId - Unique identifier of the resource.
+   * @param body - Request body with updated fields.
+   * @returns The updated resource.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(resourceId: string, body: TUpdate): Promise<TItem> {
     if (this._updateMethod === 'PUT') {
       return this._http.put<TItem>(this._path(resourceId), body);
@@ -57,7 +85,13 @@ export class CrudResource<
     return this._http.patch<TItem>(this._path(resourceId), body);
   }
 
-  /** Delete a resource by ID. */
+  /**
+   * Delete a resource by ID.
+   *
+   * @param resourceId - Unique identifier of the resource.
+   * @returns The platform's delete response (often an empty body on success).
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(resourceId: string): Promise<any> {
     return this._http.delete(this._path(resourceId));
   }

--- a/src/rest/base/CrudResource.ts
+++ b/src/rest/base/CrudResource.ts
@@ -8,6 +8,19 @@ import type { HttpClient } from '../HttpClient.js';
 import type { QueryParams } from '../types.js';
 import { BaseResource } from './BaseResource.js';
 
+/**
+ * Generic CRUD resource with configurable update method.
+ *
+ * Provides `list()`, `create()`, `get()`, `update()`, and `delete()` out of the
+ * box — most namespace resources extend this and narrow the generic types.
+ * `_updateMethod` may be overridden to `'PUT'` for APIs that replace instead
+ * of patch.
+ *
+ * @typeParam TList - Type of the paginated list response.
+ * @typeParam TItem - Type of a single resource item.
+ * @typeParam TCreate - Request body type for `create()`.
+ * @typeParam TUpdate - Request body type for `update()`.
+ */
 export class CrudResource<
   TList = any,
   TItem = any,

--- a/src/rest/base/CrudWithAddresses.ts
+++ b/src/rest/base/CrudWithAddresses.ts
@@ -23,7 +23,14 @@ export class CrudWithAddresses<
     super(http, basePath);
   }
 
-  /** List addresses associated with a resource. */
+  /**
+   * List addresses associated with a specific resource instance.
+   *
+   * @param resourceId - Unique identifier of the owning resource.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of addresses.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listAddresses(resourceId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(resourceId, 'addresses'), params);
   }

--- a/src/rest/base/CrudWithAddresses.ts
+++ b/src/rest/base/CrudWithAddresses.ts
@@ -8,6 +8,10 @@ import type { HttpClient } from '../HttpClient.js';
 import type { QueryParams } from '../types.js';
 import { CrudResource } from './CrudResource.js';
 
+/**
+ * {@link CrudResource} extended with a `listAddresses()` helper for resources that
+ * have associated Address records (e.g. fabric resources).
+ */
 export class CrudWithAddresses<
   TList = any,
   TItem = any,

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -57,44 +57,74 @@ const logger = getLogger('rest_client');
  */
 export class RestClient {
   // Fabric API
+  /** Fabric composition — AI Agents, SWML scripts, call flows, tokens, etc. */
   readonly fabric: FabricNamespace;
 
   // Calling API
+  /** REST-based call control surface (all 37 commands as methods). */
   readonly calling: CallingNamespace;
 
   // Relay REST resources
+  /** Phone-number CRUD plus availability search. */
   readonly phoneNumbers: PhoneNumbersResource;
+  /** Relay Address CRUD. */
   readonly addresses: AddressesResource;
+  /** Call-queue CRUD plus member operations. */
   readonly queues: QueuesResource;
+  /** Recording read / delete. */
   readonly recordings: RecordingsResource;
+  /** Number-group CRUD plus membership operations. */
   readonly numberGroups: NumberGroupsResource;
+  /** Verified Caller ID CRUD plus verification flow. */
   readonly verifiedCallers: VerifiedCallersResource;
+  /** Project-level SIP profile read / update (singleton). */
   readonly sipProfile: SipProfileResource;
+  /** Carrier + CNAM phone-number lookups. */
   readonly lookup: LookupResource;
+  /** Short-code read / update. */
   readonly shortCodes: ShortCodesResource;
+  /** Import externally-hosted phone numbers. */
   readonly importedNumbers: ImportedNumbersResource;
+  /** Multi-factor authentication (SMS / voice code send + verify). */
   readonly mfa: MfaResource;
+  /** US 10DLC Campaign Registry — brands, campaigns, orders, numbers. */
   readonly registry: RegistryNamespace;
 
   // Datasphere API
+  /** Datasphere RAG — document indexing and semantic search. */
   readonly datasphere: DatasphereNamespace;
 
   // Video API
+  /** Video rooms, sessions, recordings, conferences, tokens, streams. */
   readonly video: VideoNamespace;
 
   // Logs
+  /** Read-only message / voice / fax / conference logs. */
   readonly logs: LogsNamespace;
 
   // Project management
+  /** Project-scoped API token management. */
   readonly project: ProjectNamespace;
 
   // PubSub & Chat
+  /** PubSub token issuance. */
   readonly pubsub: PubSubResource;
+  /** Chat token issuance. */
   readonly chat: ChatResource;
 
   // Compatibility (Twilio-compatible) API
+  /** Twilio-compatible LAML surface (legacy; prefer native namespaces for new work). */
   readonly compat: CompatNamespace;
 
+  /**
+   * Create a new REST client.
+   *
+   * @param options - Connection options. `project`, `token`, and `host` are
+   *   required. If any are omitted they fall back to `SIGNALWIRE_PROJECT_ID`,
+   *   `SIGNALWIRE_API_TOKEN`, and `SIGNALWIRE_SPACE` environment variables.
+   * @throws {Error} When `project`, `token`, or `host` is missing from both
+   *   the options and the environment.
+   */
   constructor(options: ClientOptions = {}) {
     const project = options.project || process.env['SIGNALWIRE_PROJECT_ID'] || '';
     const token = options.token || process.env['SIGNALWIRE_API_TOKEN'] || '';

--- a/src/rest/namespaces/addresses.ts
+++ b/src/rest/namespaces/addresses.ts
@@ -18,22 +18,46 @@ export class AddressesResource extends BaseResource {
     super(http, '/api/relay/rest/addresses');
   }
 
-  /** List all addresses in the project. */
+  /**
+   * List all addresses in the project.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of addresses.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Create a new address. */
+  /**
+   * Create a new address.
+   *
+   * @param body - Address attributes (name, display name, context, etc.).
+   * @returns The newly-created address.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
 
-  /** Fetch a single address by ID. */
+  /**
+   * Fetch a single address by ID.
+   *
+   * @param addressId - Unique identifier of the address.
+   * @returns The address record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(addressId: string): Promise<any> {
     return this._http.get(this._path(addressId));
   }
 
-  /** Delete an address. */
+  /**
+   * Delete an address.
+   *
+   * @param addressId - Unique identifier of the address.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(addressId: string): Promise<any> {
     return this._http.delete(this._path(addressId));
   }

--- a/src/rest/namespaces/addresses.ts
+++ b/src/rest/namespaces/addresses.ts
@@ -8,24 +8,32 @@ import type { HttpClient } from '../HttpClient.js';
 import type { QueryParams } from '../types.js';
 import { BaseResource } from '../base/BaseResource.js';
 
-/** Address management (no update endpoint). */
+/**
+ * Address management (no update endpoint).
+ *
+ * Access via `client.addresses.*`.
+ */
 export class AddressesResource extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/relay/rest/addresses');
   }
 
+  /** List all addresses in the project. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Create a new address. */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
 
+  /** Fetch a single address by ID. */
   async get(addressId: string): Promise<any> {
     return this._http.get(this._path(addressId));
   }
 
+  /** Delete an address. */
   async delete(addressId: string): Promise<any> {
     return this._http.delete(this._path(addressId));
   }

--- a/src/rest/namespaces/calling.ts
+++ b/src/rest/namespaces/calling.ts
@@ -15,6 +15,15 @@ import { BaseResource } from '../base/BaseResource.js';
  * Access via `client.calling.*`. Every method issues one command against a live
  * call by ID and returns the platform's JSON response.
  *
+ * Every command method shares the same shape:
+ *
+ * - First argument (when present) is the target call's ID.
+ * - Second argument is a platform-shaped `params` object — see the
+ *   [Calling API reference](https://developer.signalwire.com/rest/signalwire-rest/endpoints/calling/)
+ *   for the fields each command accepts.
+ * - The method returns the JSON-decoded platform response.
+ * - Throws {@link RestError} on any non-2xx HTTP response.
+ *
  * @example Play audio on an active call
  * ```ts
  * await client.calling.play(callId, {
@@ -44,213 +53,481 @@ export class CallingNamespace extends BaseResource {
 
   // Call lifecycle
 
-  /** Place an outbound call. */
+  /**
+   * Place an outbound call.
+   *
+   * @param params - Platform-shaped dial parameters (from, to, timeout, etc.).
+   *   Defaults to `{}`.
+   * @returns The dial command response, typically containing a new `call_id`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async dial(params: any = {}): Promise<any> {
     return this._execute('dial', undefined, params);
   }
 
-  /** Update properties on an in-progress call. */
+  /**
+   * Update properties on an in-progress call.
+   *
+   * @param params - Platform-shaped update parameters. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(params: any = {}): Promise<any> {
     return this._execute('update', undefined, params);
   }
 
-  /** Gracefully end a call. */
+  /**
+   * Gracefully end a call.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Platform-shaped end parameters. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async end(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.end', callId, params);
   }
 
-  /** Transfer a call to another destination. */
+  /**
+   * Transfer a call to another destination.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Platform-shaped transfer parameters (`to`, `from`, etc.).
+   *   Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async transfer(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.transfer', callId, params);
   }
 
-  /** Drop one leg from a call without ending the other. */
+  /**
+   * Drop one leg from a call without ending the other.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Platform-shaped disconnect parameters. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async disconnect(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.disconnect', callId, params);
   }
 
   // Play
 
-  /** Start media playback on a call. */
+  /**
+   * Start media playback on a call.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Playback parameters — see `Play` action schema. Defaults to `{}`.
+   * @returns The play command response, containing a `control_id` used to
+   *   pause / resume / stop the playback later.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async play(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.play', callId, params);
   }
 
-  /** Pause active playback. */
+  /**
+   * Pause active playback.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id` from the matching `play()` call.
+   *   Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async playPause(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.play.pause', callId, params);
   }
 
-  /** Resume paused playback. */
+  /**
+   * Resume paused playback.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async playResume(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.play.resume', callId, params);
   }
 
-  /** Stop active playback. */
+  /**
+   * Stop active playback.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async playStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.play.stop', callId, params);
   }
 
-  /** Adjust the playback volume. */
+  /**
+   * Adjust the playback volume.
+   *
+   * @param callId - Target call's ID.
+   * @param params - `control_id` plus `volume` (integer dB). Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async playVolume(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.play.volume', callId, params);
   }
 
   // Record
 
-  /** Start recording a call. */
+  /**
+   * Start recording a call.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Recording parameters (`record` config, callbacks, etc.).
+   *   Defaults to `{}`.
+   * @returns The record command response containing a `control_id`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async record(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.record', callId, params);
   }
 
-  /** Pause an active recording. */
+  /**
+   * Pause an active recording.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async recordPause(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.record.pause', callId, params);
   }
 
-  /** Resume a paused recording. */
+  /**
+   * Resume a paused recording.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async recordResume(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.record.resume', callId, params);
   }
 
-  /** Stop and finalise a recording. */
+  /**
+   * Stop and finalise a recording.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The final recording metadata.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async recordStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.record.stop', callId, params);
   }
 
   // Collect
 
-  /** Collect DTMF / speech input from the caller. */
+  /**
+   * Collect DTMF / speech input from the caller.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Collect configuration (`digits`, `speech`, timeouts, etc.).
+   *   Defaults to `{}`.
+   * @returns The collect command response containing a `control_id`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async collect(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.collect', callId, params);
   }
 
-  /** Stop an in-progress collect operation. */
+  /**
+   * Stop an in-progress collect operation.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async collectStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.collect.stop', callId, params);
   }
 
-  /** Start input timers for a collect operation. */
+  /**
+   * Start input timers for a collect operation (useful when `initial_timeout`
+   * should be reset after media finishes playing).
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async collectStartInputTimers(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.collect.start_input_timers', callId, params);
   }
 
   // Detect
 
-  /** Run answering-machine / fax / DTMF detection. */
+  /**
+   * Run answering-machine / fax / DTMF detection.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Detect configuration. Defaults to `{}`.
+   * @returns The detect command response containing a `control_id`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async detect(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.detect', callId, params);
   }
 
-  /** Stop an active detect operation. */
+  /**
+   * Stop an active detect operation.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async detectStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.detect.stop', callId, params);
   }
 
   // Tap
 
-  /** Start a media tap (mirror audio to an external URI). */
+  /**
+   * Start a media tap (mirror audio to an external URI).
+   *
+   * @param callId - Target call's ID.
+   * @param params - Tap configuration (`uri`, `direction`, `codec`, etc.).
+   *   Defaults to `{}`.
+   * @returns The tap command response containing a `control_id`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async tap(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.tap', callId, params);
   }
 
-  /** Stop an active media tap. */
+  /**
+   * Stop an active media tap.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async tapStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.tap.stop', callId, params);
   }
 
   // Stream
 
-  /** Start an outbound media stream. */
+  /**
+   * Start an outbound media stream (typically to a WebSocket endpoint).
+   *
+   * @param callId - Target call's ID.
+   * @param params - Stream configuration. Defaults to `{}`.
+   * @returns The stream command response containing a `control_id`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async stream(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.stream', callId, params);
   }
 
-  /** Stop an outbound media stream. */
+  /**
+   * Stop an outbound media stream.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async streamStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.stream.stop', callId, params);
   }
 
   // Denoise
 
-  /** Enable noise reduction on the call. */
+  /**
+   * Enable noise reduction on the call.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Denoise configuration. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async denoise(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.denoise', callId, params);
   }
 
-  /** Disable noise reduction. */
+  /**
+   * Disable noise reduction.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Platform-shaped parameters. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async denoiseStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.denoise.stop', callId, params);
   }
 
   // Transcribe
 
-  /** Start real-time transcription on the call. */
+  /**
+   * Start real-time transcription on the call.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Transcription configuration. Defaults to `{}`.
+   * @returns The transcribe command response containing a `control_id`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async transcribe(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.transcribe', callId, params);
   }
 
-  /** Stop real-time transcription. */
+  /**
+   * Stop real-time transcription.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The final transcription metadata.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async transcribeStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.transcribe.stop', callId, params);
   }
 
   // AI
 
-  /** Send a message into an active AI agent session. */
+  /**
+   * Send a message into an active AI agent session.
+   *
+   * @param callId - Target call's ID.
+   * @param params - AI message payload. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async aiMessage(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.ai_message', callId, params);
   }
 
-  /** Put the AI session on hold (pause turn-taking). */
+  /**
+   * Put the AI session on hold (pause turn-taking).
+   *
+   * @param callId - Target call's ID.
+   * @param params - Platform-shaped parameters. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async aiHold(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.ai_hold', callId, params);
   }
 
-  /** Resume an AI session that was on hold. */
+  /**
+   * Resume an AI session that was on hold.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Platform-shaped parameters. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async aiUnhold(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.ai_unhold', callId, params);
   }
 
-  /** Terminate the active AI session on a call. */
+  /**
+   * Terminate the active AI session on a call.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Platform-shaped parameters. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async aiStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.ai.stop', callId, params);
   }
 
   // Live transcribe / translate
 
-  /** Start live transcription that emits events as speech is recognised. */
+  /**
+   * Start live transcription that emits events as speech is recognised.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Configuration (languages, model, partials, etc.).
+   *   Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async liveTranscribe(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.live_transcribe', callId, params);
   }
 
-  /** Start live translation between two languages. */
+  /**
+   * Start live translation between two languages.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Configuration (`source_lang`, `target_lang`, etc.).
+   *   Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async liveTranslate(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.live_translate', callId, params);
   }
 
   // Fax
 
-  /** Stop a send-fax operation mid-stream. */
+  /**
+   * Stop a send-fax operation mid-stream.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async sendFaxStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.send_fax.stop', callId, params);
   }
 
-  /** Stop a receive-fax operation mid-stream. */
+  /**
+   * Stop a receive-fax operation mid-stream.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Must include `control_id`. Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async receiveFaxStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.receive_fax.stop', callId, params);
   }
 
   // SIP
 
-  /** Send a SIP REFER to transfer a call outside the platform. */
+  /**
+   * Send a SIP REFER to transfer a call outside the platform.
+   *
+   * @param callId - Target call's ID.
+   * @param params - REFER parameters (`refer_to`, etc.). Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async refer(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.refer', callId, params);
   }
 
   // Custom events
 
-  /** Emit a custom user event on the call for your webhooks. */
+  /**
+   * Emit a custom user event on the call for your webhooks.
+   *
+   * @param callId - Target call's ID.
+   * @param params - Event payload — freeform data delivered to your webhook.
+   *   Defaults to `{}`.
+   * @returns The platform's response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async userEvent(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.user_event', callId, params);
   }

--- a/src/rest/namespaces/calling.ts
+++ b/src/rest/namespaces/calling.ts
@@ -9,7 +9,26 @@
 import type { HttpClient } from '../HttpClient.js';
 import { BaseResource } from '../base/BaseResource.js';
 
-/** REST call control — all 37 commands dispatched via single POST endpoint. */
+/**
+ * REST call control — all 37 commands dispatched via a single POST endpoint.
+ *
+ * Access via `client.calling.*`. Every method issues one command against a live
+ * call by ID and returns the platform's JSON response.
+ *
+ * @example Play audio on an active call
+ * ```ts
+ * await client.calling.play(callId, {
+ *   play: [{ type: 'audio', url: 'https://cdn.example.com/hold.mp3' }],
+ * });
+ * ```
+ *
+ * @example Start and stop recording
+ * ```ts
+ * const rec = await client.calling.record(callId, { record: { audio: {} } });
+ * // ... later ...
+ * await client.calling.recordStop(callId, { control_id: rec.control_id });
+ * ```
+ */
 export class CallingNamespace extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/calling/calls');
@@ -24,163 +43,214 @@ export class CallingNamespace extends BaseResource {
   }
 
   // Call lifecycle
+
+  /** Place an outbound call. */
   async dial(params: any = {}): Promise<any> {
     return this._execute('dial', undefined, params);
   }
 
+  /** Update properties on an in-progress call. */
   async update(params: any = {}): Promise<any> {
     return this._execute('update', undefined, params);
   }
 
+  /** Gracefully end a call. */
   async end(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.end', callId, params);
   }
 
+  /** Transfer a call to another destination. */
   async transfer(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.transfer', callId, params);
   }
 
+  /** Drop one leg from a call without ending the other. */
   async disconnect(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.disconnect', callId, params);
   }
 
   // Play
+
+  /** Start media playback on a call. */
   async play(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.play', callId, params);
   }
 
+  /** Pause active playback. */
   async playPause(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.play.pause', callId, params);
   }
 
+  /** Resume paused playback. */
   async playResume(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.play.resume', callId, params);
   }
 
+  /** Stop active playback. */
   async playStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.play.stop', callId, params);
   }
 
+  /** Adjust the playback volume. */
   async playVolume(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.play.volume', callId, params);
   }
 
   // Record
+
+  /** Start recording a call. */
   async record(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.record', callId, params);
   }
 
+  /** Pause an active recording. */
   async recordPause(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.record.pause', callId, params);
   }
 
+  /** Resume a paused recording. */
   async recordResume(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.record.resume', callId, params);
   }
 
+  /** Stop and finalise a recording. */
   async recordStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.record.stop', callId, params);
   }
 
   // Collect
+
+  /** Collect DTMF / speech input from the caller. */
   async collect(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.collect', callId, params);
   }
 
+  /** Stop an in-progress collect operation. */
   async collectStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.collect.stop', callId, params);
   }
 
+  /** Start input timers for a collect operation. */
   async collectStartInputTimers(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.collect.start_input_timers', callId, params);
   }
 
   // Detect
+
+  /** Run answering-machine / fax / DTMF detection. */
   async detect(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.detect', callId, params);
   }
 
+  /** Stop an active detect operation. */
   async detectStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.detect.stop', callId, params);
   }
 
   // Tap
+
+  /** Start a media tap (mirror audio to an external URI). */
   async tap(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.tap', callId, params);
   }
 
+  /** Stop an active media tap. */
   async tapStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.tap.stop', callId, params);
   }
 
   // Stream
+
+  /** Start an outbound media stream. */
   async stream(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.stream', callId, params);
   }
 
+  /** Stop an outbound media stream. */
   async streamStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.stream.stop', callId, params);
   }
 
   // Denoise
+
+  /** Enable noise reduction on the call. */
   async denoise(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.denoise', callId, params);
   }
 
+  /** Disable noise reduction. */
   async denoiseStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.denoise.stop', callId, params);
   }
 
   // Transcribe
+
+  /** Start real-time transcription on the call. */
   async transcribe(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.transcribe', callId, params);
   }
 
+  /** Stop real-time transcription. */
   async transcribeStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.transcribe.stop', callId, params);
   }
 
   // AI
+
+  /** Send a message into an active AI agent session. */
   async aiMessage(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.ai_message', callId, params);
   }
 
+  /** Put the AI session on hold (pause turn-taking). */
   async aiHold(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.ai_hold', callId, params);
   }
 
+  /** Resume an AI session that was on hold. */
   async aiUnhold(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.ai_unhold', callId, params);
   }
 
+  /** Terminate the active AI session on a call. */
   async aiStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.ai.stop', callId, params);
   }
 
   // Live transcribe / translate
+
+  /** Start live transcription that emits events as speech is recognised. */
   async liveTranscribe(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.live_transcribe', callId, params);
   }
 
+  /** Start live translation between two languages. */
   async liveTranslate(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.live_translate', callId, params);
   }
 
   // Fax
+
+  /** Stop a send-fax operation mid-stream. */
   async sendFaxStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.send_fax.stop', callId, params);
   }
 
+  /** Stop a receive-fax operation mid-stream. */
   async receiveFaxStop(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.receive_fax.stop', callId, params);
   }
 
   // SIP
+
+  /** Send a SIP REFER to transfer a call outside the platform. */
   async refer(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.refer', callId, params);
   }
 
   // Custom events
+
+  /** Emit a custom user event on the call for your webhooks. */
   async userEvent(callId: string, params: any = {}): Promise<any> {
     return this._execute('calling.user_event', callId, params);
   }

--- a/src/rest/namespaces/chat.ts
+++ b/src/rest/namespaces/chat.ts
@@ -18,7 +18,13 @@ export class ChatResource extends BaseResource {
     super(http, '/api/chat/tokens');
   }
 
-  /** Generate a Chat token. */
+  /**
+   * Generate a short-lived Chat token.
+   *
+   * @param body - Token payload (e.g. `{ room_name, user_name, permissions }`).
+   * @returns The token record, typically `{ token: "eyJ..." }`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createToken(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }

--- a/src/rest/namespaces/chat.ts
+++ b/src/rest/namespaces/chat.ts
@@ -7,7 +7,12 @@
 import type { HttpClient } from '../HttpClient.js';
 import { BaseResource } from '../base/BaseResource.js';
 
-/** Chat token generation. */
+/**
+ * Chat token generation.
+ *
+ * Access via `client.chat.*`. Issues short-lived tokens that end-user clients
+ * use to join chat channels.
+ */
 export class ChatResource extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/chat/tokens');

--- a/src/rest/namespaces/compat.ts
+++ b/src/rest/namespaces/compat.ts
@@ -11,24 +11,53 @@ import type { QueryParams } from '../types.js';
 import { BaseResource } from '../base/BaseResource.js';
 import { CrudResource } from '../base/CrudResource.js';
 
-/** Compat account/subproject management. */
+/** Compat account / subproject management (Twilio-compatible LAML). */
 export class CompatAccounts extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/laml/2010-04-01/Accounts');
   }
 
+  /**
+   * List accounts visible to the authenticated project.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A LAML-shaped paginated account list.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /**
+   * Create a new sub-account under the authenticated parent account.
+   *
+   * @param body - Account payload (`FriendlyName`, etc.) — LAML form keys.
+   * @returns The newly-created account record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
 
+  /**
+   * Fetch an account by SID.
+   *
+   * @param sid - Account SID (e.g. `"AC..."`).
+   * @returns The account record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(sid: string): Promise<any> {
     return this._http.get(this._path(sid));
   }
 
+  /**
+   * Update an account's attributes. LAML uses `POST` (not PATCH/PUT).
+   *
+   * @param sid - Account SID.
+   * @param body - Partial update payload. Defaults to `{}`.
+   * @returns The updated account record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
@@ -40,22 +69,65 @@ export class CompatCalls extends CrudResource {
     super(http, basePath);
   }
 
+  /**
+   * Update an in-progress or past call. LAML uses `POST` (not PATCH/PUT).
+   *
+   * @param sid - Call SID (e.g. `"CA..."`).
+   * @param body - LAML-form update payload (`Status`, `Url`, etc.). Defaults to `{}`.
+   * @returns The updated call record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
+  /**
+   * Start recording an active call.
+   *
+   * @param callSid - Call SID.
+   * @param body - Recording parameters (channels, trim, status callback, etc.).
+   *   Defaults to `{}`.
+   * @returns The newly-started recording record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async startRecording(callSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(callSid, 'Recordings'), body);
   }
 
+  /**
+   * Update an active recording (e.g. `Status=paused` / `Status=stopped`).
+   *
+   * @param callSid - Call SID.
+   * @param recordingSid - Recording SID returned by {@link startRecording}.
+   * @param body - Update payload. Defaults to `{}`.
+   * @returns The updated recording record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async updateRecording(callSid: string, recordingSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(callSid, 'Recordings', recordingSid), body);
   }
 
+  /**
+   * Start a media stream on an active call (WebSocket media forwarding).
+   *
+   * @param callSid - Call SID.
+   * @param body - Stream parameters (URL, track, etc.). Defaults to `{}`.
+   * @returns The newly-started stream record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async startStream(callSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(callSid, 'Streams'), body);
   }
 
+  /**
+   * Stop an active media stream on a call.
+   *
+   * @param callSid - Call SID.
+   * @param streamSid - Stream SID returned by {@link startStream}.
+   * @param body - Update payload. Defaults to `{}`.
+   * @returns The stopped stream record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async stopStream(callSid: string, streamSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(callSid, 'Streams', streamSid), body);
   }
@@ -67,18 +139,50 @@ export class CompatMessages extends CrudResource {
     super(http, basePath);
   }
 
+  /**
+   * Update a message. LAML uses `POST` (not PATCH/PUT).
+   *
+   * @param sid - Message SID (e.g. `"SM..."` / `"MM..."`).
+   * @param body - LAML-form update payload. Defaults to `{}`.
+   * @returns The updated message record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
+  /**
+   * List media attachments for a message (MMS).
+   *
+   * @param messageSid - Message SID.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of media records.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listMedia(messageSid: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(messageSid, 'Media'), params);
   }
 
+  /**
+   * Fetch a specific media attachment on a message.
+   *
+   * @param messageSid - Message SID.
+   * @param mediaSid - Media SID.
+   * @returns The media record (metadata + URL).
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async getMedia(messageSid: string, mediaSid: string): Promise<any> {
     return this._http.get(this._path(messageSid, 'Media', mediaSid));
   }
 
+  /**
+   * Delete a media attachment from a message.
+   *
+   * @param messageSid - Message SID.
+   * @param mediaSid - Media SID.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async deleteMedia(messageSid: string, mediaSid: string): Promise<any> {
     return this._http.delete(this._path(messageSid, 'Media', mediaSid));
   }
@@ -90,18 +194,50 @@ export class CompatFaxes extends CrudResource {
     super(http, basePath);
   }
 
+  /**
+   * Update a fax. LAML uses `POST` (not PATCH/PUT).
+   *
+   * @param sid - Fax SID (e.g. `"FX..."`).
+   * @param body - LAML-form update payload. Defaults to `{}`.
+   * @returns The updated fax record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
+  /**
+   * List media attachments for a fax.
+   *
+   * @param faxSid - Fax SID.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of media records.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listMedia(faxSid: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(faxSid, 'Media'), params);
   }
 
+  /**
+   * Fetch a specific media attachment on a fax.
+   *
+   * @param faxSid - Fax SID.
+   * @param mediaSid - Media SID.
+   * @returns The media record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async getMedia(faxSid: string, mediaSid: string): Promise<any> {
     return this._http.get(this._path(faxSid, 'Media', mediaSid));
   }
 
+  /**
+   * Delete a media attachment from a fax.
+   *
+   * @param faxSid - Fax SID.
+   * @param mediaSid - Media SID.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async deleteMedia(faxSid: string, mediaSid: string): Promise<any> {
     return this._http.delete(this._path(faxSid, 'Media', mediaSid));
   }
@@ -113,63 +249,173 @@ export class CompatConferences extends BaseResource {
     super(http, basePath);
   }
 
+  /**
+   * List conferences in the account.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of conferences.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /**
+   * Fetch a conference by SID.
+   *
+   * @param sid - Conference SID (e.g. `"CF..."`).
+   * @returns The conference record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(sid: string): Promise<any> {
     return this._http.get(this._path(sid));
   }
 
+  /**
+   * Update a conference (e.g. `Status=completed` to terminate).
+   * LAML uses `POST` (not PATCH/PUT).
+   *
+   * @param sid - Conference SID.
+   * @param body - LAML-form update payload. Defaults to `{}`.
+   * @returns The updated conference record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
   // Participants
+
+  /**
+   * List participants in a conference.
+   *
+   * @param conferenceSid - Conference SID.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of participants.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listParticipants(conferenceSid: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(conferenceSid, 'Participants'), params);
   }
 
+  /**
+   * Fetch a specific participant (by its call SID) in a conference.
+   *
+   * @param conferenceSid - Conference SID.
+   * @param callSid - Participant's call SID.
+   * @returns The participant record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async getParticipant(conferenceSid: string, callSid: string): Promise<any> {
     return this._http.get(this._path(conferenceSid, 'Participants', callSid));
   }
 
+  /**
+   * Update a participant (mute, hold, announce, etc.). LAML uses `POST`.
+   *
+   * @param conferenceSid - Conference SID.
+   * @param callSid - Participant's call SID.
+   * @param body - LAML-form update payload (e.g. `{ Muted: 'true' }`).
+   *   Defaults to `{}`.
+   * @returns The updated participant record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async updateParticipant(conferenceSid: string, callSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(conferenceSid, 'Participants', callSid), body);
   }
 
+  /**
+   * Remove a participant from a conference (kick).
+   *
+   * @param conferenceSid - Conference SID.
+   * @param callSid - Participant's call SID.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async removeParticipant(conferenceSid: string, callSid: string): Promise<any> {
     return this._http.delete(this._path(conferenceSid, 'Participants', callSid));
   }
 
   // Conference recordings
+
+  /**
+   * List recordings taken of a conference.
+   *
+   * @param conferenceSid - Conference SID.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of recordings.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listRecordings(conferenceSid: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(conferenceSid, 'Recordings'), params);
   }
 
+  /**
+   * Fetch a specific conference recording.
+   *
+   * @param conferenceSid - Conference SID.
+   * @param recordingSid - Recording SID.
+   * @returns The recording record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async getRecording(conferenceSid: string, recordingSid: string): Promise<any> {
     return this._http.get(this._path(conferenceSid, 'Recordings', recordingSid));
   }
 
+  /**
+   * Update an active conference recording (pause, resume, stop). LAML uses `POST`.
+   *
+   * @param conferenceSid - Conference SID.
+   * @param recordingSid - Recording SID.
+   * @param body - LAML-form update payload. Defaults to `{}`.
+   * @returns The updated recording record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async updateRecording(conferenceSid: string, recordingSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(conferenceSid, 'Recordings', recordingSid), body);
   }
 
+  /**
+   * Delete a conference recording.
+   *
+   * @param conferenceSid - Conference SID.
+   * @param recordingSid - Recording SID.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async deleteRecording(conferenceSid: string, recordingSid: string): Promise<any> {
     return this._http.delete(this._path(conferenceSid, 'Recordings', recordingSid));
   }
 
   // Conference streams
+
+  /**
+   * Start a media stream on a conference.
+   *
+   * @param conferenceSid - Conference SID.
+   * @param body - Stream parameters (URL, track, etc.). Defaults to `{}`.
+   * @returns The newly-started stream record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async startStream(conferenceSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(conferenceSid, 'Streams'), body);
   }
 
+  /**
+   * Stop an active conference media stream.
+   *
+   * @param conferenceSid - Conference SID.
+   * @param streamSid - Stream SID returned by {@link startStream}.
+   * @param body - Update payload. Defaults to `{}`.
+   * @returns The stopped stream record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async stopStream(conferenceSid: string, streamSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(conferenceSid, 'Streams', streamSid), body);
   }
 }
 
-/** Compat phone number management. */
+/** Compat phone number management with searching, purchasing, and import. */
 export class CompatPhoneNumbers extends BaseResource {
   private readonly _availableBase: string;
 
@@ -178,141 +424,327 @@ export class CompatPhoneNumbers extends BaseResource {
     this._availableBase = basePath.replace('/IncomingPhoneNumbers', '/AvailablePhoneNumbers');
   }
 
+  /**
+   * List owned incoming phone numbers in the account.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of owned numbers.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /**
+   * Purchase a phone number (LAML `POST /IncomingPhoneNumbers`).
+   *
+   * @param body - Purchase payload, typically including `PhoneNumber` or
+   *   `AreaCode` plus webhook URLs.
+   * @returns The newly-purchased phone-number record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async purchase(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
 
+  /**
+   * Fetch an owned phone number by SID.
+   *
+   * @param sid - Phone number SID (e.g. `"PN..."`).
+   * @returns The phone-number record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(sid: string): Promise<any> {
     return this._http.get(this._path(sid));
   }
 
+  /**
+   * Update an owned phone number (webhook URLs, friendly name, etc.).
+   * LAML uses `POST`.
+   *
+   * @param sid - Phone number SID.
+   * @param body - LAML-form update payload. Defaults to `{}`.
+   * @returns The updated phone-number record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
+  /**
+   * Release an owned phone number (delete).
+   *
+   * @param sid - Phone number SID.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(sid: string): Promise<any> {
     return this._http.delete(this._path(sid));
   }
 
+  /**
+   * Import an externally-hosted phone number into the account
+   * (LAML `/ImportedPhoneNumbers`).
+   *
+   * @param body - Import payload (number, carrier details, etc.).
+   * @returns The newly-imported number record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async importNumber(body: any): Promise<any> {
     const path = this._basePath.replace('/IncomingPhoneNumbers', '/ImportedPhoneNumbers');
     return this._http.post(path, body);
   }
 
+  /**
+   * List countries in which numbers are available for purchase.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of country records with capabilities.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listAvailableCountries(params?: QueryParams): Promise<any> {
     return this._http.get(this._availableBase, params);
   }
 
+  /**
+   * Search for available local phone numbers in a country.
+   *
+   * @param country - ISO-3166 country code (e.g. `"US"`, `"CA"`).
+   * @param params - Search filters (`AreaCode`, `Contains`, `NearNumber`, etc.).
+   * @returns A paginated list of available local numbers.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async searchLocal(country: string, params?: QueryParams): Promise<any> {
     return this._http.get(`${this._availableBase}/${country}/Local`, params);
   }
 
+  /**
+   * Search for available toll-free phone numbers in a country.
+   *
+   * @param country - ISO-3166 country code.
+   * @param params - Search filters (`Contains`, `NearNumber`, etc.).
+   * @returns A paginated list of available toll-free numbers.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async searchTollFree(country: string, params?: QueryParams): Promise<any> {
     return this._http.get(`${this._availableBase}/${country}/TollFree`, params);
   }
 }
 
-/** Compat application management. */
+/** Compat application management (LAML-style `Applications`). */
 export class CompatApplications extends CrudResource {
   constructor(http: HttpClient, basePath: string) {
     super(http, basePath);
   }
 
+  /**
+   * Update an application. LAML uses `POST` (not PATCH/PUT).
+   *
+   * @param sid - Application SID (e.g. `"AP..."`).
+   * @param body - LAML-form update payload. Defaults to `{}`.
+   * @returns The updated application record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 }
 
-/** Compat cXML/LaML script management. */
+/** Compat cXML / LaML Bin management. */
 export class CompatLamlBins extends CrudResource {
   constructor(http: HttpClient, basePath: string) {
     super(http, basePath);
   }
 
+  /**
+   * Update a LaML Bin's stored script. LAML uses `POST` (not PATCH/PUT).
+   *
+   * @param sid - LaML Bin SID (e.g. `"LA..."`).
+   * @param body - Payload containing the new `VoiceMethod`, `Url`, etc.
+   *   Defaults to `{}`.
+   * @returns The updated LaML Bin record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 }
 
-/** Compat queue management with members. */
+/** Compat queue management with member operations. */
 export class CompatQueues extends CrudResource {
   constructor(http: HttpClient, basePath: string) {
     super(http, basePath);
   }
 
+  /**
+   * Update a queue. LAML uses `POST` (not PATCH/PUT).
+   *
+   * @param sid - Queue SID (e.g. `"QU..."`).
+   * @param body - LAML-form update payload. Defaults to `{}`.
+   * @returns The updated queue record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   override async update(sid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(sid), body);
   }
 
+  /**
+   * List members (calls) currently waiting in a queue.
+   *
+   * @param queueSid - Queue SID.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of queue members.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listMembers(queueSid: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(queueSid, 'Members'), params);
   }
 
+  /**
+   * Fetch a specific member (by call SID) currently waiting in a queue.
+   *
+   * @param queueSid - Queue SID.
+   * @param callSid - Call SID of the queued member.
+   * @returns The queue-member record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async getMember(queueSid: string, callSid: string): Promise<any> {
     return this._http.get(this._path(queueSid, 'Members', callSid));
   }
 
+  /**
+   * Dequeue a member — LAML's `POST` on a queued call redirects it to the
+   * given `Url` (typically to connect the caller to a queue consumer).
+   *
+   * @param queueSid - Queue SID.
+   * @param callSid - Call SID of the queued member.
+   * @param body - LAML-form payload (commonly `{ Url, Method }`).
+   *   Defaults to `{}`.
+   * @returns The updated queue-member record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async dequeueMember(queueSid: string, callSid: string, body: any = {}): Promise<any> {
     return this._http.post(this._path(queueSid, 'Members', callSid), body);
   }
 }
 
-/** Compat recording management. */
+/** Compat recording management (list / get / delete). */
 export class CompatRecordings extends BaseResource {
   constructor(http: HttpClient, basePath: string) {
     super(http, basePath);
   }
 
+  /**
+   * List recordings in the account.
+   *
+   * @param params - Optional filter / pagination query parameters
+   *   (date range, call SID, conference SID, etc.).
+   * @returns A paginated list of recordings.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /**
+   * Fetch a recording by SID.
+   *
+   * @param sid - Recording SID (e.g. `"RE..."`).
+   * @returns The recording record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(sid: string): Promise<any> {
     return this._http.get(this._path(sid));
   }
 
+  /**
+   * Delete a recording.
+   *
+   * @param sid - Recording SID.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(sid: string): Promise<any> {
     return this._http.delete(this._path(sid));
   }
 }
 
-/** Compat transcription management. */
+/** Compat transcription management (list / get / delete). */
 export class CompatTranscriptions extends BaseResource {
   constructor(http: HttpClient, basePath: string) {
     super(http, basePath);
   }
 
+  /**
+   * List transcriptions in the account.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of transcriptions.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /**
+   * Fetch a transcription by SID.
+   *
+   * @param sid - Transcription SID (e.g. `"TR..."`).
+   * @returns The transcription record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(sid: string): Promise<any> {
     return this._http.get(this._path(sid));
   }
 
+  /**
+   * Delete a transcription.
+   *
+   * @param sid - Transcription SID.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(sid: string): Promise<any> {
     return this._http.delete(this._path(sid));
   }
 }
 
-/** Compat API token management. */
+/** Compat API token management (non-LAML — uses `PATCH`). */
 export class CompatTokens extends BaseResource {
   constructor(http: HttpClient, basePath: string) {
     super(http, basePath);
   }
 
+  /**
+   * Create a new Compat API token.
+   *
+   * @param body - Token payload (friendly name, scopes, etc.).
+   * @returns The newly-created token record, including the secret value.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
 
+  /**
+   * Update a Compat API token.
+   *
+   * @param tokenId - Unique identifier of the token.
+   * @param body - Partial update payload. Defaults to `{}`.
+   * @returns The updated token record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(tokenId: string, body: any = {}): Promise<any> {
     return this._http.patch(this._path(tokenId), body);
   }
 
+  /**
+   * Revoke and delete a Compat API token.
+   *
+   * @param tokenId - Unique identifier of the token.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(tokenId: string): Promise<any> {
     return this._http.delete(this._path(tokenId));
   }
@@ -336,17 +768,29 @@ export class CompatTokens extends BaseResource {
  * ```
  */
 export class CompatNamespace {
+  /** Main and sub-account CRUD. */
   readonly accounts: CompatAccounts;
+  /** Call CRUD plus recording / stream sub-resource management. */
   readonly calls: CompatCalls;
+  /** Message CRUD plus media sub-resource management. */
   readonly messages: CompatMessages;
+  /** Fax CRUD plus media sub-resource management. */
   readonly faxes: CompatFaxes;
+  /** Conference read / update with participants, recordings, and streams. */
   readonly conferences: CompatConferences;
+  /** Phone number CRUD plus search / purchase / import helpers. */
   readonly phoneNumbers: CompatPhoneNumbers;
+  /** LAML Application CRUD. */
   readonly applications: CompatApplications;
+  /** LaML Bin (hosted script) CRUD. */
   readonly lamlBins: CompatLamlBins;
+  /** Queue CRUD plus member list / fetch / dequeue. */
   readonly queues: CompatQueues;
+  /** Recording list / fetch / delete. */
   readonly recordings: CompatRecordings;
+  /** Transcription list / fetch / delete. */
   readonly transcriptions: CompatTranscriptions;
+  /** Compat API token create / update / delete. */
   readonly tokens: CompatTokens;
 
   constructor(http: HttpClient, accountSid: string) {

--- a/src/rest/namespaces/compat.ts
+++ b/src/rest/namespaces/compat.ts
@@ -318,7 +318,23 @@ export class CompatTokens extends BaseResource {
   }
 }
 
-/** Twilio-compatible LAML API namespace with AccountSid scoping. */
+/**
+ * Twilio-compatible LAML API namespace with AccountSid scoping.
+ *
+ * Access via `client.compat.*`. This is the legacy LAML (cXML) surface for code
+ * migrated from Twilio — all updates use POST bodies instead of REST-idiomatic
+ * PATCH/PUT. Prefer the native SignalWire namespaces (`client.calling`, `client.fabric`,
+ * etc.) for greenfield projects.
+ *
+ * @example Send an SMS via the LAML Messages API
+ * ```ts
+ * await client.compat.messages.create({
+ *   From: '+15551112222',
+ *   To: '+15553334444',
+ *   Body: 'Hello from SignalWire!',
+ * });
+ * ```
+ */
 export class CompatNamespace {
   readonly accounts: CompatAccounts;
   readonly calls: CompatCalls;

--- a/src/rest/namespaces/datasphere.ts
+++ b/src/rest/namespaces/datasphere.ts
@@ -14,22 +14,50 @@ export class DatasphereDocuments extends CrudResource {
     super(http, '/api/datasphere/documents');
   }
 
-  /** Semantic search across documents. */
+  /**
+   * Run a semantic search across indexed documents.
+   *
+   * @param body - Search payload (typically `{ query: "...", document_id?: "...",
+   *   limit?: 5, tags?: [...] }`).
+   * @returns The ranked search hits.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async search(body: any): Promise<any> {
     return this._http.post(this._path('search'), body);
   }
 
-  /** List chunks for a document. */
+  /**
+   * List content chunks for a document.
+   *
+   * @param documentId - Unique identifier of the document.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of chunks.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listChunks(documentId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(documentId, 'chunks'), params);
   }
 
-  /** Get a specific chunk. */
+  /**
+   * Fetch a specific chunk of a document by ID.
+   *
+   * @param documentId - Unique identifier of the document.
+   * @param chunkId - Unique identifier of the chunk.
+   * @returns The chunk record with its content.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async getChunk(documentId: string, chunkId: string): Promise<any> {
     return this._http.get(this._path(documentId, 'chunks', chunkId));
   }
 
-  /** Delete a specific chunk. */
+  /**
+   * Delete a specific chunk from a document.
+   *
+   * @param documentId - Unique identifier of the document.
+   * @param chunkId - Unique identifier of the chunk.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async deleteChunk(documentId: string, chunkId: string): Promise<any> {
     return this._http.delete(this._path(documentId, 'chunks', chunkId));
   }
@@ -51,6 +79,7 @@ export class DatasphereDocuments extends CrudResource {
  * ```
  */
 export class DatasphereNamespace {
+  /** Document CRUD plus semantic search and chunk management. */
   readonly documents: DatasphereDocuments;
 
   constructor(http: HttpClient) {

--- a/src/rest/namespaces/datasphere.ts
+++ b/src/rest/namespaces/datasphere.ts
@@ -35,7 +35,21 @@ export class DatasphereDocuments extends CrudResource {
   }
 }
 
-/** Datasphere API namespace. */
+/**
+ * Datasphere API namespace.
+ *
+ * Access via `client.datasphere.*`. Datasphere is SignalWire's RAG service —
+ * index documents and run semantic search from within agent tools.
+ *
+ * @example
+ * ```ts
+ * const hits = await client.datasphere.documents.search({
+ *   query: 'refund policy',
+ *   document_id: 'doc_abc',
+ *   limit: 5,
+ * });
+ * ```
+ */
 export class DatasphereNamespace {
   readonly documents: DatasphereDocuments;
 

--- a/src/rest/namespaces/fabric.ts
+++ b/src/rest/namespaces/fabric.ts
@@ -25,22 +25,25 @@ export class FabricResourcePUT extends CrudWithAddresses {
   }
 }
 
-/** Call flows with version management. Uses singular 'call_flow' for sub-resource paths. */
+/** Call flows with version management. Uses singular `call_flow` for sub-resource paths. */
 export class CallFlowsResource extends FabricResourcePUT {
   constructor(http: HttpClient, basePath: string) {
     super(http, basePath);
   }
 
+  /** List addresses attached to a call flow resource. */
   override async listAddresses(resourceId: string, params?: QueryParams): Promise<any> {
     const path = this._basePath.replace('/call_flows', '/call_flow');
     return this._http.get(`${path}/${resourceId}/addresses`, params);
   }
 
+  /** List all saved versions of a call flow. */
   async listVersions(resourceId: string, params?: QueryParams): Promise<any> {
     const path = this._basePath.replace('/call_flows', '/call_flow');
     return this._http.get(`${path}/${resourceId}/versions`, params);
   }
 
+  /** Publish a new version of a call flow. */
   async deployVersion(resourceId: string, body: any = {}): Promise<any> {
     const path = this._basePath.replace('/call_flows', '/call_flow');
     return this._http.post(`${path}/${resourceId}/versions`, body);
@@ -65,22 +68,27 @@ export class SubscribersResource extends FabricResourcePUT {
     super(http, basePath);
   }
 
+  /** List the SIP endpoints registered under a subscriber. */
   async listSipEndpoints(subscriberId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(subscriberId, 'sip_endpoints'), params);
   }
 
+  /** Register a new SIP endpoint under a subscriber. */
   async createSipEndpoint(subscriberId: string, body: any): Promise<any> {
     return this._http.post(this._path(subscriberId, 'sip_endpoints'), body);
   }
 
+  /** Fetch a single SIP endpoint by ID. */
   async getSipEndpoint(subscriberId: string, endpointId: string): Promise<any> {
     return this._http.get(this._path(subscriberId, 'sip_endpoints', endpointId));
   }
 
+  /** Update a SIP endpoint's settings. */
   async updateSipEndpoint(subscriberId: string, endpointId: string, body: any): Promise<any> {
     return this._http.patch(this._path(subscriberId, 'sip_endpoints', endpointId), body);
   }
 
+  /** Delete a SIP endpoint. */
   async deleteSipEndpoint(subscriberId: string, endpointId: string): Promise<any> {
     return this._http.delete(this._path(subscriberId, 'sip_endpoints', endpointId));
   }
@@ -103,26 +111,32 @@ export class GenericResources extends BaseResource {
     super(http, basePath);
   }
 
+  /** List all fabric resources regardless of specific type. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Fetch a single fabric resource by ID. */
   async get(resourceId: string): Promise<any> {
     return this._http.get(this._path(resourceId));
   }
 
+  /** Delete a fabric resource. */
   async delete(resourceId: string): Promise<any> {
     return this._http.delete(this._path(resourceId));
   }
 
+  /** List addresses associated with any fabric resource. */
   async listAddresses(resourceId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(resourceId, 'addresses'), params);
   }
 
+  /** Assign a phone route to a fabric resource. */
   async assignPhoneRoute(resourceId: string, body: any): Promise<any> {
     return this._http.post(this._path(resourceId, 'phone_routes'), body);
   }
 
+  /** Assign a domain application to a fabric resource. */
   async assignDomainApplication(resourceId: string, body: any): Promise<any> {
     return this._http.post(this._path(resourceId, 'domain_applications'), body);
   }
@@ -134,10 +148,12 @@ export class FabricAddresses extends BaseResource {
     super(http, basePath);
   }
 
+  /** List all fabric addresses in the project. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Fetch a single fabric address by ID. */
   async get(addressId: string): Promise<any> {
     return this._http.get(this._path(addressId));
   }
@@ -149,28 +165,44 @@ export class FabricTokens extends BaseResource {
     super(http, '/api/fabric');
   }
 
+  /** Issue a new subscriber JWT used by end-user clients. */
   async createSubscriberToken(body: any = {}): Promise<any> {
     return this._http.post(this._path('subscribers', 'tokens'), body);
   }
 
+  /** Refresh an existing subscriber JWT. */
   async refreshSubscriberToken(body: any = {}): Promise<any> {
     return this._http.post(this._path('subscribers', 'tokens', 'refresh'), body);
   }
 
+  /** Create a single-use invite token for onboarding a new subscriber. */
   async createInviteToken(body: any = {}): Promise<any> {
     return this._http.post(this._path('subscriber', 'invites'), body);
   }
 
+  /** Issue a guest token (no subscriber account required). */
   async createGuestToken(body: any = {}): Promise<any> {
     return this._http.post(this._path('guests', 'tokens'), body);
   }
 
+  /** Issue a short-lived embed token for browser-side SignalWire widgets. */
   async createEmbedToken(body: any = {}): Promise<any> {
     return this._http.post(this._path('embeds', 'tokens'), body);
   }
 }
 
-/** Fabric API namespace grouping all resource types. */
+/**
+ * Fabric API namespace grouping all resource types.
+ *
+ * Access via `client.fabric.*`.
+ *
+ * @example
+ * ```ts
+ * const agents = await client.fabric.aiAgents.list();
+ * const flow = await client.fabric.callFlows.create({ name: 'main-ivr' });
+ * const token = await client.fabric.tokens.createSubscriberToken({ subscriber_id: 'sub_123' });
+ * ```
+ */
 export class FabricNamespace {
   // PUT-update resources
   readonly swmlScripts: FabricResourcePUT;

--- a/src/rest/namespaces/fabric.ts
+++ b/src/rest/namespaces/fabric.ts
@@ -31,19 +31,40 @@ export class CallFlowsResource extends FabricResourcePUT {
     super(http, basePath);
   }
 
-  /** List addresses attached to a call flow resource. */
+  /**
+   * List addresses attached to a call flow resource.
+   *
+   * @param resourceId - Unique identifier of the call flow.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of addresses.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   override async listAddresses(resourceId: string, params?: QueryParams): Promise<any> {
     const path = this._basePath.replace('/call_flows', '/call_flow');
     return this._http.get(`${path}/${resourceId}/addresses`, params);
   }
 
-  /** List all saved versions of a call flow. */
+  /**
+   * List all saved versions of a call flow.
+   *
+   * @param resourceId - Unique identifier of the call flow.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of call-flow versions.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listVersions(resourceId: string, params?: QueryParams): Promise<any> {
     const path = this._basePath.replace('/call_flows', '/call_flow');
     return this._http.get(`${path}/${resourceId}/versions`, params);
   }
 
-  /** Publish a new version of a call flow. */
+  /**
+   * Publish a new version of a call flow.
+   *
+   * @param resourceId - Unique identifier of the call flow.
+   * @param body - Version payload (schema and metadata). Defaults to `{}`.
+   * @returns The newly-published version record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async deployVersion(resourceId: string, body: any = {}): Promise<any> {
     const path = this._basePath.replace('/call_flows', '/call_flow');
     return this._http.post(`${path}/${resourceId}/versions`, body);
@@ -56,6 +77,14 @@ export class ConferenceRoomsResource extends FabricResourcePUT {
     super(http, basePath);
   }
 
+  /**
+   * List addresses attached to a conference-room resource.
+   *
+   * @param resourceId - Unique identifier of the conference room.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of addresses.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   override async listAddresses(resourceId: string, params?: QueryParams): Promise<any> {
     const path = this._basePath.replace('/conference_rooms', '/conference_room');
     return this._http.get(`${path}/${resourceId}/addresses`, params);
@@ -68,27 +97,63 @@ export class SubscribersResource extends FabricResourcePUT {
     super(http, basePath);
   }
 
-  /** List the SIP endpoints registered under a subscriber. */
+  /**
+   * List the SIP endpoints registered under a subscriber.
+   *
+   * @param subscriberId - Unique identifier of the subscriber.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of SIP endpoints.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listSipEndpoints(subscriberId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(subscriberId, 'sip_endpoints'), params);
   }
 
-  /** Register a new SIP endpoint under a subscriber. */
+  /**
+   * Register a new SIP endpoint under a subscriber.
+   *
+   * @param subscriberId - Unique identifier of the subscriber.
+   * @param body - SIP endpoint payload (credentials, codecs, etc.).
+   * @returns The newly-created SIP endpoint record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createSipEndpoint(subscriberId: string, body: any): Promise<any> {
     return this._http.post(this._path(subscriberId, 'sip_endpoints'), body);
   }
 
-  /** Fetch a single SIP endpoint by ID. */
+  /**
+   * Fetch a single SIP endpoint by ID.
+   *
+   * @param subscriberId - Unique identifier of the subscriber.
+   * @param endpointId - Unique identifier of the SIP endpoint.
+   * @returns The SIP endpoint record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async getSipEndpoint(subscriberId: string, endpointId: string): Promise<any> {
     return this._http.get(this._path(subscriberId, 'sip_endpoints', endpointId));
   }
 
-  /** Update a SIP endpoint's settings. */
+  /**
+   * Update a SIP endpoint's settings.
+   *
+   * @param subscriberId - Unique identifier of the subscriber.
+   * @param endpointId - Unique identifier of the SIP endpoint.
+   * @param body - Partial update payload (PATCH semantics).
+   * @returns The updated SIP endpoint record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async updateSipEndpoint(subscriberId: string, endpointId: string, body: any): Promise<any> {
     return this._http.patch(this._path(subscriberId, 'sip_endpoints', endpointId), body);
   }
 
-  /** Delete a SIP endpoint. */
+  /**
+   * Delete a SIP endpoint.
+   *
+   * @param subscriberId - Unique identifier of the subscriber.
+   * @param endpointId - Unique identifier of the SIP endpoint.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async deleteSipEndpoint(subscriberId: string, endpointId: string): Promise<any> {
     return this._http.delete(this._path(subscriberId, 'sip_endpoints', endpointId));
   }
@@ -111,32 +176,71 @@ export class GenericResources extends BaseResource {
     super(http, basePath);
   }
 
-  /** List all fabric resources regardless of specific type. */
+  /**
+   * List all fabric resources regardless of specific type.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of generic fabric resources.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Fetch a single fabric resource by ID. */
+  /**
+   * Fetch a single fabric resource by ID.
+   *
+   * @param resourceId - Unique identifier of the resource.
+   * @returns The resource record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(resourceId: string): Promise<any> {
     return this._http.get(this._path(resourceId));
   }
 
-  /** Delete a fabric resource. */
+  /**
+   * Delete a fabric resource.
+   *
+   * @param resourceId - Unique identifier of the resource.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(resourceId: string): Promise<any> {
     return this._http.delete(this._path(resourceId));
   }
 
-  /** List addresses associated with any fabric resource. */
+  /**
+   * List addresses associated with any fabric resource.
+   *
+   * @param resourceId - Unique identifier of the resource.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of addresses.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listAddresses(resourceId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(resourceId, 'addresses'), params);
   }
 
-  /** Assign a phone route to a fabric resource. */
+  /**
+   * Assign a phone route to a fabric resource.
+   *
+   * @param resourceId - Unique identifier of the resource.
+   * @param body - Phone route payload (typically `{ phone_number_id }`).
+   * @returns The phone-route assignment record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async assignPhoneRoute(resourceId: string, body: any): Promise<any> {
     return this._http.post(this._path(resourceId, 'phone_routes'), body);
   }
 
-  /** Assign a domain application to a fabric resource. */
+  /**
+   * Assign a domain application to a fabric resource.
+   *
+   * @param resourceId - Unique identifier of the resource.
+   * @param body - Domain application payload.
+   * @returns The domain-application assignment record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async assignDomainApplication(resourceId: string, body: any): Promise<any> {
     return this._http.post(this._path(resourceId, 'domain_applications'), body);
   }
@@ -148,12 +252,24 @@ export class FabricAddresses extends BaseResource {
     super(http, basePath);
   }
 
-  /** List all fabric addresses in the project. */
+  /**
+   * List all fabric addresses in the project.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of fabric addresses.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Fetch a single fabric address by ID. */
+  /**
+   * Fetch a single fabric address by ID.
+   *
+   * @param addressId - Unique identifier of the address.
+   * @returns The address record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(addressId: string): Promise<any> {
     return this._http.get(this._path(addressId));
   }
@@ -165,27 +281,58 @@ export class FabricTokens extends BaseResource {
     super(http, '/api/fabric');
   }
 
-  /** Issue a new subscriber JWT used by end-user clients. */
+  /**
+   * Issue a new subscriber JWT used by end-user clients.
+   *
+   * @param body - Token payload (subscriber ID, TTL, scopes). Defaults to `{}`.
+   * @returns The token record, typically `{ token: "eyJ..." }`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createSubscriberToken(body: any = {}): Promise<any> {
     return this._http.post(this._path('subscribers', 'tokens'), body);
   }
 
-  /** Refresh an existing subscriber JWT. */
+  /**
+   * Refresh an existing subscriber JWT, extending its lifetime.
+   *
+   * @param body - Refresh payload (usually containing the current token).
+   *   Defaults to `{}`.
+   * @returns The refreshed token record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async refreshSubscriberToken(body: any = {}): Promise<any> {
     return this._http.post(this._path('subscribers', 'tokens', 'refresh'), body);
   }
 
-  /** Create a single-use invite token for onboarding a new subscriber. */
+  /**
+   * Create a single-use invite token for onboarding a new subscriber.
+   *
+   * @param body - Invite payload (email, phone, permissions). Defaults to `{}`.
+   * @returns The invite record, including the share URL / code.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createInviteToken(body: any = {}): Promise<any> {
     return this._http.post(this._path('subscriber', 'invites'), body);
   }
 
-  /** Issue a guest token (no subscriber account required). */
+  /**
+   * Issue a guest token (no subscriber account required).
+   *
+   * @param body - Guest-token payload (context, TTL, etc.). Defaults to `{}`.
+   * @returns The token record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createGuestToken(body: any = {}): Promise<any> {
     return this._http.post(this._path('guests', 'tokens'), body);
   }
 
-  /** Issue a short-lived embed token for browser-side SignalWire widgets. */
+  /**
+   * Issue a short-lived embed token for browser-side SignalWire widgets.
+   *
+   * @param body - Embed-token payload (allowed origins, TTL, etc.). Defaults to `{}`.
+   * @returns The token record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createEmbedToken(body: any = {}): Promise<any> {
     return this._http.post(this._path('embeds', 'tokens'), body);
   }
@@ -205,25 +352,41 @@ export class FabricTokens extends BaseResource {
  */
 export class FabricNamespace {
   // PUT-update resources
+  /** SWML script CRUD (full-replacement `PUT` update). */
   readonly swmlScripts: FabricResourcePUT;
+  /** Relay Application CRUD (full-replacement `PUT` update). */
   readonly relayApplications: FabricResourcePUT;
+  /** Call Flow CRUD with version listing and publishing. */
   readonly callFlows: CallFlowsResource;
+  /** Conference Room CRUD with address listing. */
   readonly conferenceRooms: ConferenceRoomsResource;
+  /** FreeSWITCH Connector CRUD. */
   readonly freeswitchConnectors: FabricResourcePUT;
+  /** Subscriber CRUD plus nested SIP endpoint management. */
   readonly subscribers: SubscribersResource;
+  /** Top-level SIP endpoint CRUD. */
   readonly sipEndpoints: FabricResourcePUT;
+  /** cXML (LaML) script CRUD. */
   readonly cxmlScripts: FabricResourcePUT;
+  /** cXML application read / update / delete (no create). */
   readonly cxmlApplications: CxmlApplicationsResource;
 
   // PATCH-update resources
+  /** SWML webhook CRUD (partial-update `PATCH` semantics). */
   readonly swmlWebhooks: FabricResource;
+  /** AI Agent CRUD — the platform-managed agent registration resource. */
   readonly aiAgents: FabricResource;
+  /** SIP Gateway CRUD. */
   readonly sipGateways: FabricResource;
+  /** cXML webhook CRUD. */
   readonly cxmlWebhooks: FabricResource;
 
   // Special resources
+  /** Generic operations across all resource types (list, get, delete, phone route assignment). */
   readonly resources: GenericResources;
+  /** Read-only access to the unified fabric address table. */
   readonly addresses: FabricAddresses;
+  /** Subscriber, guest, invite, and embed token generation. */
   readonly tokens: FabricTokens;
 
   constructor(http: HttpClient) {

--- a/src/rest/namespaces/imported-numbers.ts
+++ b/src/rest/namespaces/imported-numbers.ts
@@ -7,7 +7,11 @@
 import type { HttpClient } from '../HttpClient.js';
 import { BaseResource } from '../base/BaseResource.js';
 
-/** Import externally-hosted phone numbers. */
+/**
+ * Import externally-hosted phone numbers.
+ *
+ * Access via `client.importedNumbers.*`.
+ */
 export class ImportedNumbersResource extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/relay/rest/imported_phone_numbers');

--- a/src/rest/namespaces/imported-numbers.ts
+++ b/src/rest/namespaces/imported-numbers.ts
@@ -17,7 +17,14 @@ export class ImportedNumbersResource extends BaseResource {
     super(http, '/api/relay/rest/imported_phone_numbers');
   }
 
-  /** Import a phone number. */
+  /**
+   * Import an externally-hosted phone number into this project.
+   *
+   * @param body - Import payload specifying the number, carrier details,
+   *   and any routing configuration required by the platform.
+   * @returns The newly-imported phone-number record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }

--- a/src/rest/namespaces/logs.ts
+++ b/src/rest/namespaces/logs.ts
@@ -14,12 +14,25 @@ export class MessageLogs extends BaseResource {
     super(http, basePath);
   }
 
-  /** List message log entries. */
+  /**
+   * List message log entries.
+   *
+   * @param params - Optional filter / pagination query parameters
+   *   (e.g. date range, direction, status).
+   * @returns A paginated list of message log entries.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Fetch a single message log entry by ID. */
+  /**
+   * Fetch a single message log entry by ID.
+   *
+   * @param logId - Unique identifier of the log entry.
+   * @returns The log entry record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(logId: string): Promise<any> {
     return this._http.get(this._path(logId));
   }
@@ -31,17 +44,36 @@ export class VoiceLogs extends BaseResource {
     super(http, basePath);
   }
 
-  /** List voice (call) log entries. */
+  /**
+   * List voice (call) log entries.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of voice log entries.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Fetch a single voice log entry by ID. */
+  /**
+   * Fetch a single voice log entry by ID.
+   *
+   * @param logId - Unique identifier of the log entry.
+   * @returns The log entry record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(logId: string): Promise<any> {
     return this._http.get(this._path(logId));
   }
 
-  /** List events captured during a voice log entry. */
+  /**
+   * List events captured during a voice log entry.
+   *
+   * @param logId - Unique identifier of the log entry.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of events for the log entry.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listEvents(logId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(logId, 'events'), params);
   }
@@ -53,12 +85,24 @@ export class FaxLogs extends BaseResource {
     super(http, basePath);
   }
 
-  /** List fax log entries. */
+  /**
+   * List fax log entries.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of fax log entries.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Fetch a single fax log entry by ID. */
+  /**
+   * Fetch a single fax log entry by ID.
+   *
+   * @param logId - Unique identifier of the log entry.
+   * @returns The log entry record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(logId: string): Promise<any> {
     return this._http.get(this._path(logId));
   }
@@ -70,7 +114,13 @@ export class ConferenceLogs extends BaseResource {
     super(http, basePath);
   }
 
-  /** List conference log entries. */
+  /**
+   * List conference log entries.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of conference log entries.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
@@ -83,9 +133,13 @@ export class ConferenceLogs extends BaseResource {
  * conference logs for auditing and observability.
  */
 export class LogsNamespace {
+  /** SMS/MMS message log queries. */
   readonly messages: MessageLogs;
+  /** Voice call log queries with event drill-down. */
   readonly voice: VoiceLogs;
+  /** Fax log queries. */
   readonly fax: FaxLogs;
+  /** Conference log queries. */
   readonly conferences: ConferenceLogs;
 
   constructor(http: HttpClient) {

--- a/src/rest/namespaces/logs.ts
+++ b/src/rest/namespaces/logs.ts
@@ -14,10 +14,12 @@ export class MessageLogs extends BaseResource {
     super(http, basePath);
   }
 
+  /** List message log entries. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Fetch a single message log entry by ID. */
   async get(logId: string): Promise<any> {
     return this._http.get(this._path(logId));
   }
@@ -29,14 +31,17 @@ export class VoiceLogs extends BaseResource {
     super(http, basePath);
   }
 
+  /** List voice (call) log entries. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Fetch a single voice log entry by ID. */
   async get(logId: string): Promise<any> {
     return this._http.get(this._path(logId));
   }
 
+  /** List events captured during a voice log entry. */
   async listEvents(logId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(logId, 'events'), params);
   }
@@ -48,10 +53,12 @@ export class FaxLogs extends BaseResource {
     super(http, basePath);
   }
 
+  /** List fax log entries. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Fetch a single fax log entry by ID. */
   async get(logId: string): Promise<any> {
     return this._http.get(this._path(logId));
   }
@@ -63,12 +70,18 @@ export class ConferenceLogs extends BaseResource {
     super(http, basePath);
   }
 
+  /** List conference log entries. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 }
 
-/** Logs API namespace. */
+/**
+ * Logs API namespace.
+ *
+ * Access via `client.logs.*`. Read-only access to message, voice, fax, and
+ * conference logs for auditing and observability.
+ */
 export class LogsNamespace {
   readonly messages: MessageLogs;
   readonly voice: VoiceLogs;

--- a/src/rest/namespaces/lookup.ts
+++ b/src/rest/namespaces/lookup.ts
@@ -23,7 +23,15 @@ export class LookupResource extends BaseResource {
     super(http, '/api/relay/rest/lookup');
   }
 
-  /** Look up carrier/CNAM info for a phone number. */
+  /**
+   * Look up carrier and CNAM information for a phone number.
+   *
+   * @param e164 - The phone number in E.164 format (e.g. `"+15551234567"`).
+   * @param params - Optional query parameters, most commonly
+   *   `include: "carrier,caller-name"` to enable carrier and CNAM lookups.
+   * @returns The lookup record containing any requested datasets.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async phoneNumber(e164: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path('phone_number', e164), params);
   }

--- a/src/rest/namespaces/lookup.ts
+++ b/src/rest/namespaces/lookup.ts
@@ -8,7 +8,16 @@ import type { HttpClient } from '../HttpClient.js';
 import type { QueryParams } from '../types.js';
 import { BaseResource } from '../base/BaseResource.js';
 
-/** Phone number lookup (carrier, CNAM). */
+/**
+ * Phone number lookup (carrier, CNAM).
+ *
+ * Access via `client.lookup.*`.
+ *
+ * @example
+ * ```ts
+ * const info = await client.lookup.phoneNumber('+15551234567', { include: 'carrier,caller-name' });
+ * ```
+ */
 export class LookupResource extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/relay/rest/lookup');

--- a/src/rest/namespaces/mfa.ts
+++ b/src/rest/namespaces/mfa.ts
@@ -7,7 +7,18 @@
 import type { HttpClient } from '../HttpClient.js';
 import { BaseResource } from '../base/BaseResource.js';
 
-/** Multi-factor authentication via SMS or phone call. */
+/**
+ * Multi-factor authentication via SMS or phone call.
+ *
+ * Access via `client.mfa.*`. Two-step flow: call `.sms()` or `.call()` to send
+ * a code, then `.verify()` to confirm it.
+ *
+ * @example
+ * ```ts
+ * const req = await client.mfa.sms({ to: '+15551234567' });
+ * const result = await client.mfa.verify(req.id, { token: '123456' });
+ * ```
+ */
 export class MfaResource extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/relay/rest/mfa');

--- a/src/rest/namespaces/mfa.ts
+++ b/src/rest/namespaces/mfa.ts
@@ -24,17 +24,37 @@ export class MfaResource extends BaseResource {
     super(http, '/api/relay/rest/mfa');
   }
 
-  /** Initiate MFA via SMS. */
+  /**
+   * Initiate MFA by sending a one-time code to a phone number over SMS.
+   *
+   * @param body - MFA request payload (typically `{ to: "+15551234567",
+   *   message?: "Your code is {code}" }`).
+   * @returns The MFA request record; its `id` is used by {@link verify}.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async sms(body: any): Promise<any> {
     return this._http.post(this._path('sms'), body);
   }
 
-  /** Initiate MFA via phone call. */
+  /**
+   * Initiate MFA by placing a phone call that reads out a one-time code.
+   *
+   * @param body - MFA request payload (typically `{ to: "+15551234567" }`).
+   * @returns The MFA request record; its `id` is used by {@link verify}.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async call(body: any): Promise<any> {
     return this._http.post(this._path('call'), body);
   }
 
-  /** Verify an MFA code. */
+  /**
+   * Verify the one-time code the user received via SMS or call.
+   *
+   * @param requestId - The `id` returned from {@link sms} or {@link call}.
+   * @param body - Verification payload (typically `{ token: "123456" }`).
+   * @returns The verification result — success or failure shape.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async verify(requestId: string, body: any): Promise<any> {
     return this._http.post(this._path(requestId, 'verify'), body);
   }

--- a/src/rest/namespaces/number-groups.ts
+++ b/src/rest/namespaces/number-groups.ts
@@ -8,7 +8,11 @@ import type { HttpClient } from '../HttpClient.js';
 import type { QueryParams } from '../types.js';
 import { CrudResource } from '../base/CrudResource.js';
 
-/** Number group management with membership operations. */
+/**
+ * Number group management with membership operations.
+ *
+ * Access via `client.numberGroups.*`. Extends standard CRUD with membership helpers.
+ */
 export class NumberGroupsResource extends CrudResource {
   protected override _updateMethod: 'PATCH' | 'PUT' = 'PUT';
 

--- a/src/rest/namespaces/number-groups.ts
+++ b/src/rest/namespaces/number-groups.ts
@@ -20,22 +20,48 @@ export class NumberGroupsResource extends CrudResource {
     super(http, '/api/relay/rest/number_groups');
   }
 
-  /** List memberships for a group. */
+  /**
+   * List memberships (phone-number assignments) in a group.
+   *
+   * @param groupId - Unique identifier of the number group.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of number-group memberships.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listMemberships(groupId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(groupId, 'number_group_memberships'), params);
   }
 
-  /** Add a number to a group. */
+  /**
+   * Add a phone number to a group.
+   *
+   * @param groupId - Unique identifier of the number group.
+   * @param body - Membership payload (typically `{ phone_number_id: "..." }`).
+   * @returns The newly-created membership record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async addMembership(groupId: string, body: any): Promise<any> {
     return this._http.post(this._path(groupId, 'number_group_memberships'), body);
   }
 
-  /** Get a membership by ID. */
+  /**
+   * Fetch a membership by ID.
+   *
+   * @param membershipId - Unique identifier of the membership.
+   * @returns The membership record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async getMembership(membershipId: string): Promise<any> {
     return this._http.get(`/api/relay/rest/number_group_memberships/${membershipId}`);
   }
 
-  /** Delete a membership by ID. */
+  /**
+   * Remove a number from a group by deleting its membership.
+   *
+   * @param membershipId - Unique identifier of the membership.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async deleteMembership(membershipId: string): Promise<any> {
     return this._http.delete(`/api/relay/rest/number_group_memberships/${membershipId}`);
   }

--- a/src/rest/namespaces/phone-numbers.ts
+++ b/src/rest/namespaces/phone-numbers.ts
@@ -31,6 +31,11 @@ export class PhoneNumbersResource extends CrudResource {
    * Purchase / create a phone number resource in this project.
    * Body is optional to match Python's `**kwargs` call convention.
    *
+   * @param body - Phone-number creation payload (platform-shaped JSON).
+   *   Defaults to `{}` when omitted.
+   * @returns The newly-created phone-number resource.
+   * @throws {RestError} On any non-2xx HTTP response.
+   *
    * @example
    * ```ts
    * const num = await client.phoneNumbers.create({ number: '+15551234567' });
@@ -40,13 +45,25 @@ export class PhoneNumbersResource extends CrudResource {
     return this._http.post(this._basePath, body);
   }
 
-  /** Update a phone number resource by ID. Body is optional to match Python `**kwargs`. */
+  /**
+   * Update a phone number resource by ID. Body is optional to match Python `**kwargs`.
+   *
+   * @param resourceId - Unique phone-number resource ID.
+   * @param body - Partial update payload. Defaults to `{}`.
+   * @returns The updated phone-number resource.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   override async update(resourceId: string, body: any = {}): Promise<any> {
     return this._http.put(this._path(resourceId), body);
   }
 
   /**
    * Search available phone numbers for purchase.
+   *
+   * @param params - Search filters (e.g. `areaCode`, `contains`, `region`,
+   *   `number_type`, pagination).
+   * @returns A paginated list of matching available numbers.
+   * @throws {RestError} On any non-2xx HTTP response.
    *
    * @example
    * ```ts

--- a/src/rest/namespaces/phone-numbers.ts
+++ b/src/rest/namespaces/phone-numbers.ts
@@ -27,17 +27,32 @@ export class PhoneNumbersResource extends CrudResource {
     super(http, '/api/relay/rest/phone_numbers');
   }
 
-  /** Create a phone number resource. Body is optional to match Python **kwargs. */
+  /**
+   * Purchase / create a phone number resource in this project.
+   * Body is optional to match Python's `**kwargs` call convention.
+   *
+   * @example
+   * ```ts
+   * const num = await client.phoneNumbers.create({ number: '+15551234567' });
+   * ```
+   */
   override async create(body: any = {}): Promise<any> {
     return this._http.post(this._basePath, body);
   }
 
-  /** Update a phone number resource by ID. Body is optional to match Python **kwargs. */
+  /** Update a phone number resource by ID. Body is optional to match Python `**kwargs`. */
   override async update(resourceId: string, body: any = {}): Promise<any> {
     return this._http.put(this._path(resourceId), body);
   }
 
-  /** Search available phone numbers for purchase. */
+  /**
+   * Search available phone numbers for purchase.
+   *
+   * @example
+   * ```ts
+   * const results = await client.phoneNumbers.search({ areaCode: '512', contains: '5555' });
+   * ```
+   */
   async search(params?: QueryParams): Promise<any> {
     return this._http.get(this._path('search'), params);
   }

--- a/src/rest/namespaces/project.ts
+++ b/src/rest/namespaces/project.ts
@@ -13,17 +13,37 @@ export class ProjectTokens extends BaseResource {
     super(http, '/api/project/tokens');
   }
 
-  /** Create a new project-scoped API token. */
+  /**
+   * Create a new project-scoped API token.
+   *
+   * @param body - Token creation payload (friendly name, scopes, etc.).
+   * @returns The newly-created token record, including the secret value
+   *   (which is typically returned ONCE and not retrievable again).
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
 
-  /** Update a project API token's attributes (e.g. friendly name). */
+  /**
+   * Update a project API token's attributes (e.g. friendly name).
+   *
+   * @param tokenId - Unique identifier of the token.
+   * @param body - Partial update payload.
+   * @returns The updated token record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(tokenId: string, body: any): Promise<any> {
     return this._http.patch(this._path(tokenId), body);
   }
 
-  /** Revoke and delete a project API token. */
+  /**
+   * Revoke and delete a project API token.
+   *
+   * @param tokenId - Unique identifier of the token to revoke.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(tokenId: string): Promise<any> {
     return this._http.delete(this._path(tokenId));
   }
@@ -36,6 +56,7 @@ export class ProjectTokens extends BaseResource {
  * secondary API tokens.
  */
 export class ProjectNamespace {
+  /** Project-scoped API token create / update / delete. */
   readonly tokens: ProjectTokens;
 
   constructor(http: HttpClient) {

--- a/src/rest/namespaces/project.ts
+++ b/src/rest/namespaces/project.ts
@@ -13,20 +13,28 @@ export class ProjectTokens extends BaseResource {
     super(http, '/api/project/tokens');
   }
 
+  /** Create a new project-scoped API token. */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
 
+  /** Update a project API token's attributes (e.g. friendly name). */
   async update(tokenId: string, body: any): Promise<any> {
     return this._http.patch(this._path(tokenId), body);
   }
 
+  /** Revoke and delete a project API token. */
   async delete(tokenId: string): Promise<any> {
     return this._http.delete(this._path(tokenId));
   }
 }
 
-/** Project API namespace. */
+/**
+ * Project API namespace.
+ *
+ * Access via `client.project.*`. Manages project-level resources like
+ * secondary API tokens.
+ */
 export class ProjectNamespace {
   readonly tokens: ProjectTokens;
 

--- a/src/rest/namespaces/pubsub.ts
+++ b/src/rest/namespaces/pubsub.ts
@@ -7,7 +7,12 @@
 import type { HttpClient } from '../HttpClient.js';
 import { BaseResource } from '../base/BaseResource.js';
 
-/** PubSub token generation. */
+/**
+ * PubSub token generation.
+ *
+ * Access via `client.pubsub.*`. Issues short-lived tokens that browser / mobile
+ * clients can use to subscribe to project channels.
+ */
 export class PubSubResource extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/pubsub/tokens');

--- a/src/rest/namespaces/pubsub.ts
+++ b/src/rest/namespaces/pubsub.ts
@@ -18,7 +18,13 @@ export class PubSubResource extends BaseResource {
     super(http, '/api/pubsub/tokens');
   }
 
-  /** Generate a PubSub token. */
+  /**
+   * Generate a short-lived PubSub token.
+   *
+   * @param body - Token payload (e.g. `{ namespace, channels, expires_in }`).
+   * @returns The token record, typically `{ token: "eyJ..." }`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createToken(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }

--- a/src/rest/namespaces/queues.ts
+++ b/src/rest/namespaces/queues.ts
@@ -20,17 +20,38 @@ export class QueuesResource extends CrudResource {
     super(http, '/api/relay/rest/queues');
   }
 
-  /** List members in a queue. */
+  /**
+   * List members in a queue.
+   *
+   * @param queueId - Unique identifier of the queue.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of queue members.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listMembers(queueId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(queueId, 'members'), params);
   }
 
-  /** Get the next member in a queue. */
+  /**
+   * Get the next member to be served in a queue (FIFO head).
+   *
+   * @param queueId - Unique identifier of the queue.
+   * @returns The next queue member record, or a platform-shaped empty
+   *   response when the queue is empty.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async getNextMember(queueId: string): Promise<any> {
     return this._http.get(this._path(queueId, 'members', 'next'));
   }
 
-  /** Get a specific member in a queue. */
+  /**
+   * Fetch a specific queue member by ID.
+   *
+   * @param queueId - Unique identifier of the queue.
+   * @param memberId - Unique identifier of the queue member.
+   * @returns The queue member record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async getMember(queueId: string, memberId: string): Promise<any> {
     return this._http.get(this._path(queueId, 'members', memberId));
   }

--- a/src/rest/namespaces/queues.ts
+++ b/src/rest/namespaces/queues.ts
@@ -8,7 +8,11 @@ import type { HttpClient } from '../HttpClient.js';
 import type { QueryParams } from '../types.js';
 import { CrudResource } from '../base/CrudResource.js';
 
-/** Queue management with member operations. */
+/**
+ * Queue management with member operations.
+ *
+ * Access via `client.queues.*`. Extends standard CRUD with member list/fetch.
+ */
 export class QueuesResource extends CrudResource {
   protected override _updateMethod: 'PATCH' | 'PUT' = 'PUT';
 

--- a/src/rest/namespaces/recordings.ts
+++ b/src/rest/namespaces/recordings.ts
@@ -18,17 +18,35 @@ export class RecordingsResource extends BaseResource {
     super(http, '/api/relay/rest/recordings');
   }
 
-  /** List recordings in the project. */
+  /**
+   * List recordings in the project.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of recordings.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Fetch a recording's metadata by ID. */
+  /**
+   * Fetch a recording's metadata by ID.
+   *
+   * @param recordingId - Unique identifier of the recording.
+   * @returns The recording metadata record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(recordingId: string): Promise<any> {
     return this._http.get(this._path(recordingId));
   }
 
-  /** Delete a recording. */
+  /**
+   * Delete a recording.
+   *
+   * @param recordingId - Unique identifier of the recording.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(recordingId: string): Promise<any> {
     return this._http.delete(this._path(recordingId));
   }

--- a/src/rest/namespaces/recordings.ts
+++ b/src/rest/namespaces/recordings.ts
@@ -8,20 +8,27 @@ import type { HttpClient } from '../HttpClient.js';
 import type { QueryParams } from '../types.js';
 import { BaseResource } from '../base/BaseResource.js';
 
-/** Recording management (read-only + delete). */
+/**
+ * Recording management (read-only + delete).
+ *
+ * Access via `client.recordings.*`.
+ */
 export class RecordingsResource extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/relay/rest/recordings');
   }
 
+  /** List recordings in the project. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Fetch a recording's metadata by ID. */
   async get(recordingId: string): Promise<any> {
     return this._http.get(this._path(recordingId));
   }
 
+  /** Delete a recording. */
   async delete(recordingId: string): Promise<any> {
     return this._http.delete(this._path(recordingId));
   }

--- a/src/rest/namespaces/registry.ts
+++ b/src/rest/namespaces/registry.ts
@@ -14,22 +14,27 @@ export class RegistryBrands extends BaseResource {
     super(http, basePath);
   }
 
+  /** List all 10DLC brands in the project. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Register a new 10DLC brand. */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
 
+  /** Fetch a brand by ID. */
   async get(brandId: string): Promise<any> {
     return this._http.get(this._path(brandId));
   }
 
+  /** List campaigns registered under a brand. */
   async listCampaigns(brandId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(brandId, 'campaigns'), params);
   }
 
+  /** Register a new campaign under a brand. */
   async createCampaign(brandId: string, body: any): Promise<any> {
     return this._http.post(this._path(brandId, 'campaigns'), body);
   }
@@ -41,22 +46,27 @@ export class RegistryCampaigns extends BaseResource {
     super(http, basePath);
   }
 
+  /** Fetch a campaign by ID. */
   async get(campaignId: string): Promise<any> {
     return this._http.get(this._path(campaignId));
   }
 
+  /** Update a campaign's attributes. */
   async update(campaignId: string, body: any): Promise<any> {
     return this._http.put(this._path(campaignId), body);
   }
 
+  /** List the phone numbers assigned to a campaign. */
   async listNumbers(campaignId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(campaignId, 'numbers'), params);
   }
 
+  /** List number-assignment orders for a campaign. */
   async listOrders(campaignId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(campaignId, 'orders'), params);
   }
 
+  /** Create a new number-assignment order against a campaign. */
   async createOrder(campaignId: string, body: any): Promise<any> {
     return this._http.post(this._path(campaignId, 'orders'), body);
   }
@@ -68,6 +78,7 @@ export class RegistryOrders extends BaseResource {
     super(http, basePath);
   }
 
+  /** Fetch a number-assignment order by ID. */
   async get(orderId: string): Promise<any> {
     return this._http.get(this._path(orderId));
   }
@@ -79,12 +90,18 @@ export class RegistryNumbers extends BaseResource {
     super(http, basePath);
   }
 
+  /** Remove a number from a 10DLC campaign assignment. */
   async delete(numberId: string): Promise<any> {
     return this._http.delete(this._path(numberId));
   }
 }
 
-/** 10DLC Campaign Registry namespace. */
+/**
+ * 10DLC Campaign Registry namespace.
+ *
+ * Access via `client.registry.*`. Groups brand, campaign, order, and number
+ * resources for US A2P 10DLC compliance registration.
+ */
 export class RegistryNamespace {
   readonly brands: RegistryBrands;
   readonly campaigns: RegistryCampaigns;

--- a/src/rest/namespaces/registry.ts
+++ b/src/rest/namespaces/registry.ts
@@ -14,27 +14,59 @@ export class RegistryBrands extends BaseResource {
     super(http, basePath);
   }
 
-  /** List all 10DLC brands in the project. */
+  /**
+   * List all 10DLC brands in the project.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of brands.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Register a new 10DLC brand. */
+  /**
+   * Register a new 10DLC brand.
+   *
+   * @param body - Brand registration payload (EIN, legal name, etc.).
+   * @returns The newly-registered brand record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
 
-  /** Fetch a brand by ID. */
+  /**
+   * Fetch a brand by ID.
+   *
+   * @param brandId - Unique identifier of the brand.
+   * @returns The brand record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(brandId: string): Promise<any> {
     return this._http.get(this._path(brandId));
   }
 
-  /** List campaigns registered under a brand. */
+  /**
+   * List campaigns registered under a brand.
+   *
+   * @param brandId - Unique identifier of the brand.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of campaigns.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listCampaigns(brandId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(brandId, 'campaigns'), params);
   }
 
-  /** Register a new campaign under a brand. */
+  /**
+   * Register a new campaign under a brand.
+   *
+   * @param brandId - Unique identifier of the brand.
+   * @param body - Campaign registration payload (use case, sample messages, etc.).
+   * @returns The newly-registered campaign record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createCampaign(brandId: string, body: any): Promise<any> {
     return this._http.post(this._path(brandId, 'campaigns'), body);
   }
@@ -46,27 +78,61 @@ export class RegistryCampaigns extends BaseResource {
     super(http, basePath);
   }
 
-  /** Fetch a campaign by ID. */
+  /**
+   * Fetch a campaign by ID.
+   *
+   * @param campaignId - Unique identifier of the campaign.
+   * @returns The campaign record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(campaignId: string): Promise<any> {
     return this._http.get(this._path(campaignId));
   }
 
-  /** Update a campaign's attributes. */
+  /**
+   * Update a campaign's attributes.
+   *
+   * @param campaignId - Unique identifier of the campaign.
+   * @param body - Full updated campaign attributes (replace semantics).
+   * @returns The updated campaign record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(campaignId: string, body: any): Promise<any> {
     return this._http.put(this._path(campaignId), body);
   }
 
-  /** List the phone numbers assigned to a campaign. */
+  /**
+   * List the phone numbers assigned to a campaign.
+   *
+   * @param campaignId - Unique identifier of the campaign.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of assigned numbers.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listNumbers(campaignId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(campaignId, 'numbers'), params);
   }
 
-  /** List number-assignment orders for a campaign. */
+  /**
+   * List number-assignment orders for a campaign.
+   *
+   * @param campaignId - Unique identifier of the campaign.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of number-assignment orders.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listOrders(campaignId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(campaignId, 'orders'), params);
   }
 
-  /** Create a new number-assignment order against a campaign. */
+  /**
+   * Create a new number-assignment order against a campaign.
+   *
+   * @param campaignId - Unique identifier of the campaign.
+   * @param body - Order payload (phone number IDs, etc.).
+   * @returns The newly-created order record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createOrder(campaignId: string, body: any): Promise<any> {
     return this._http.post(this._path(campaignId, 'orders'), body);
   }
@@ -78,7 +144,13 @@ export class RegistryOrders extends BaseResource {
     super(http, basePath);
   }
 
-  /** Fetch a number-assignment order by ID. */
+  /**
+   * Fetch a number-assignment order by ID.
+   *
+   * @param orderId - Unique identifier of the order.
+   * @returns The order record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(orderId: string): Promise<any> {
     return this._http.get(this._path(orderId));
   }
@@ -90,7 +162,13 @@ export class RegistryNumbers extends BaseResource {
     super(http, basePath);
   }
 
-  /** Remove a number from a 10DLC campaign assignment. */
+  /**
+   * Remove a number from a 10DLC campaign assignment.
+   *
+   * @param numberId - Unique identifier of the assigned number.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(numberId: string): Promise<any> {
     return this._http.delete(this._path(numberId));
   }
@@ -103,9 +181,13 @@ export class RegistryNumbers extends BaseResource {
  * resources for US A2P 10DLC compliance registration.
  */
 export class RegistryNamespace {
+  /** 10DLC brand CRUD and nested campaign operations. */
   readonly brands: RegistryBrands;
+  /** 10DLC campaign CRUD, number listing, and order management. */
   readonly campaigns: RegistryCampaigns;
+  /** 10DLC number-assignment order read access. */
   readonly orders: RegistryOrders;
+  /** 10DLC number assignment removal. */
   readonly numbers: RegistryNumbers;
 
   constructor(http: HttpClient) {

--- a/src/rest/namespaces/short-codes.ts
+++ b/src/rest/namespaces/short-codes.ts
@@ -8,20 +8,27 @@ import type { HttpClient } from '../HttpClient.js';
 import type { QueryParams } from '../types.js';
 import { BaseResource } from '../base/BaseResource.js';
 
-/** Short code management (read + update only). */
+/**
+ * Short code management (read + update only).
+ *
+ * Access via `client.shortCodes.*`.
+ */
 export class ShortCodesResource extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/relay/rest/short_codes');
   }
 
+  /** List short codes in the project. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Fetch a short code by ID. */
   async get(shortCodeId: string): Promise<any> {
     return this._http.get(this._path(shortCodeId));
   }
 
+  /** Update a short code's configuration (webhooks, friendly name, etc.). */
   async update(shortCodeId: string, body: any): Promise<any> {
     return this._http.put(this._path(shortCodeId), body);
   }

--- a/src/rest/namespaces/short-codes.ts
+++ b/src/rest/namespaces/short-codes.ts
@@ -18,17 +18,36 @@ export class ShortCodesResource extends BaseResource {
     super(http, '/api/relay/rest/short_codes');
   }
 
-  /** List short codes in the project. */
+  /**
+   * List short codes in the project.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of short codes.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Fetch a short code by ID. */
+  /**
+   * Fetch a short code by ID.
+   *
+   * @param shortCodeId - Unique identifier of the short code.
+   * @returns The short-code record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(shortCodeId: string): Promise<any> {
     return this._http.get(this._path(shortCodeId));
   }
 
-  /** Update a short code's configuration (webhooks, friendly name, etc.). */
+  /**
+   * Update a short code's configuration (webhooks, friendly name, etc.).
+   *
+   * @param shortCodeId - Unique identifier of the short code.
+   * @param body - Full updated short-code attributes (replace semantics).
+   * @returns The updated short-code record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(shortCodeId: string, body: any): Promise<any> {
     return this._http.put(this._path(shortCodeId), body);
   }

--- a/src/rest/namespaces/sip-profile.ts
+++ b/src/rest/namespaces/sip-profile.ts
@@ -7,7 +7,11 @@
 import type { HttpClient } from '../HttpClient.js';
 import { BaseResource } from '../base/BaseResource.js';
 
-/** Project SIP profile (singleton resource). */
+/**
+ * Project SIP profile (singleton resource).
+ *
+ * Access via `client.sipProfile.*`.
+ */
 export class SipProfileResource extends BaseResource {
   constructor(http: HttpClient) {
     super(http, '/api/relay/rest/sip_profile');

--- a/src/rest/namespaces/sip-profile.ts
+++ b/src/rest/namespaces/sip-profile.ts
@@ -17,12 +17,23 @@ export class SipProfileResource extends BaseResource {
     super(http, '/api/relay/rest/sip_profile');
   }
 
-  /** Get the SIP profile. */
+  /**
+   * Fetch the project's SIP profile.
+   *
+   * @returns The SIP profile record for this project.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async get(): Promise<any> {
     return this._http.get(this._basePath);
   }
 
-  /** Update the SIP profile. */
+  /**
+   * Update the project's SIP profile.
+   *
+   * @param body - Full SIP profile attributes (replace semantics — not patch).
+   * @returns The updated SIP profile.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(body: any): Promise<any> {
     return this._http.put(this._basePath, body);
   }

--- a/src/rest/namespaces/verified-callers.ts
+++ b/src/rest/namespaces/verified-callers.ts
@@ -7,7 +7,13 @@
 import type { HttpClient } from '../HttpClient.js';
 import { CrudResource } from '../base/CrudResource.js';
 
-/** Verified caller ID management with verification flow. */
+/**
+ * Verified caller ID management with verification flow.
+ *
+ * Access via `client.verifiedCallers.*`. Extends standard CRUD with
+ * `redialVerification()` and `submitVerification()` for the two-step
+ * phone-number verification handshake.
+ */
 export class VerifiedCallersResource extends CrudResource {
   protected override _updateMethod: 'PATCH' | 'PUT' = 'PUT';
 

--- a/src/rest/namespaces/verified-callers.ts
+++ b/src/rest/namespaces/verified-callers.ts
@@ -21,12 +21,25 @@ export class VerifiedCallersResource extends CrudResource {
     super(http, '/api/relay/rest/verified_caller_ids');
   }
 
-  /** Redial verification call. */
+  /**
+   * Redial the verification call, starting the handshake over from scratch.
+   *
+   * @param callerId - Unique identifier of the verified caller ID resource.
+   * @returns The platform-shaped verification response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async redialVerification(callerId: string): Promise<any> {
     return this._http.post(this._path(callerId, 'verification'));
   }
 
-  /** Submit verification code. */
+  /**
+   * Submit the verification code the caller received on the verification call.
+   *
+   * @param callerId - Unique identifier of the verified caller ID resource.
+   * @param body - Verification payload (typically `{ verification_code: "1234" }`).
+   * @returns The completed verification record.
+   * @throws {RestError} On any non-2xx HTTP response (including a rejected code).
+   */
   async submitVerification(callerId: string, body: any): Promise<any> {
     return this._http.put(this._path(callerId, 'verification'), body);
   }

--- a/src/rest/namespaces/video.ts
+++ b/src/rest/namespaces/video.ts
@@ -17,10 +17,12 @@ export class VideoRooms extends CrudResource {
     super(http, basePath);
   }
 
+  /** List outbound streams associated with a room. */
   async listStreams(roomId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(roomId, 'streams'), params);
   }
 
+  /** Start a new outbound stream from a room (e.g. RTMP to YouTube). */
   async createStream(roomId: string, body: any): Promise<any> {
     return this._http.post(this._path(roomId, 'streams'), body);
   }
@@ -32,6 +34,7 @@ export class VideoRoomTokens extends BaseResource {
     super(http, basePath);
   }
 
+  /** Issue a JWT token that grants a client access to a specific room. */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
@@ -43,22 +46,27 @@ export class VideoRoomSessions extends BaseResource {
     super(http, basePath);
   }
 
+  /** List past and active room sessions. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Fetch a single room session by ID. */
   async get(sessionId: string): Promise<any> {
     return this._http.get(this._path(sessionId));
   }
 
+  /** List the event log for a room session. */
   async listEvents(sessionId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(sessionId, 'events'), params);
   }
 
+  /** List members that participated in a room session. */
   async listMembers(sessionId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(sessionId, 'members'), params);
   }
 
+  /** List recordings captured during a room session. */
   async listRecordings(sessionId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(sessionId, 'recordings'), params);
   }
@@ -70,18 +78,22 @@ export class VideoRoomRecordings extends BaseResource {
     super(http, basePath);
   }
 
+  /** List all room recordings in the project. */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
+  /** Fetch a room recording by ID. */
   async get(recordingId: string): Promise<any> {
     return this._http.get(this._path(recordingId));
   }
 
+  /** Delete a room recording. */
   async delete(recordingId: string): Promise<any> {
     return this._http.delete(this._path(recordingId));
   }
 
+  /** List event log entries for a room recording. */
   async listEvents(recordingId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(recordingId, 'events'), params);
   }
@@ -95,14 +107,17 @@ export class VideoConferences extends CrudResource {
     super(http, basePath);
   }
 
+  /** List conference tokens associated with a conference. */
   async listConferenceTokens(conferenceId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(conferenceId, 'conference_tokens'), params);
   }
 
+  /** List outbound streams associated with a conference. */
   async listStreams(conferenceId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(conferenceId, 'streams'), params);
   }
 
+  /** Start an outbound stream from a conference. */
   async createStream(conferenceId: string, body: any): Promise<any> {
     return this._http.post(this._path(conferenceId, 'streams'), body);
   }
@@ -114,10 +129,12 @@ export class VideoConferenceTokens extends BaseResource {
     super(http, basePath);
   }
 
+  /** Fetch a conference token by ID. */
   async get(tokenId: string): Promise<any> {
     return this._http.get(this._path(tokenId));
   }
 
+  /** Reset / regenerate a conference token, invalidating the previous value. */
   async reset(tokenId: string): Promise<any> {
     return this._http.post(this._path(tokenId, 'reset'));
   }
@@ -129,20 +146,33 @@ export class VideoStreams extends BaseResource {
     super(http, basePath);
   }
 
+  /** Fetch a video stream by ID. */
   async get(streamId: string): Promise<any> {
     return this._http.get(this._path(streamId));
   }
 
+  /** Update a video stream's configuration (e.g. destination URL). */
   async update(streamId: string, body: any): Promise<any> {
     return this._http.put(this._path(streamId), body);
   }
 
+  /** Stop and delete a video stream. */
   async delete(streamId: string): Promise<any> {
     return this._http.delete(this._path(streamId));
   }
 }
 
-/** Video API namespace. */
+/**
+ * Video API namespace.
+ *
+ * Access via `client.video.*`.
+ *
+ * @example Create a room and issue a client token
+ * ```ts
+ * const room = await client.video.rooms.create({ name: 'standup' });
+ * const token = await client.video.roomTokens.create({ room_name: 'standup', user_name: 'Alice' });
+ * ```
+ */
 export class VideoNamespace {
   readonly rooms: VideoRooms;
   readonly roomTokens: VideoRoomTokens;

--- a/src/rest/namespaces/video.ts
+++ b/src/rest/namespaces/video.ts
@@ -17,12 +17,26 @@ export class VideoRooms extends CrudResource {
     super(http, basePath);
   }
 
-  /** List outbound streams associated with a room. */
+  /**
+   * List outbound streams associated with a room.
+   *
+   * @param roomId - Unique identifier of the video room.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of outbound streams.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listStreams(roomId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(roomId, 'streams'), params);
   }
 
-  /** Start a new outbound stream from a room (e.g. RTMP to YouTube). */
+  /**
+   * Start a new outbound stream from a room (e.g. RTMP to YouTube, Twitch).
+   *
+   * @param roomId - Unique identifier of the video room.
+   * @param body - Stream configuration (destination URL, credentials, etc.).
+   * @returns The newly-created stream record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createStream(roomId: string, body: any): Promise<any> {
     return this._http.post(this._path(roomId, 'streams'), body);
   }
@@ -34,7 +48,13 @@ export class VideoRoomTokens extends BaseResource {
     super(http, basePath);
   }
 
-  /** Issue a JWT token that grants a client access to a specific room. */
+  /**
+   * Issue a JWT token that grants a browser / mobile client access to a room.
+   *
+   * @param body - Token payload (`room_name`, `user_name`, `permissions`, etc.).
+   * @returns The token record, typically `{ token: "eyJ..." }`.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async create(body: any): Promise<any> {
     return this._http.post(this._basePath, body);
   }
@@ -46,27 +66,60 @@ export class VideoRoomSessions extends BaseResource {
     super(http, basePath);
   }
 
-  /** List past and active room sessions. */
+  /**
+   * List past and active room sessions in the project.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of room sessions.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Fetch a single room session by ID. */
+  /**
+   * Fetch a single room session by ID.
+   *
+   * @param sessionId - Unique identifier of the room session.
+   * @returns The room-session record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(sessionId: string): Promise<any> {
     return this._http.get(this._path(sessionId));
   }
 
-  /** List the event log for a room session. */
+  /**
+   * List the event log for a room session.
+   *
+   * @param sessionId - Unique identifier of the room session.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of session events.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listEvents(sessionId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(sessionId, 'events'), params);
   }
 
-  /** List members that participated in a room session. */
+  /**
+   * List members that participated in a room session.
+   *
+   * @param sessionId - Unique identifier of the room session.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of members (past and current).
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listMembers(sessionId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(sessionId, 'members'), params);
   }
 
-  /** List recordings captured during a room session. */
+  /**
+   * List recordings captured during a room session.
+   *
+   * @param sessionId - Unique identifier of the room session.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of session recordings.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listRecordings(sessionId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(sessionId, 'recordings'), params);
   }
@@ -78,22 +131,47 @@ export class VideoRoomRecordings extends BaseResource {
     super(http, basePath);
   }
 
-  /** List all room recordings in the project. */
+  /**
+   * List all room recordings in the project.
+   *
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of recordings.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async list(params?: QueryParams): Promise<any> {
     return this._http.get(this._basePath, params);
   }
 
-  /** Fetch a room recording by ID. */
+  /**
+   * Fetch a room recording by ID.
+   *
+   * @param recordingId - Unique identifier of the recording.
+   * @returns The recording record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(recordingId: string): Promise<any> {
     return this._http.get(this._path(recordingId));
   }
 
-  /** Delete a room recording. */
+  /**
+   * Delete a room recording.
+   *
+   * @param recordingId - Unique identifier of the recording.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(recordingId: string): Promise<any> {
     return this._http.delete(this._path(recordingId));
   }
 
-  /** List event log entries for a room recording. */
+  /**
+   * List event log entries for a room recording.
+   *
+   * @param recordingId - Unique identifier of the recording.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of recording events.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listEvents(recordingId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(recordingId, 'events'), params);
   }
@@ -107,17 +185,38 @@ export class VideoConferences extends CrudResource {
     super(http, basePath);
   }
 
-  /** List conference tokens associated with a conference. */
+  /**
+   * List conference tokens associated with a conference.
+   *
+   * @param conferenceId - Unique identifier of the conference.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of conference tokens.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listConferenceTokens(conferenceId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(conferenceId, 'conference_tokens'), params);
   }
 
-  /** List outbound streams associated with a conference. */
+  /**
+   * List outbound streams associated with a conference.
+   *
+   * @param conferenceId - Unique identifier of the conference.
+   * @param params - Optional filter / pagination query parameters.
+   * @returns A paginated list of streams.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async listStreams(conferenceId: string, params?: QueryParams): Promise<any> {
     return this._http.get(this._path(conferenceId, 'streams'), params);
   }
 
-  /** Start an outbound stream from a conference. */
+  /**
+   * Start an outbound stream from a conference (e.g. RTMP to YouTube).
+   *
+   * @param conferenceId - Unique identifier of the conference.
+   * @param body - Stream configuration (destination URL, credentials, etc.).
+   * @returns The newly-created stream record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async createStream(conferenceId: string, body: any): Promise<any> {
     return this._http.post(this._path(conferenceId, 'streams'), body);
   }
@@ -129,12 +228,24 @@ export class VideoConferenceTokens extends BaseResource {
     super(http, basePath);
   }
 
-  /** Fetch a conference token by ID. */
+  /**
+   * Fetch a conference token by ID.
+   *
+   * @param tokenId - Unique identifier of the conference token.
+   * @returns The conference-token record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(tokenId: string): Promise<any> {
     return this._http.get(this._path(tokenId));
   }
 
-  /** Reset / regenerate a conference token, invalidating the previous value. */
+  /**
+   * Reset / regenerate a conference token, invalidating the previous value.
+   *
+   * @param tokenId - Unique identifier of the conference token to reset.
+   * @returns The refreshed token record with a new secret.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async reset(tokenId: string): Promise<any> {
     return this._http.post(this._path(tokenId, 'reset'));
   }
@@ -146,17 +257,36 @@ export class VideoStreams extends BaseResource {
     super(http, basePath);
   }
 
-  /** Fetch a video stream by ID. */
+  /**
+   * Fetch a video stream by ID.
+   *
+   * @param streamId - Unique identifier of the stream.
+   * @returns The stream record.
+   * @throws {RestError} On any non-2xx HTTP response (including `404`).
+   */
   async get(streamId: string): Promise<any> {
     return this._http.get(this._path(streamId));
   }
 
-  /** Update a video stream's configuration (e.g. destination URL). */
+  /**
+   * Update a video stream's configuration (e.g. destination URL).
+   *
+   * @param streamId - Unique identifier of the stream.
+   * @param body - Full updated stream attributes (replace semantics).
+   * @returns The updated stream record.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async update(streamId: string, body: any): Promise<any> {
     return this._http.put(this._path(streamId), body);
   }
 
-  /** Stop and delete a video stream. */
+  /**
+   * Stop and delete a video stream.
+   *
+   * @param streamId - Unique identifier of the stream.
+   * @returns The platform's delete response.
+   * @throws {RestError} On any non-2xx HTTP response.
+   */
   async delete(streamId: string): Promise<any> {
     return this._http.delete(this._path(streamId));
   }
@@ -174,12 +304,19 @@ export class VideoStreams extends BaseResource {
  * ```
  */
 export class VideoNamespace {
+  /** Video room CRUD plus outbound stream management. */
   readonly rooms: VideoRooms;
+  /** Issue JWT tokens for browser / mobile clients to join rooms. */
   readonly roomTokens: VideoRoomTokens;
+  /** Past and active room session read access. */
   readonly roomSessions: VideoRoomSessions;
+  /** Room recording read, delete, and event-log access. */
   readonly roomRecordings: VideoRoomRecordings;
+  /** Video conference CRUD plus stream / token management. */
   readonly conferences: VideoConferences;
+  /** Individual conference token read / reset operations. */
   readonly conferenceTokens: VideoConferenceTokens;
+  /** Individual video stream read / update / delete operations. */
   readonly streams: VideoStreams;
 
   constructor(http: HttpClient) {

--- a/src/rest/pagination.ts
+++ b/src/rest/pagination.ts
@@ -12,10 +12,17 @@ import type { QueryParams } from './types.js';
 /**
  * Async generator that yields items across paginated API responses.
  *
- * @param http - HttpClient instance
- * @param path - Initial API path
- * @param params - Query parameters for the first request
- * @param dataKey - Key containing the array of items (default: "data")
+ * Handles both relay REST (`links.next`) and LAML (`next_page_uri`) pagination
+ * styles transparently.
+ *
+ * @typeParam T - Element type yielded.
+ * @param http - {@link HttpClient} instance used to fetch each page.
+ * @param path - Initial API path (absolute URL or path relative to `http.baseUrl`).
+ * @param params - Query parameters applied to the first request only.
+ *   Subsequent pages use the server-supplied next-page URL unchanged.
+ * @param dataKey - Key on each response containing the array of items.
+ *   Defaults to `"data"`.
+ * @returns An async iterable that yields one `T` per call until exhausted.
  */
 export async function* paginate<T>(
   http: HttpClient,
@@ -65,10 +72,17 @@ export async function* paginate<T>(
 /**
  * Collect all paginated items into an array.
  *
- * @param http - HttpClient instance
- * @param path - Initial API path
- * @param params - Query parameters
- * @param dataKey - Key containing the array of items (default: "data")
+ * Convenience wrapper around {@link paginate} for callers who want the full
+ * list. Beware: loads every page into memory — for very large result sets,
+ * iterate via `paginate()` directly.
+ *
+ * @typeParam T - Element type collected.
+ * @param http - {@link HttpClient} instance used to fetch each page.
+ * @param path - Initial API path.
+ * @param params - Query parameters applied to the first request.
+ * @param dataKey - Key on each response containing the array of items.
+ *   Defaults to `"data"`.
+ * @returns A flat array of every item across all pages.
  */
 export async function paginateAll<T>(
   http: HttpClient,

--- a/src/skills/SkillBase.ts
+++ b/src/skills/SkillBase.ts
@@ -84,8 +84,43 @@ export interface ParameterSchemaEntry {
 /**
  * Abstract base class for agent skills.
  *
- * Skills are modular capabilities that can be added to an agent.
- * They define tools, prompt sections, hints, and global data.
+ * Skills are modular, reusable capabilities that plug into an {@link AgentBase}.
+ * A single skill can contribute:
+ *
+ * - **Tools** (SWAIG functions) via `getTools()` or `defineTool()`
+ * - **Prompt sections** via `_getPromptSections()`
+ * - **Speech hints** via `getHints()`
+ * - **Global data** seeded into each call via `getGlobalData()`
+ *
+ * Skills are added to an agent with `agent.addSkill('name', config)` and the
+ * {@link SkillManager} calls `setAgent()` + `setup()` in sequence before the
+ * agent starts serving requests.
+ *
+ * @example Custom skill
+ * ```ts
+ * import { SkillBase, FunctionResult, type SkillToolDefinition } from '@signalwire/sdk';
+ *
+ * export class GreetingSkill extends SkillBase {
+ *   static override SKILL_NAME = 'greeting';
+ *   static override SKILL_DESCRIPTION = 'Responds with a configurable greeting.';
+ *
+ *   override getTools(): SkillToolDefinition[] {
+ *     return [{
+ *       name: 'say_hello',
+ *       description: 'Say a friendly hello.',
+ *       parameters: { type: 'object', properties: {} },
+ *       handler: () => new FunctionResult(this.getConfig('message', 'Hi!')),
+ *     }];
+ *   }
+ * }
+ *
+ * // In your agent:
+ * agent.addSkill(new GreetingSkill({ message: 'Howdy!' }));
+ * ```
+ *
+ * @see {@link SkillManager}
+ * @see {@link SkillRegistry}
+ * @see {@link AgentBase.addSkill}
  */
 export abstract class SkillBase {
   /**

--- a/src/skills/SkillManager.ts
+++ b/src/skills/SkillManager.ts
@@ -60,12 +60,16 @@ export class SkillManager {
    * Add a skill to the manager, validating env vars and calling setup().
    * Uses the skill's instance key for deduplication.
    *
-   * Throws on duplicate (when multi-instance is disallowed), missing env vars,
-   * or setup errors. {@link loadSkill} / {@link loadSkillByName} wrap this and
-   * catch to return `[false, msg]`, matching Python `load_skill`'s return
-   * contract (`skill_manager.py` lines 114-118).
+   * {@link loadSkill} / {@link loadSkillByName} wrap this and catch to return
+   * `[false, msg]`, matching Python `load_skill`'s return contract
+   * (`skill_manager.py` lines 114-118).
    *
    * @param skill - The skill instance to add.
+   * @returns Resolves once the skill is registered.
+   * @throws {Error} When a single-instance skill is already loaded, its
+   *   required environment variables are missing, its parameter schema is
+   *   empty, its required packages cannot be imported, or `setup()` returns
+   *   `false`.
    */
   async addSkill(skill: SkillBase): Promise<void> {
     const name = skill.skillName;

--- a/src/skills/builtin/api_ninjas_trivia.ts
+++ b/src/skills/builtin/api_ninjas_trivia.ts
@@ -50,6 +50,11 @@ const VALID_CATEGORIES = [
  *
  * Tier 2 built-in skill. Requires the `API_NINJAS_KEY` environment variable.
  * Supports optional `default_category` and `reveal_answer` config options.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('api_ninjas_trivia', { default_category: 'sciencenature' });
+ * ```
  */
 export class ApiNinjasTriviaSkill extends SkillBase {
   static override SKILL_NAME = 'api_ninjas_trivia';

--- a/src/skills/builtin/ask_claude.ts
+++ b/src/skills/builtin/ask_claude.ts
@@ -72,6 +72,11 @@ interface AnthropicErrorResponse {
  * Tier 3 built-in skill. Requires the `ANTHROPIC_API_KEY` environment variable.
  * Supports `model` and `max_tokens` config options to control which Claude model
  * is used and the maximum response length.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('ask_claude', { model: 'claude-sonnet-4-6', max_tokens: 512 });
+ * ```
  */
 export class AskClaudeSkill extends SkillBase {
   // TS-only skill (no Python equivalent).

--- a/src/skills/builtin/claude_skills.ts
+++ b/src/skills/builtin/claude_skills.ts
@@ -72,6 +72,11 @@ interface ParsedSkill {
  * This skill parses Claude Code skill directories and makes them available
  * as SWAIG tools that the AI can call. Each Claude skill becomes a tool
  * that returns the skill's instructions when invoked.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('claude_skills', { skills_dir: './claude-skills' });
+ * ```
  */
 export class ClaudeSkillsSkill extends SkillBase {
   // Python ground truth: skills/claude_skills/skill.py

--- a/src/skills/builtin/custom_skills.ts
+++ b/src/skills/builtin/custom_skills.ts
@@ -75,6 +75,21 @@ interface CustomSkillsConfigData {
  * **Security warning:** This skill uses `new Function()` to compile user-provided
  * code at runtime. It is gated behind the `SWML_ALLOW_CUSTOM_HANDLER_CODE=true`
  * environment variable to prevent unintended code execution.
+ *
+ * @example
+ * ```ts
+ * // Requires SWML_ALLOW_CUSTOM_HANDLER_CODE=true
+ * agent.addSkill('custom_skills', {
+ *   tools: [
+ *     {
+ *       name: 'echo',
+ *       description: 'Echo back the caller-supplied message.',
+ *       parameters: { type: 'object', properties: { msg: { type: 'string' } } },
+ *       handlerBody: 'return new FunctionResult(args.msg);',
+ *     },
+ *   ],
+ * });
+ * ```
  */
 export class CustomSkillsSkill extends SkillBase {
   // TS-only skill (no Python equivalent).

--- a/src/skills/builtin/datasphere.ts
+++ b/src/skills/builtin/datasphere.ts
@@ -58,6 +58,15 @@ interface DataSphereResponse {
  * `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, and `SIGNALWIRE_SPACE` environment
  * variables. Supports `count`, `distance`, `tags`, `language`, `pos_to_expand`,
  * `max_synonyms`, and `no_results_message` config options.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('datasphere', {
+ *   document_id: 'doc_abc123',
+ *   count: 3,
+ *   tags: ['faq'],
+ * });
+ * ```
  */
 export class DataSphereSkill extends SkillBase {
   // Python ground truth: skills/datasphere/skill.py:20-27.

--- a/src/skills/builtin/datasphere_serverless.ts
+++ b/src/skills/builtin/datasphere_serverless.ts
@@ -33,6 +33,14 @@ const DEFAULT_NO_RESULTS_MESSAGE =
  * executes directly, without a webhook endpoint. Supports `document_id`,
  * `count`, `distance`, `tags`, `language`, `pos_to_expand`, `max_synonyms`,
  * and `no_results_message` config options.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('datasphere_serverless', {
+ *   document_id: 'doc_abc123',
+ *   count: 3,
+ * });
+ * ```
  */
 export class DataSphereServerlessSkill extends SkillBase {
   // Python ground truth: skills/datasphere_serverless/skill.py:20-28

--- a/src/skills/builtin/datetime.ts
+++ b/src/skills/builtin/datetime.ts
@@ -18,6 +18,13 @@ import { FunctionResult } from '../../FunctionResult.js';
  *
  * Tier 1 built-in skill with no external dependencies. Supports all IANA
  * timezone identifiers via the Intl.DateTimeFormat API.
+ *
+ * Registers two SWAIG tools: `get_current_time` and `get_current_date`.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('datetime');
+ * ```
  */
 export class DateTimeSkill extends SkillBase {
   // Python ground truth: skills/datetime/skill.py

--- a/src/skills/builtin/google_maps.ts
+++ b/src/skills/builtin/google_maps.ts
@@ -98,6 +98,11 @@ interface RoutesV2Response {
  *
  * Tier 3 built-in skill. Requires the `GOOGLE_MAPS_API_KEY` environment variable.
  * Supports a `default_mode` config option ("driving"|"walking"|"bicycling"|"transit").
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('google_maps', { default_mode: 'driving' });
+ * ```
  */
 export class GoogleMapsSkill extends SkillBase {
   // Python ground truth: skills/google_maps/skill.py

--- a/src/skills/builtin/info_gatherer.ts
+++ b/src/skills/builtin/info_gatherer.ts
@@ -46,6 +46,16 @@ interface QuestionDefinition {
  * `questions` config, the same `prefix` / `completion_message` options,
  * the same two tools (`start_questions`, `submit_answer`), and the same
  * state shape in `global_data`.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('info_gatherer', {
+ *   questions: [
+ *     { key_name: 'name', question_text: 'What is your name?' },
+ *     { key_name: 'email', question_text: 'Your email?', confirm: true },
+ *   ],
+ * });
+ * ```
  */
 export class InfoGathererSkill extends SkillBase {
   // Python ground truth: skills/info_gatherer/skill.py:26-31

--- a/src/skills/builtin/joke.ts
+++ b/src/skills/builtin/joke.ts
@@ -87,6 +87,11 @@ const VALID_CATEGORIES = ['general', 'programming', 'dad'];
  *
  * Tier 1 built-in skill with no external dependencies. Includes general,
  * programming, and dad joke categories.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('joke');
+ * ```
  */
 export class JokeSkill extends SkillBase {
   // Python ground truth: skills/joke/skill.py

--- a/src/skills/builtin/math.ts
+++ b/src/skills/builtin/math.ts
@@ -64,6 +64,13 @@ function safeEvaluate(expr: string): number {
  *
  * Tier 1 built-in skill with no external dependencies. Only allows digits,
  * basic arithmetic operators, parentheses, decimal points, and spaces.
+ *
+ * Registers a single SWAIG tool: `calculate`.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('math');
+ * ```
  */
 export class MathSkill extends SkillBase {
   // Python ground truth: skills/math/skill.py

--- a/src/skills/builtin/mcp_gateway.ts
+++ b/src/skills/builtin/mcp_gateway.ts
@@ -49,6 +49,14 @@ interface McpToolDefinition {
  * services, enumerates each service's tools, and registers them as SWAIG
  * tools prefixed with `tool_prefix` (default `mcp_`). A hidden hangup hook
  * tool cleans up MCP sessions when the call ends.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('mcp_gateway', {
+ *   gateway_url: 'https://mcp-gateway.example.com',
+ *   tool_prefix: 'mcp_',
+ * });
+ * ```
  */
 export class McpGatewaySkill extends SkillBase {
   // Python ground truth: skills/mcp_gateway/skill.py:~70-76

--- a/src/skills/builtin/native_vector_search.ts
+++ b/src/skills/builtin/native_vector_search.ts
@@ -146,6 +146,15 @@ function scoreTfIdf(
  * Document search using TF-IDF in-memory scoring or a remote search server.
  *
  * Multi-instance capable (distinguished by `tool_name` + `index_file`).
+ *
+ * @example Local JSON index
+ * ```ts
+ * agent.addSkill('native_vector_search', {
+ *   tool_name: 'search_docs',
+ *   index_file: './data/support-docs.json',
+ *   count: 3,
+ * });
+ * ```
  */
 export class NativeVectorSearchSkill extends SkillBase {
   // Python ground truth: skills/native_vector_search/skill.py:~75-82

--- a/src/skills/builtin/play_background_file.ts
+++ b/src/skills/builtin/play_background_file.ts
@@ -39,6 +39,15 @@ interface PreConfiguredFile {
  *    values that trigger the corresponding file playback.
  *  - Free-form `default_file_url` / `allowed_domains`: emits two tools,
  *    `play_background` (arbitrary URL) and `stop_background`.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('play_background_file', {
+ *   files: [
+ *     { key: 'hold', url: 'https://cdn.example.com/hold-music.mp3', description: 'Hold music' },
+ *   ],
+ * });
+ * ```
  */
 export class PlayBackgroundFileSkill extends SkillBase {
   // Python ground truth: skills/play_background_file/skill.py

--- a/src/skills/builtin/spider.ts
+++ b/src/skills/builtin/spider.ts
@@ -56,6 +56,11 @@ const STRIP_TAG_REGEXES: RegExp[] = [
  * mirrors the Python schema (delay, concurrent_requests, timeout, max_pages,
  * max_depth, extract_type, max_text_length, clean_text, selectors,
  * follow_patterns, user_agent, headers, follow_robots_txt, cache_enabled).
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('spider', { max_pages: 5, max_depth: 2 });
+ * ```
  */
 export class SpiderSkill extends SkillBase {
   // Python ground truth: skills/spider/skill.py:~140-145

--- a/src/skills/builtin/swml_transfer.ts
+++ b/src/skills/builtin/swml_transfer.ts
@@ -59,6 +59,16 @@ interface TransferConfig {
  * Multi-instance capable (distinguished by `tool_name`).
  * Accepts either Python-style `transfers` config (regex → per-entry config)
  * or TypeScript-style `patterns` array of named destinations.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('swml_transfer', {
+ *   patterns: [
+ *     { name: 'sales', pattern: /sales|pricing|buy/i, to: '+15551112222' },
+ *     { name: 'support', pattern: /help|support|broken/i, to: '+15553334444' },
+ *   ],
+ * });
+ * ```
  */
 export class SwmlTransferSkill extends SkillBase {
   // Python ground truth: skills/swml_transfer/skill.py:~60-67

--- a/src/skills/builtin/weather_api.ts
+++ b/src/skills/builtin/weather_api.ts
@@ -57,6 +57,13 @@ interface WeatherApiResponse {
  * **Unit aliases:** For migration compatibility with the Python SDK the `units`
  * config also accepts `"fahrenheit"` (normalized to `"imperial"`) and
  * `"celsius"` (normalized to `"metric"`).
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('weather_api', { units: 'imperial' });
+ * // or pass the key explicitly:
+ * agent.addSkill('weather_api', { api_key: process.env.WEATHER_API_KEY });
+ * ```
  */
 export class WeatherApiSkill extends SkillBase {
   // Python ground truth: skills/weather_api/skill.py

--- a/src/skills/builtin/web_search.ts
+++ b/src/skills/builtin/web_search.ts
@@ -191,6 +191,15 @@ interface GoogleSearchResponse {
  * Supported config: `tool_name`, `num_results`, `no_results_message`,
  * `safe_search`, `delay`, `max_content_length`, `oversample_factor`,
  * `min_quality_score`.
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('web_search', {
+ *   api_key: process.env.GOOGLE_SEARCH_API_KEY,
+ *   search_engine_id: process.env.GOOGLE_CSE_ID,
+ *   num_results: 3,
+ * });
+ * ```
  */
 export class WebSearchSkill extends SkillBase {
   // Python ground truth: skills/web_search/skill.py:559-567

--- a/src/skills/builtin/wikipedia_search.ts
+++ b/src/skills/builtin/wikipedia_search.ts
@@ -46,6 +46,11 @@ interface WikipediaActionExtractsResponse {
  * Tier 3 built-in skill with no external API key required. The configured
  * `num_results` drives how many articles are aggregated; `no_results_message`
  * customizes the fallback text (supports `{query}` interpolation).
+ *
+ * @example
+ * ```ts
+ * agent.addSkill('wikipedia_search', { num_results: 2 });
+ * ```
  */
 export class WikipediaSearchSkill extends SkillBase {
   // Python ground truth: skills/wikipedia_search/skill.py:26-31


### PR DESCRIPTION
## Summary
- Adds `@example` blocks, cross-references, and fills remaining JSDoc gaps on every public class, type, and method exported from `@signalwire/sdk`.
- Pure documentation — no runtime behavior changes.
- Goal: a developer hitting IntelliSense / hover in VS Code (or reading generated TypeDoc) gets an immediate, minimal, copy-pasteable example for every primary entry point.

## What got touched (68 files, +1,260 / -51)

**Package overview**
- `src/index.ts` — quick-start snippets for agent, prefab, and REST client + `@see` links to key classes

**Core agent API (class-level `@example` + filled gaps)**
- `AgentBase` — subclass + imperative examples; enriched JSDoc on `onSummary`, `setDynamicConfigCallback`, `serve`
- `FunctionResult`, `DataMap`, `ContextBuilder`, `SwmlBuilder`, `PomBuilder`
- `SWMLService`, `AgentServer`, `WebService`, `ServerlessAdapter`

**Skills framework**
- `SkillBase` — custom-skill example
- All 18 built-in skills (`datetime`, `math`, `joke`, `weather_api`, `web_search`, `google_maps`, `wikipedia_search`, `swml_transfer`, `play_background_file`, `api_ninjas_trivia`, `info_gatherer`, `custom_skills`, `datasphere`, `datasphere_serverless`, `native_vector_search`, `spider`, `claude_skills`, `ask_claude`, `mcp_gateway`) — each now has a minimal `agent.addSkill(...)` example

**Prefab agents**
- `InfoGathererAgent`, `SurveyAgent`, `FAQBotAgent`, `ConciergeAgent`, `ReceptionistAgent` — each gets a realistic usage example in its class JSDoc

**REST client**
- `HttpClient`, `BaseResource`, `CrudResource`, `CrudWithAddresses` — class-level JSDoc
- Every namespace got a class-level `@example` or usage note and missing per-method JSDoc: `fabric`, `calling` (37 commands), `phone-numbers`, `addresses`, `queues`, `recordings`, `number-groups`, `verified-callers`, `sip-profile`, `lookup`, `short-codes`, `imported-numbers`, `mfa`, `registry`, `datasphere`, `video`, `logs`, `project`, `pubsub`, `chat`, `compat`

**RELAY client**
- `RelayClient`, `Call`, `Message`, `Action` — class-level examples and property JSDoc on every public field
- `Deferred`, `RelayError` — filled in

**LiveKit-compat shim**
- `livewire/index.ts` — `Agent`, `AgentSession`, `RunContext` got richer JSDoc

## Test plan
- [x] `npm run build` — tsc clean
- [x] `npm test` — 1687 / 1687 passing (vitest)
- [ ] Spot-check IntelliSense in VS Code on `AgentBase`, `FunctionResult`, `DataMap`, one prefab, one REST namespace, one skill
- [ ] Optional: regenerate TypeDoc and review rendered output

## Notes
- The diagnostics in my editor flagged some pre-existing unused-private warnings (`_configFile`, `_sipRoute`, etc.) — those are unchanged by this PR.
- No public API surface was added or renamed; imports and exports are untouched.