### PR TITLE
Add PhoneCallHandler enum and typed phone-binding helpers

### DIFF
--- a/rest/docs/fabric.md
+++ b/rest/docs/fabric.md
@@ -52,12 +52,12 @@ These resources use `PUT` for updates (full replacement):
 
 These resources use `PATCH` for updates (partial update):
 
-| Attribute | API Path |
-|-----------|----------|
-| `fabric.swml_webhooks` | `/api/fabric/resources/swml_webhooks` |
-| `fabric.ai_agents` | `/api/fabric/resources/ai_agents` |
-| `fabric.sip_gateways` | `/api/fabric/resources/sip_gateways` |
-| `fabric.cxml_webhooks` | `/api/fabric/resources/cxml_webhooks` |
+| Attribute | API Path | Notes |
+|-----------|----------|-------|
+| `fabric.swmlWebhooks` | `/api/fabric/resources/swml_webhooks` | **Auto-materialized.** Created as a side-effect of `phoneNumbers.setSwmlWebhook(sid, url)`. Do not create directly — see [phone-binding.md](phone-binding.md). |
+| `fabric.aiAgents` | `/api/fabric/resources/ai_agents` | Can be created directly, or bind an existing one with `phoneNumbers.setAiAgent(sid, agentId)`. |
+| `fabric.sipGateways` | `/api/fabric/resources/sip_gateways` | |
+| `fabric.cxmlWebhooks` | `/api/fabric/resources/cxml_webhooks` | **Auto-materialized** by `phoneNumbers.setCxmlWebhook(sid, { url })`. Note: this is the **cXML (Twilio-compat)** handler — despite the `laml_webhooks` wire name. |
 
 ## Call Flows -- Extra Methods
 
@@ -131,11 +131,23 @@ client.fabric.resources.delete("resource-uuid")
 # List addresses for any resource
 addresses = client.fabric.resources.list_addresses("resource-uuid")
 
-# Assign a resource to a phone route
-client.fabric.resources.assign_phone_route("resource-uuid", phone_route_id="route-uuid")
-
 # Assign a resource as a domain application handler
 client.fabric.resources.assign_domain_application("resource-uuid", domain_application_id="da-uuid")
+```
+
+### `assignPhoneRoute` — narrow-use, not for the common case
+
+This SDK exposes `client.fabric.resources.assignPhoneRoute(resourceId, ...)` which posts to `/api/fabric/resources/{id}/phone_routes`. **This does not bind a phone number to an SWML/cXML webhook or AI agent.** Those bindings are configured on the phone number (see [phone-binding.md](phone-binding.md)) and the Fabric resource is materialized automatically.
+
+`assignPhoneRoute` applies only to a few legacy resource types that accept phone-route attachment as an explicit step; which types accept it is defined by the server and visible in `rest-apis/relay-rest/openapi.yaml`. Calling it against `swml_webhook` / `cxml_webhook` / `ai_agent` returns 404 or 422. The method still posts (for backwards compatibility) but emits a one-time deprecation warning on first call.
+
+## Binding a phone number to a handler
+
+See **[phone-binding.md](phone-binding.md)** for the `PhoneCallHandler` enum, the mapping from each handler value to its auto-materialized Fabric resource, and the typed `phoneNumbers.set*` helpers. The one-liner summary:
+
+```ts
+// SWML webhook (your backend returns SWML per call)
+await client.phoneNumbers.setSwmlWebhook(pnId, 'https://example.com/swml');
 ```
 
 ## Fabric Addresses

--- a/rest/docs/phone-binding.md
+++ b/rest/docs/phone-binding.md
@@ -1,0 +1,125 @@
+# Binding a phone number to a call handler
+
+Routing an inbound phone number to something — an SWML webhook, a cXML app, an AI Agent, a call flow — is configured on the **phone number**, not on the Fabric resource. Fabric resources are *derived representations* of bindings configured on adjacent entities. Read this page before writing code that creates webhook/agent/flow resources manually; for the common cases, you don't need to.
+
+## The mental model
+
+A phone number has a `call_handler` field that chooses what to do with inbound calls. Setting `call_handler` (together with its handler-specific required field) triggers the server to materialize the appropriate Fabric resource automatically.
+
+```
+┌────────────────────────┐      sets       ┌──────────────────────────┐
+│ PUT /phone_numbers/X   │────────────────▶│ call_handler +           │
+│ (you call this)        │                 │ handler-specific URL/ID  │
+└────────────────────────┘                 └──────────────────────────┘
+                                                        │
+                                                        ▼
+                                       ┌──────────────────────────────┐
+                                       │ Fabric resource materializes │
+                                       │ automatically, keyed off the │
+                                       │ URL or ID you supplied       │
+                                       └──────────────────────────────┘
+```
+
+You rarely create a Fabric webhook resource directly. Doing so without binding a phone number to it leaves an orphan; `fabric.swmlWebhooks.create` and `fabric.cxmlWebhooks.create` in this SDK emit a deprecation warning pointing at the helpers below.
+
+## The `PhoneCallHandler` enum
+
+The authoritative list of handler values. Import from the top-level SDK entrypoint:
+
+```ts
+import { PhoneCallHandler } from '@signalwire/sdk';
+```
+
+| `PhoneCallHandler` | `call_handler` wire value | Required companion field | Auto-materializes Fabric resource |
+|---|---|---|---|
+| `RELAY_SCRIPT` | `relay_script` | `call_relay_script_url` | `swml_webhook` |
+| `LAML_WEBHOOKS` | `laml_webhooks` | `call_request_url` | `cxml_webhook` |
+| `LAML_APPLICATION` | `laml_application` | `call_laml_application_id` | `cxml_application` |
+| `AI_AGENT` | `ai_agent` | `call_ai_agent_id` | `ai_agent` |
+| `CALL_FLOW` | `call_flow` | `call_flow_id` | `call_flow` |
+| `RELAY_APPLICATION` | `relay_application` | `call_relay_application` | `relay_application` |
+| `RELAY_TOPIC` | `relay_topic` | `call_relay_topic` | *(no Fabric resource — routes via RELAY client)* |
+| `RELAY_CONTEXT` | `relay_context` | `call_relay_context` | *(no Fabric resource — legacy; prefer `RELAY_TOPIC`)* |
+| `RELAY_CONNECTOR` | `relay_connector` | *(connector config)* | *(internal)* |
+| `VIDEO_ROOM` | `video_room` | `call_video_room_id` | *(no Fabric resource — routes to Video API)* |
+| `DIALOGFLOW` | `dialogflow` | `call_dialogflow_agent_id` | *(no Fabric resource)* |
+
+**Naming note on `LAML_WEBHOOKS`:** the wire value is plural and contains "webhooks", but it produces a **cXML** (Twilio-compat) handler — not a generic webhook, not an SWML webhook. For SWML, use `RELAY_SCRIPT`. The dashboard labels these resources "cXML Webhook" after assignment.
+
+**Naming note on `PhoneCallHandler`:** the enum is deliberately **not** named `CallHandler` — that symbol is already used by the RELAY client (`src/relay/types.ts`) as an inbound-call callback type.
+
+**`calling_handler_resource_id`** (where present in responses) is **server-derived** and read-only. Don't try to set it on update; the server computes it from the handler you chose.
+
+## Typed helpers on `phoneNumbers`
+
+Every helper is a one-line wrapper over `phoneNumbers.update` with the right `call_handler` value and companion field already set.
+
+```ts
+// SWML webhook (the common case — your backend returns SWML per call)
+await client.phoneNumbers.setSwmlWebhook(pnId, 'https://example.com/swml');
+
+// cXML / LAML webhook (Twilio-compat)
+await client.phoneNumbers.setCxmlWebhook(pnId, {
+  url: 'https://example.com/voice.xml',
+  fallbackUrl: 'https://example.com/fallback.xml',      // optional
+  statusCallbackUrl: 'https://example.com/status',      // optional
+});
+
+// Existing cXML application by ID
+await client.phoneNumbers.setCxmlApplication(pnId, 'app-uuid');
+
+// AI Agent by ID (agent created via fabric.aiAgents or AgentBase)
+await client.phoneNumbers.setAiAgent(pnId, 'agent-uuid');
+
+// Call flow (optionally pin a version — default is current_deployed)
+await client.phoneNumbers.setCallFlow(pnId, {
+  flowId: 'flow-uuid',
+  version: 'current_deployed',
+});
+
+// Relay application (named routing)
+await client.phoneNumbers.setRelayApplication(pnId, 'my-relay-app');
+
+// Relay topic (RELAY client subscription)
+await client.phoneNumbers.setRelayTopic(pnId, { topic: 'office' });
+```
+
+All helpers return the updated phone number representation. All are thin wrappers over the single underlying `phoneNumbers.update(sid, { call_handler, ... })` call; use the update form directly when you need an unusual combination.
+
+The wire-level form is always available:
+
+```ts
+await client.phoneNumbers.update(pnId, {
+  call_handler: PhoneCallHandler.RELAY_SCRIPT, // or the raw string 'relay_script'
+  call_relay_script_url: 'https://example.com/swml',
+});
+```
+
+## What NOT to do
+
+### Don't pre-create the webhook resource
+
+```ts
+// WRONG — orphan resource, does nothing. Emits a deprecation warning.
+const webhook = await client.fabric.swmlWebhooks.create({
+  name: 'my-webhook',
+  primary_request_url: 'https://example.com/swml',
+});
+await client.fabric.resources.assignPhoneRoute(webhook.id, { phone_number_id: pnId });
+// ↑ returns 404 / 422 depending on body shape
+```
+
+The `swmlWebhooks.create` and `cxmlWebhooks.create` endpoints exist historically but are not how you bind a number. The Fabric resource is materialized as a side-effect of `phoneNumbers.update`; there's nothing to attach.
+
+### `assignPhoneRoute` is narrow and deprecated for the common case
+
+`client.fabric.resources.assignPhoneRoute(...)` posts to `/api/fabric/resources/{id}/phone_routes`. It applies only to a few legacy resource types that accept phone-route attachment as a separate step (the authoritative list lives in the OpenAPI spec at `rest-apis/relay-rest/openapi.yaml`). It **does not work** for `swml_webhook`, `cxml_webhook`, or `ai_agent` — those use the derivation model above. This SDK keeps the method for backwards compatibility but emits a one-time deprecation warning on first call.
+
+## Summary
+
+- Bindings live on `phoneNumbers`, not on Fabric resources.
+- Set `call_handler` + the one handler-specific field; the server materializes the resource for you.
+- Use the typed `phoneNumbers.set*` helpers — they document the enum values inline.
+- `swml_webhook` and `cxml_webhook` Fabric resources are auto-materialized. Don't manually create them.
+- `laml_webhooks` produces a **cXML** handler despite the name. Use `RELAY_SCRIPT` for SWML.
+- `assignPhoneRoute` is narrow and not needed for the common handlers.

--- a/rest/examples/rest-bind-phone-to-swml-webhook.ts
+++ b/rest/examples/rest-bind-phone-to-swml-webhook.ts
@@ -1,0 +1,66 @@
+/**
+ * REST Example: Bind an inbound phone number to an SWML webhook (the happy path).
+ *
+ * This is the simplest way to route a SignalWire phone number to a backend
+ * that returns an SWML document per inbound call. You set `call_handler`
+ * on the phone number; the server auto-materializes a `swml_webhook`
+ * Fabric resource pointing at your URL. You do **not** need to create the
+ * Fabric webhook resource manually; you do **not** call `assignPhoneRoute`.
+ *
+ * Prerequisites:
+ *   export SIGNALWIRE_PROJECT_ID=your-project-id
+ *   export SIGNALWIRE_API_TOKEN=your-api-token
+ *   export SIGNALWIRE_SPACE=your-space.signalwire.com
+ *   export PHONE_NUMBER_SID=pn-...             # SID of a phone number you own
+ *   export SWML_WEBHOOK_URL=https://...        # your backend's SWML endpoint
+ *
+ * Run:
+ *   npx tsx rest/examples/rest-bind-phone-to-swml-webhook.ts
+ */
+
+import { RestClient, PhoneCallHandler } from '../../src/index.js';
+
+async function main(): Promise<void> {
+  const pnSid = process.env['PHONE_NUMBER_SID'];
+  const webhookUrl = process.env['SWML_WEBHOOK_URL'];
+  if (!pnSid || !webhookUrl) {
+    throw new Error('Set PHONE_NUMBER_SID and SWML_WEBHOOK_URL.');
+  }
+
+  const client = new RestClient();
+
+  // The typed helper — one line:
+  console.log(`Binding ${pnSid} to ${webhookUrl} ...`);
+  await client.phoneNumbers.setSwmlWebhook(pnSid, webhookUrl);
+
+  // The equivalent wire-level form (use this if you need unusual fields):
+  //
+  // await client.phoneNumbers.update(pnSid, {
+  //   call_handler: PhoneCallHandler.RELAY_SCRIPT,
+  //   call_relay_script_url: webhookUrl,
+  // });
+
+  // Verify: the server auto-created a swml_webhook Fabric resource.
+  const pn = await client.phoneNumbers.get(pnSid);
+  console.log(`  call_handler = ${JSON.stringify(pn.call_handler)}`);
+  console.log(`  call_relay_script_url = ${JSON.stringify(pn.call_relay_script_url)}`);
+  console.log(
+    `  calling_handler_resource_id (server-derived) = ${JSON.stringify(pn.calling_handler_resource_id)}`,
+  );
+
+  // To route to something other than an SWML webhook, use:
+  //   client.phoneNumbers.setCxmlWebhook(sid, { url })          // LAML / Twilio-compat
+  //   client.phoneNumbers.setAiAgent(sid, agentId)              // AI Agent
+  //   client.phoneNumbers.setCallFlow(sid, { flowId })          // Call Flow
+  //   client.phoneNumbers.setRelayApplication(sid, name)        // Named RELAY app
+  //   client.phoneNumbers.setRelayTopic(sid, { topic })         // RELAY topic
+
+  // Keep PhoneCallHandler referenced so eslint/tsc don't strip it from the
+  // illustrative "wire-level form" comment above.
+  void PhoneCallHandler;
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/rest/examples/rest-fabric-conferences-and-routing.ts
+++ b/rest/examples/rest-fabric-conferences-and-routing.ts
@@ -75,18 +75,7 @@ async function main() {
     console.log(`  Resource detail: ${detail.display_name ?? 'N/A'} (${detail.type ?? 'N/A'})`);
   }
 
-  // 8. Assign a phone route to a resource (demo)
-  console.log('\nAssigning phone route (demo)...');
-  try {
-    await client.fabric.resources.assignPhoneRoute(relayId, { phone_number: '+15551234567' });
-    console.log('  Phone route assigned');
-  } catch (err) {
-    if (err instanceof RestError) {
-      console.log(`  Route assignment failed (expected in demo): ${err.statusCode}`);
-    } else throw err;
-  }
-
-  // 9. Assign a domain application (demo)
+  // 8. Assign a domain application (demo)
   console.log('\nAssigning domain application (demo)...');
   try {
     await client.fabric.resources.assignDomainApplication(relayId, { domain: 'app.example.com' });
@@ -97,7 +86,7 @@ async function main() {
     } else throw err;
   }
 
-  // 10. Generate tokens
+  // 9. Generate tokens
   console.log('\nGenerating tokens...');
   try {
     const guest = await client.fabric.tokens.createGuestToken({ resource_id: relayId });
@@ -126,7 +115,12 @@ async function main() {
     } else throw err;
   }
 
-  // 11. Clean up
+  // NOTE: To bind a phone number to a webhook / agent / flow, set
+  // call_handler on the phone number directly — see
+  // rest-bind-phone-to-swml-webhook.ts. `assignPhoneRoute` does NOT work
+  // for swml_webhook / cxml_webhook / ai_agent bindings.
+
+  // Clean up
   console.log('\nCleaning up...');
   await client.fabric.relayApplications.delete(relayId);
   console.log(`  Deleted relay application ${relayId}`);

--- a/src/rest/callHandler.ts
+++ b/src/rest/callHandler.ts
@@ -1,0 +1,61 @@
+/**
+ * PhoneCallHandler — enum of `call_handler` values accepted by
+ * {@link PhoneNumbersResource.update}.
+ *
+ * Named `PhoneCallHandler` (not `CallHandler`) to avoid colliding with the
+ * RELAY client's inbound-call-handler callback type already exported from
+ * `src/relay/types.ts`.
+ *
+ * Setting a phone number's `call_handler` + the handler-specific companion
+ * field routes inbound calls and auto-materializes the matching Fabric
+ * resource on the server. See the high-level helpers on
+ * {@link PhoneNumbersResource} (`setSwmlWebhook`, `setCxmlWebhook`,
+ * `setCxmlApplication`, `setAiAgent`, `setCallFlow`, `setRelayApplication`,
+ * `setRelayTopic`).
+ *
+ * | Member | Wire value | Companion field | Auto-creates Fabric resource |
+ * |---|---|---|---|
+ * | `RELAY_SCRIPT` | `relay_script` | `call_relay_script_url` | `swml_webhook` |
+ * | `LAML_WEBHOOKS` | `laml_webhooks` | `call_request_url` | `cxml_webhook` |
+ * | `LAML_APPLICATION` | `laml_application` | `call_laml_application_id` | `cxml_application` |
+ * | `AI_AGENT` | `ai_agent` | `call_ai_agent_id` | `ai_agent` |
+ * | `CALL_FLOW` | `call_flow` | `call_flow_id` | `call_flow` |
+ * | `RELAY_APPLICATION` | `relay_application` | `call_relay_application` | `relay_application` |
+ * | `RELAY_TOPIC` | `relay_topic` | `call_relay_topic` | *(routes via RELAY)* |
+ * | `RELAY_CONTEXT` | `relay_context` | `call_relay_context` | *(legacy, prefer topic)* |
+ * | `RELAY_CONNECTOR` | `relay_connector` | *(connector config)* | *(internal)* |
+ * | `VIDEO_ROOM` | `video_room` | `call_video_room_id` | *(routes to Video API)* |
+ * | `DIALOGFLOW` | `dialogflow` | `call_dialogflow_agent_id` | *(none)* |
+ *
+ * Note: `LAML_WEBHOOKS` (wire value `laml_webhooks`) produces a **cXML**
+ * handler, not a generic webhook. For SWML, use `RELAY_SCRIPT`.
+ *
+ * @example
+ * ```ts
+ * import { PhoneCallHandler } from '@signalwire/sdk';
+ *
+ * await client.phoneNumbers.update(pnSid, {
+ *   call_handler: PhoneCallHandler.RELAY_SCRIPT,
+ *   call_relay_script_url: 'https://example.com/swml',
+ * });
+ *
+ * // Or use the typed helper:
+ * await client.phoneNumbers.setSwmlWebhook(pnSid, 'https://example.com/swml');
+ * ```
+ */
+export const PhoneCallHandler = {
+  RELAY_SCRIPT: 'relay_script',
+  LAML_WEBHOOKS: 'laml_webhooks',
+  LAML_APPLICATION: 'laml_application',
+  AI_AGENT: 'ai_agent',
+  CALL_FLOW: 'call_flow',
+  RELAY_APPLICATION: 'relay_application',
+  RELAY_TOPIC: 'relay_topic',
+  RELAY_CONTEXT: 'relay_context',
+  RELAY_CONNECTOR: 'relay_connector',
+  VIDEO_ROOM: 'video_room',
+  DIALOGFLOW: 'dialogflow',
+} as const;
+
+/** Union of every valid `call_handler` wire value. */
+export type PhoneCallHandler = typeof PhoneCallHandler[keyof typeof PhoneCallHandler];

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -206,11 +206,15 @@ export { BaseResource } from './base/BaseResource.js';
 export { CrudResource } from './base/CrudResource.js';
 export { CrudWithAddresses } from './base/CrudWithAddresses.js';
 
+// Call-handler enum (for phoneNumbers.update call_handler field)
+export { PhoneCallHandler } from './callHandler.js';
+
 // Namespaces
-export { FabricNamespace, FabricResource, FabricResourcePUT, CallFlowsResource, ConferenceRoomsResource, SubscribersResource, CxmlApplicationsResource, GenericResources, FabricAddresses, FabricTokens } from './namespaces/fabric.js';
+export { FabricNamespace, FabricResource, FabricResourcePUT, CallFlowsResource, ConferenceRoomsResource, SubscribersResource, CxmlApplicationsResource, AutoMaterializedWebhookResource, SwmlWebhooksResource, CxmlWebhooksResource, GenericResources, FabricAddresses, FabricTokens } from './namespaces/fabric.js';
 export { CallingNamespace } from './namespaces/calling.js';
 export { DatasphereNamespace, DatasphereDocuments } from './namespaces/datasphere.js';
 export { PhoneNumbersResource } from './namespaces/phone-numbers.js';
+export type { SetSwmlWebhookExtra, SetCxmlWebhookParams, SetCallFlowParams, SetRelayTopicParams } from './namespaces/phone-numbers.js';
 export { AddressesResource } from './namespaces/addresses.js';
 export { QueuesResource } from './namespaces/queues.js';
 export { RecordingsResource } from './namespaces/recordings.js';

--- a/src/rest/namespaces/fabric.ts
+++ b/src/rest/namespaces/fabric.ts
@@ -170,8 +170,62 @@ export class CxmlApplicationsResource extends FabricResourcePUT {
   }
 }
 
+/**
+ * Fabric webhook resource that is normally auto-materialized by the
+ * corresponding `phoneNumbers.set*Webhook` helper.
+ *
+ * Creating directly produces an orphan Fabric resource that isn't bound to
+ * any phone number — the API's binding model configures the webhook on the
+ * phone number, and the server materializes the Fabric resource as a
+ * side-effect.  `create` remains for backwards compatibility but emits a
+ * one-time deprecation warning on first call.
+ *
+ * See the porting-sdk's `phone-binding.md` for the full model.
+ */
+export class AutoMaterializedWebhookResource extends FabricResource {
+  /** Label used in the deprecation warning (subclasses override). */
+  protected _autoHelperName: string = 'phoneNumbers.set*Webhook';
+  private static _warned = new WeakSet<object>();
+
+  constructor(http: HttpClient, basePath: string) {
+    super(http, basePath);
+  }
+
+  /**
+   * @deprecated Creating a webhook Fabric resource directly produces an
+   *   orphan that is not bound to any phone number. Use the
+   *   `phoneNumbers.setSwmlWebhook` / `setCxmlWebhook` helper instead — it
+   *   updates the phone number and the server auto-materializes the
+   *   resource. Kept for backwards compatibility.
+   */
+  override async create(body: any = {}): Promise<any> {
+    if (!AutoMaterializedWebhookResource._warned.has(this)) {
+      AutoMaterializedWebhookResource._warned.add(this);
+      console.warn(
+        `[signalwire] Creating a webhook Fabric resource directly produces ` +
+        `an orphan not bound to any phone number. Use ${this._autoHelperName} ` +
+        `instead; it updates the phone number and the server auto-materializes ` +
+        `the resource. See porting-sdk's phone-binding.md.`,
+      );
+    }
+    return super.create(body);
+  }
+}
+
+/** Auto-materialized SWML webhook — normally created via `phoneNumbers.setSwmlWebhook`. */
+export class SwmlWebhooksResource extends AutoMaterializedWebhookResource {
+  protected override _autoHelperName = 'phoneNumbers.setSwmlWebhook(sid, url)';
+}
+
+/** Auto-materialized cXML webhook — normally created via `phoneNumbers.setCxmlWebhook`. */
+export class CxmlWebhooksResource extends AutoMaterializedWebhookResource {
+  protected override _autoHelperName = 'phoneNumbers.setCxmlWebhook(sid, { url })';
+}
+
 /** Generic resource operations across all fabric resource types. */
 export class GenericResources extends BaseResource {
+  private static _assignPhoneRouteWarned = new WeakSet<object>();
+
   constructor(http: HttpClient, basePath: string) {
     super(http, basePath);
   }
@@ -224,12 +278,33 @@ export class GenericResources extends BaseResource {
   /**
    * Assign a phone route to a fabric resource.
    *
+   * @deprecated For the common cases — SWML webhooks, cXML webhooks, AI
+   *   agents — this endpoint **does not work**. Bindings for those are
+   *   configured on the phone number via {@link PhoneNumbersResource.setSwmlWebhook}
+   *   / `setCxmlWebhook` / `setAiAgent`, and the Fabric resource is
+   *   auto-materialized by the server. Calling this method against
+   *   `swml_webhook`, `cxml_webhook`, or `ai_agent` resource IDs returns
+   *   `404` or `422`. The endpoint (`POST /api/fabric/resources/{id}/phone_routes`)
+   *   applies only to a narrow set of legacy resource types listed in
+   *   `rest-apis/relay-rest/openapi.yaml`. Emits a one-time deprecation
+   *   warning on first call; kept for backwards compatibility.
+   *
    * @param resourceId - Unique identifier of the resource.
-   * @param body - Phone route payload (typically `{ phone_number_id }`).
+   * @param body - Phone route payload.
    * @returns The phone-route assignment record.
    * @throws {RestError} On any non-2xx HTTP response.
    */
   async assignPhoneRoute(resourceId: string, body: any): Promise<any> {
+    if (!GenericResources._assignPhoneRouteWarned.has(this)) {
+      GenericResources._assignPhoneRouteWarned.add(this);
+      console.warn(
+        '[signalwire] assignPhoneRoute does not bind phone numbers to ' +
+        'swml_webhook / cxml_webhook / ai_agent resources — those are ' +
+        'configured via phoneNumbers.setSwmlWebhook / setCxmlWebhook / ' +
+        'setAiAgent. This method applies only to a narrow set of legacy ' +
+        "resource types. See porting-sdk's phone-binding.md.",
+      );
+    }
     return this._http.post(this._path(resourceId, 'phone_routes'), body);
   }
 
@@ -372,14 +447,22 @@ export class FabricNamespace {
   readonly cxmlApplications: CxmlApplicationsResource;
 
   // PATCH-update resources
-  /** SWML webhook CRUD (partial-update `PATCH` semantics). */
-  readonly swmlWebhooks: FabricResource;
+  /**
+   * SWML webhook CRUD. **Auto-materialized** as a side-effect of
+   * {@link PhoneNumbersResource.setSwmlWebhook}; direct `create` produces
+   * an orphan resource and emits a deprecation warning.
+   */
+  readonly swmlWebhooks: SwmlWebhooksResource;
   /** AI Agent CRUD — the platform-managed agent registration resource. */
   readonly aiAgents: FabricResource;
   /** SIP Gateway CRUD. */
   readonly sipGateways: FabricResource;
-  /** cXML webhook CRUD. */
-  readonly cxmlWebhooks: FabricResource;
+  /**
+   * cXML webhook CRUD. **Auto-materialized** as a side-effect of
+   * {@link PhoneNumbersResource.setCxmlWebhook}; direct `create` produces
+   * an orphan resource and emits a deprecation warning.
+   */
+  readonly cxmlWebhooks: CxmlWebhooksResource;
 
   // Special resources
   /** Generic operations across all resource types (list, get, delete, phone route assignment). */
@@ -404,10 +487,13 @@ export class FabricNamespace {
     this.cxmlApplications = new CxmlApplicationsResource(http, `${base}/cxml_applications`);
 
     // PATCH-update resources
-    this.swmlWebhooks = new FabricResource(http, `${base}/swml_webhooks`);
+    // swmlWebhooks and cxmlWebhooks are normally auto-materialized by
+    // phoneNumbers.setSwmlWebhook / setCxmlWebhook. Direct create still
+    // works for backcompat but emits a deprecation warning.
+    this.swmlWebhooks = new SwmlWebhooksResource(http, `${base}/swml_webhooks`);
     this.aiAgents = new FabricResource(http, `${base}/ai_agents`);
     this.sipGateways = new FabricResource(http, `${base}/sip_gateways`);
-    this.cxmlWebhooks = new FabricResource(http, `${base}/cxml_webhooks`);
+    this.cxmlWebhooks = new CxmlWebhooksResource(http, `${base}/cxml_webhooks`);
 
     // Special resources
     this.resources = new GenericResources(http, base);

--- a/src/rest/namespaces/phone-numbers.ts
+++ b/src/rest/namespaces/phone-numbers.ts
@@ -1,5 +1,5 @@
 /**
- * Phone Numbers namespace — list, search, purchase, get, update, release.
+ * Phone Numbers namespace — list, search, purchase, get, update, release, bind.
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -7,9 +7,60 @@
 import type { HttpClient } from '../HttpClient.js';
 import type { QueryParams } from '../types.js';
 import { CrudResource } from '../base/CrudResource.js';
+import { PhoneCallHandler } from '../callHandler.js';
+
+/** Optional companion fields for {@link PhoneNumbersResource.setSwmlWebhook}. */
+export interface SetSwmlWebhookExtra {
+  [key: string]: unknown;
+}
+
+/** Parameters for {@link PhoneNumbersResource.setCxmlWebhook}. */
+export interface SetCxmlWebhookParams {
+  /** Primary cXML document URL. Serialized as `call_request_url`. */
+  url: string;
+  /** Fallback URL if the primary request fails. Serialized as `call_fallback_url`. */
+  fallbackUrl?: string;
+  /** Status callback URL for call status updates. Serialized as `call_status_callback_url`. */
+  statusCallbackUrl?: string;
+  /** Any additional wire-level fields are passed through verbatim. */
+  [key: string]: unknown;
+}
+
+/** Parameters for {@link PhoneNumbersResource.setCallFlow}. */
+export interface SetCallFlowParams {
+  /** Call Flow resource ID. Serialized as `call_flow_id`. */
+  flowId: string;
+  /**
+   * Optional pinned version — `"working_copy"` or `"current_deployed"`
+   * (server default when omitted). Serialized as `call_flow_version`.
+   */
+  version?: string;
+  /** Any additional wire-level fields are passed through verbatim. */
+  [key: string]: unknown;
+}
+
+/** Parameters for {@link PhoneNumbersResource.setRelayTopic}. */
+export interface SetRelayTopicParams {
+  /** RELAY topic name. Serialized as `call_relay_topic`. */
+  topic: string;
+  /**
+   * Optional status callback URL for RELAY topic delivery updates.
+   * Serialized as `call_relay_topic_status_callback_url`.
+   */
+  statusCallbackUrl?: string;
+  /** Any additional wire-level fields are passed through verbatim. */
+  [key: string]: unknown;
+}
 
 /**
  * Phone number management.
+ *
+ * Supports the standard CRUD surface plus typed helpers for binding an
+ * inbound call to a handler (SWML webhook, cXML webhook, AI agent, call
+ * flow, RELAY application/topic). The binding model is: set `call_handler`
+ * + the handler-specific companion field on the phone number; the server
+ * auto-materializes the matching Fabric resource. See
+ * {@link PhoneCallHandler} for the enum of valid `call_handler` values.
  *
  * `create` and `update` accept an untyped body object (`body: any = {}`).
  * No `PhoneNumberCreateParams` / `PhoneNumberUpdateParams` interfaces are
@@ -48,6 +99,11 @@ export class PhoneNumbersResource extends CrudResource {
   /**
    * Update a phone number resource by ID. Body is optional to match Python `**kwargs`.
    *
+   * Setting `call_handler` + the matching companion field (see
+   * {@link PhoneCallHandler}) on the phone number auto-materializes the
+   * matching Fabric resource on the server; prefer the `set*` helpers
+   * below for the common cases.
+   *
    * @param resourceId - Unique phone-number resource ID.
    * @param body - Partial update payload. Defaults to `{}`.
    * @returns The updated phone-number resource.
@@ -72,5 +128,168 @@ export class PhoneNumbersResource extends CrudResource {
    */
   async search(params?: QueryParams): Promise<any> {
     return this._http.get(this._path('search'), params);
+  }
+
+  // -- Typed binding helpers ----------------------------------------------
+  //
+  // Each helper is a one-line wrapper over `update` with the right
+  // `call_handler` value and companion field already set. Pass through
+  // extra fields for cases the helper doesn't name explicitly (e.g.
+  // `call_fallback_url` on cXML webhooks).
+
+  /**
+   * Route inbound calls to an SWML webhook URL.
+   *
+   * Your backend returns an SWML document per call. The server
+   * auto-creates a `swml_webhook` Fabric resource keyed off this URL —
+   * you do **not** need to call `fabric.swmlWebhooks.create` or
+   * `fabric.resources.assignPhoneRoute`.
+   *
+   * @param resourceId - Unique phone-number resource ID.
+   * @param url - Your backend's SWML endpoint.
+   * @param extra - Additional wire-level fields (e.g. `name`) merged into
+   *   the PUT body.
+   * @returns The updated phone-number resource.
+   *
+   * @example
+   * ```ts
+   * await client.phoneNumbers.setSwmlWebhook('pn-1', 'https://example.com/swml');
+   * ```
+   */
+  async setSwmlWebhook(resourceId: string, url: string, extra: SetSwmlWebhookExtra = {}): Promise<any> {
+    return this.update(resourceId, {
+      call_handler: PhoneCallHandler.RELAY_SCRIPT,
+      call_relay_script_url: url,
+      ...extra,
+    });
+  }
+
+  /**
+   * Route inbound calls to a cXML (Twilio-compat / LAML) webhook.
+   *
+   * Despite the wire value `laml_webhooks` being plural, this creates a
+   * single `cxml_webhook` Fabric resource.  `fallbackUrl` is used when the
+   * primary URL fails; `statusCallbackUrl` receives call status updates.
+   *
+   * @param resourceId - Unique phone-number resource ID.
+   * @param params - URL and optional fallback/status URLs plus any extra
+   *   wire-level fields.
+   * @returns The updated phone-number resource.
+   *
+   * @example
+   * ```ts
+   * await client.phoneNumbers.setCxmlWebhook('pn-1', {
+   *   url: 'https://example.com/voice.xml',
+   *   fallbackUrl: 'https://example.com/fallback.xml',
+   * });
+   * ```
+   */
+  async setCxmlWebhook(resourceId: string, params: SetCxmlWebhookParams): Promise<any> {
+    const { url, fallbackUrl, statusCallbackUrl, ...extra } = params;
+    const body: Record<string, unknown> = {
+      call_handler: PhoneCallHandler.LAML_WEBHOOKS,
+      call_request_url: url,
+      ...extra,
+    };
+    if (fallbackUrl !== undefined) {
+      body['call_fallback_url'] = fallbackUrl;
+    }
+    if (statusCallbackUrl !== undefined) {
+      body['call_status_callback_url'] = statusCallbackUrl;
+    }
+    return this.update(resourceId, body);
+  }
+
+  /**
+   * Route inbound calls to an existing cXML application by ID.
+   *
+   * @param resourceId - Unique phone-number resource ID.
+   * @param applicationId - cXML application ID.
+   * @param extra - Additional wire-level fields merged into the body.
+   * @returns The updated phone-number resource.
+   */
+  async setCxmlApplication(resourceId: string, applicationId: string, extra: Record<string, unknown> = {}): Promise<any> {
+    return this.update(resourceId, {
+      call_handler: PhoneCallHandler.LAML_APPLICATION,
+      call_laml_application_id: applicationId,
+      ...extra,
+    });
+  }
+
+  /**
+   * Route inbound calls to an AI Agent Fabric resource by ID.
+   *
+   * @param resourceId - Unique phone-number resource ID.
+   * @param agentId - AI agent Fabric resource ID.
+   * @param extra - Additional wire-level fields merged into the body.
+   * @returns The updated phone-number resource.
+   */
+  async setAiAgent(resourceId: string, agentId: string, extra: Record<string, unknown> = {}): Promise<any> {
+    return this.update(resourceId, {
+      call_handler: PhoneCallHandler.AI_AGENT,
+      call_ai_agent_id: agentId,
+      ...extra,
+    });
+  }
+
+  /**
+   * Route inbound calls to a Call Flow by ID.
+   *
+   * `version` accepts `"working_copy"` or `"current_deployed"` (server
+   * default when omitted).
+   *
+   * @param resourceId - Unique phone-number resource ID.
+   * @param params - Flow ID and optional pinned version plus any extra
+   *   wire-level fields.
+   * @returns The updated phone-number resource.
+   */
+  async setCallFlow(resourceId: string, params: SetCallFlowParams): Promise<any> {
+    const { flowId, version, ...extra } = params;
+    const body: Record<string, unknown> = {
+      call_handler: PhoneCallHandler.CALL_FLOW,
+      call_flow_id: flowId,
+      ...extra,
+    };
+    if (version !== undefined) {
+      body['call_flow_version'] = version;
+    }
+    return this.update(resourceId, body);
+  }
+
+  /**
+   * Route inbound calls to a named RELAY application.
+   *
+   * @param resourceId - Unique phone-number resource ID.
+   * @param name - RELAY application name.
+   * @param extra - Additional wire-level fields merged into the body.
+   * @returns The updated phone-number resource.
+   */
+  async setRelayApplication(resourceId: string, name: string, extra: Record<string, unknown> = {}): Promise<any> {
+    return this.update(resourceId, {
+      call_handler: PhoneCallHandler.RELAY_APPLICATION,
+      call_relay_application: name,
+      ...extra,
+    });
+  }
+
+  /**
+   * Route inbound calls to a RELAY topic (client subscription).
+   *
+   * @param resourceId - Unique phone-number resource ID.
+   * @param params - Topic name and optional status-callback URL plus any
+   *   extra wire-level fields.
+   * @returns The updated phone-number resource.
+   */
+  async setRelayTopic(resourceId: string, params: SetRelayTopicParams): Promise<any> {
+    const { topic, statusCallbackUrl, ...extra } = params;
+    const body: Record<string, unknown> = {
+      call_handler: PhoneCallHandler.RELAY_TOPIC,
+      call_relay_topic: topic,
+      ...extra,
+    };
+    if (statusCallbackUrl !== undefined) {
+      body['call_relay_topic_status_callback_url'] = statusCallbackUrl;
+    }
+    return this.update(resourceId, body);
   }
 }

--- a/tests/rest/fabric.test.ts
+++ b/tests/rest/fabric.test.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { HttpClient } from '../../src/rest/HttpClient.js';
 import { FabricNamespace } from '../../src/rest/namespaces/fabric.js';
 import { mockClientOptions } from './helpers.js';
@@ -115,6 +116,58 @@ describe('FabricNamespace', () => {
     });
   });
 
+  describe('Auto-materialized webhook resources', () => {
+    it('swmlWebhooks.create emits deprecation warning but still posts', async () => {
+      const { fabric, getRequests } = setup([{ status: 200, body: { id: 'wh1' } }]);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        await fabric.swmlWebhooks.create({ name: 'oops', primary_request_url: 'https://example.com' });
+        expect(getRequests()[0].method).toBe('POST');
+        expect(getRequests()[0].url).toContain('/api/fabric/resources/swml_webhooks');
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const warnMsg = String(warnSpy.mock.calls[0]?.[0] ?? '');
+        expect(warnMsg).toContain('setSwmlWebhook');
+        expect(warnMsg).toContain('phone-binding.md');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('cxmlWebhooks.create emits deprecation warning but still posts', async () => {
+      const { fabric, getRequests } = setup([{ status: 200, body: { id: 'wh2' } }]);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        await fabric.cxmlWebhooks.create({ name: 'oops', primary_request_url: 'https://example.com' });
+        expect(getRequests()[0].method).toBe('POST');
+        expect(getRequests()[0].url).toContain('/api/fabric/resources/cxml_webhooks');
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const warnMsg = String(warnSpy.mock.calls[0]?.[0] ?? '');
+        expect(warnMsg).toContain('setCxmlWebhook');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('swmlWebhooks.list / get / update / delete do NOT warn', async () => {
+      const { fabric } = setup([
+        { status: 200, body: { data: [] } },
+        { status: 200, body: { id: 'wh1' } },
+        { status: 200, body: { id: 'wh1' } },
+        { status: 204 },
+      ]);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        await fabric.swmlWebhooks.list();
+        await fabric.swmlWebhooks.get('wh1');
+        await fabric.swmlWebhooks.update('wh1', { name: 'renamed' });
+        await fabric.swmlWebhooks.delete('wh1');
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
   describe('Generic Resources', () => {
     it('lists all resources', async () => {
       const { fabric, getRequests } = setup();
@@ -123,11 +176,28 @@ describe('FabricNamespace', () => {
       expect(getRequests()[0].url).not.toContain('/api/fabric/resources/');
     });
 
-    it('assigns phone route', async () => {
-      const { fabric, getRequests } = setup([{ status: 200, body: {} }]);
-      await fabric.resources.assignPhoneRoute('r1', { number: '+15551234567' });
-      expect(getRequests()[0].url).toContain('/api/fabric/resources/r1/phone_routes');
-      expect(getRequests()[0].method).toBe('POST');
+    it('assigns phone route (deprecated) and emits one-time warning', async () => {
+      const { fabric, getRequests } = setup([{ status: 200, body: {} }, { status: 200, body: {} }]);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        await fabric.resources.assignPhoneRoute('r1', { number: '+15551234567' });
+        expect(getRequests()[0].url).toContain('/api/fabric/resources/r1/phone_routes');
+        expect(getRequests()[0].method).toBe('POST');
+
+        // Deprecation warning fires on first call and steers users to the
+        // phoneNumbers helpers documented in phone-binding.md.
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const warnMsg = String(warnSpy.mock.calls[0]?.[0] ?? '');
+        expect(warnMsg).toContain('phoneNumbers.setSwmlWebhook');
+        expect(warnMsg).toContain('phone-binding.md');
+
+        // Warning is one-time per instance: second call posts but does not warn.
+        warnSpy.mockClear();
+        await fabric.resources.assignPhoneRoute('r1', { number: '+15551234567' });
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('assigns domain application', async () => {

--- a/tests/rest/phoneNumbers.test.ts
+++ b/tests/rest/phoneNumbers.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for PhoneNumbersResource — CRUD, search, and typed binding helpers.
+ *
+ * The typed helpers wrap `phoneNumbers.update` with the correct
+ * `call_handler` + companion field combination for each handler type. A
+ * regression test asserts the full happy-path binding flow does NOT require
+ * pre-creating a Fabric webhook resource and does NOT call
+ * `assignPhoneRoute` — the two traps found in the phone-binding
+ * post-mortem.
+ */
+
+import { HttpClient } from '../../src/rest/HttpClient.js';
+import { PhoneNumbersResource } from '../../src/rest/namespaces/phone-numbers.js';
+import { FabricNamespace } from '../../src/rest/namespaces/fabric.js';
+import { PhoneCallHandler } from '../../src/rest/callHandler.js';
+import { mockClientOptions } from './helpers.js';
+
+const BASE = '/api/relay/rest/phone_numbers';
+
+function setup(responses: any[] = [{ status: 200, body: {} }]) {
+  const { options, getRequests } = mockClientOptions(responses);
+  const http = new HttpClient(options);
+  const phoneNumbers = new PhoneNumbersResource(http);
+  const fabric = new FabricNamespace(http);
+  return { phoneNumbers, fabric, getRequests };
+}
+
+describe('PhoneCallHandler enum', () => {
+  it('exposes all 11 wire values', () => {
+    const expected = new Set([
+      'relay_script',
+      'laml_webhooks',
+      'laml_application',
+      'ai_agent',
+      'call_flow',
+      'relay_application',
+      'relay_topic',
+      'relay_context',
+      'relay_connector',
+      'video_room',
+      'dialogflow',
+    ]);
+    const actual = new Set(Object.values(PhoneCallHandler));
+    expect(actual).toEqual(expected);
+  });
+
+  it('members are plain strings (serialize identically to wire)', () => {
+    expect(PhoneCallHandler.RELAY_SCRIPT).toBe('relay_script');
+    expect(PhoneCallHandler.AI_AGENT).toBe('ai_agent');
+    expect(JSON.stringify({ h: PhoneCallHandler.CALL_FLOW })).toBe('{"h":"call_flow"}');
+  });
+
+  it('is named PhoneCallHandler (not CallHandler) to avoid RELAY client collision', async () => {
+    // The RELAY client exports a separate CallHandler callback type.  Confirm
+    // that importing from the REST entrypoint yields a distinct symbol with
+    // the expected rename, and that no `CallHandler` leaks from rest/index.
+    const restIndex = await import('../../src/rest/index.js');
+    expect(restIndex.PhoneCallHandler).toBeDefined();
+    expect((restIndex as Record<string, unknown>)['CallHandler']).toBeUndefined();
+  });
+});
+
+describe('PhoneNumbersResource — typed binding helpers', () => {
+  describe('setSwmlWebhook', () => {
+    it('sets call_handler=relay_script + call_relay_script_url', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setSwmlWebhook('pn-1', 'https://example.com/swml');
+
+      const req = getRequests()[0];
+      expect(req?.method).toBe('PUT');
+      expect(req?.url).toContain(`${BASE}/pn-1`);
+      expect(req?.body).toEqual({
+        call_handler: 'relay_script',
+        call_relay_script_url: 'https://example.com/swml',
+      });
+    });
+
+    it('passes through extra fields (e.g. name)', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setSwmlWebhook('pn-1', 'https://example.com/swml', { name: 'Support Line' });
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'relay_script',
+        call_relay_script_url: 'https://example.com/swml',
+        name: 'Support Line',
+      });
+    });
+  });
+
+  describe('setCxmlWebhook', () => {
+    it('minimal form: sets call_handler=laml_webhooks + call_request_url', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setCxmlWebhook('pn-1', { url: 'https://example.com/voice.xml' });
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'laml_webhooks',
+        call_request_url: 'https://example.com/voice.xml',
+      });
+    });
+
+    it('includes fallbackUrl and statusCallbackUrl when supplied', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setCxmlWebhook('pn-1', {
+        url: 'https://example.com/voice.xml',
+        fallbackUrl: 'https://example.com/fallback.xml',
+        statusCallbackUrl: 'https://example.com/status',
+      });
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'laml_webhooks',
+        call_request_url: 'https://example.com/voice.xml',
+        call_fallback_url: 'https://example.com/fallback.xml',
+        call_status_callback_url: 'https://example.com/status',
+      });
+    });
+
+    it('passes through extra wire-level fields', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setCxmlWebhook('pn-1', {
+        url: 'https://example.com/voice.xml',
+        call_status_callback_method: 'POST',
+      });
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'laml_webhooks',
+        call_request_url: 'https://example.com/voice.xml',
+        call_status_callback_method: 'POST',
+      });
+    });
+  });
+
+  describe('setCxmlApplication', () => {
+    it('sets call_handler=laml_application + call_laml_application_id', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setCxmlApplication('pn-1', 'app-1');
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'laml_application',
+        call_laml_application_id: 'app-1',
+      });
+    });
+  });
+
+  describe('setAiAgent', () => {
+    it('sets call_handler=ai_agent + call_ai_agent_id', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setAiAgent('pn-1', 'agent-1');
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'ai_agent',
+        call_ai_agent_id: 'agent-1',
+      });
+    });
+  });
+
+  describe('setCallFlow', () => {
+    it('minimal: sets call_handler=call_flow + call_flow_id', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setCallFlow('pn-1', { flowId: 'cf-1' });
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'call_flow',
+        call_flow_id: 'cf-1',
+      });
+    });
+
+    it('includes call_flow_version when version specified', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setCallFlow('pn-1', { flowId: 'cf-1', version: 'current_deployed' });
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'call_flow',
+        call_flow_id: 'cf-1',
+        call_flow_version: 'current_deployed',
+      });
+    });
+  });
+
+  describe('setRelayApplication', () => {
+    it('sets call_handler=relay_application + call_relay_application', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setRelayApplication('pn-1', 'my-app');
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'relay_application',
+        call_relay_application: 'my-app',
+      });
+    });
+  });
+
+  describe('setRelayTopic', () => {
+    it('minimal: sets call_handler=relay_topic + call_relay_topic', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setRelayTopic('pn-1', { topic: 'office' });
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'relay_topic',
+        call_relay_topic: 'office',
+      });
+    });
+
+    it('includes call_relay_topic_status_callback_url when supplied', async () => {
+      const { phoneNumbers, getRequests } = setup();
+      await phoneNumbers.setRelayTopic('pn-1', {
+        topic: 'office',
+        statusCallbackUrl: 'https://example.com/status',
+      });
+      expect(getRequests()[0]?.body).toEqual({
+        call_handler: 'relay_topic',
+        call_relay_topic: 'office',
+        call_relay_topic_status_callback_url: 'https://example.com/status',
+      });
+    });
+  });
+
+  describe('helper coverage', () => {
+    it('every expected helper is present on phoneNumbers', () => {
+      const { phoneNumbers } = setup();
+      const expected = [
+        'setSwmlWebhook',
+        'setCxmlWebhook',
+        'setCxmlApplication',
+        'setAiAgent',
+        'setCallFlow',
+        'setRelayApplication',
+        'setRelayTopic',
+      ] as const;
+      for (const name of expected) {
+        expect(typeof (phoneNumbers as unknown as Record<string, unknown>)[name]).toBe('function');
+      }
+    });
+  });
+});
+
+describe('Phone-binding post-mortem regression', () => {
+  /**
+   * The post-mortem identified two traps:
+   *   1. `fabric.swmlWebhooks.create(...)` looks right but produces orphans.
+   *   2. `fabric.resources.assignPhoneRoute(...)` rejects swml_webhook bindings.
+   *
+   * The correct happy-path binding is a single PUT to
+   * `/api/relay/rest/phone_numbers/{sid}` — no Fabric create, no phone_routes
+   * post. This test pins that contract.
+   */
+  it('setSwmlWebhook makes exactly ONE PUT to phone_numbers, no fabric calls', async () => {
+    const { phoneNumbers, getRequests } = setup();
+    await phoneNumbers.setSwmlWebhook('pn-1', 'https://example.com/swml');
+
+    const reqs = getRequests();
+    expect(reqs).toHaveLength(1);
+
+    const req = reqs[0]!;
+    expect(req.method).toBe('PUT');
+    expect(req.url).toContain(`${BASE}/pn-1`);
+    // No fabric.swmlWebhooks.create (POST to /api/fabric/resources/swml_webhooks).
+    expect(req.url).not.toContain('/api/fabric/resources/swml_webhooks');
+    // No fabric.resources.assignPhoneRoute (POST to .../phone_routes).
+    expect(req.url).not.toContain('/phone_routes');
+  });
+
+  it('wire-level form with raw strings works (no enum import needed)', async () => {
+    const { phoneNumbers, getRequests } = setup();
+    await phoneNumbers.update('pn-1', {
+      call_handler: 'relay_script',
+      call_relay_script_url: 'https://example.com/swml',
+    });
+    const req = getRequests()[0]!;
+    expect(req.method).toBe('PUT');
+    expect(req.body).toEqual({
+      call_handler: 'relay_script',
+      call_relay_script_url: 'https://example.com/swml',
+    });
+  });
+
+  it('PhoneCallHandler.RELAY_SCRIPT serializes to the same wire value', async () => {
+    const { phoneNumbers, getRequests } = setup();
+    await phoneNumbers.update('pn-1', {
+      call_handler: PhoneCallHandler.RELAY_SCRIPT,
+      call_relay_script_url: 'https://example.com/swml',
+    });
+    expect(getRequests()[0]?.body).toEqual({
+      call_handler: 'relay_script',
+      call_relay_script_url: 'https://example.com/swml',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Ships typed phone-binding helpers — the good path for routing an inbound number to an SWML webhook / cXML webhook / AI agent / call flow / RELAY app/topic. Driven by a user post-mortem documenting hours lost on the existing trap (`fabric.swmlWebhooks.create` + `fabric.resources.assignPhoneRoute` looked canonical but always failed live). Matches Python reference PR signalwire/signalwire-python#4 and the porting-sdk spec at `phone-binding.md`.

- New `PhoneCallHandler` const-object + string-literal union with all 11 wire values. Named to avoid collision with the existing `CallHandler` export in `src/relay/types.ts`.
- Seven typed helpers on `phone_numbers`: `setSwmlWebhook`, `setCxmlWebhook`, `setCxmlApplication`, `setAiAgent`, `setCallFlow`, `setRelayApplication`, `setRelayTopic`. Each wraps `update` with the right `call_handler` + companion field.
- `@deprecated` + one-time `console.warn` on `GenericResources.assignPhoneRoute` pointing at the helpers.
- `AutoMaterializedWebhookResource` subclasses for `swmlWebhooks` / `cxmlWebhooks` — `create` warns, list/get/update/delete unchanged.
- Fixed the misleading section in `rest-fabric-conferences-and-routing.ts`.
- New example `rest-bind-phone-to-swml-webhook.ts` and local `rest/docs/phone-binding.md`.

## Test plan

- [x] `npx vitest run tests/rest/` — 244 passed (22 new). Deterministic across 3 runs.
- [x] 19 new tests in `phoneNumbers.test.ts`: enum contract (all 11 values, no `CallHandler` export leak), one per helper asserting wire body, 3 post-mortem regression guards (exactly one PUT to phone_numbers, no `/fabric/resources/swml_webhooks` POST, no `/phone_routes` POST).
- [x] 3 new deprecation tests in `fabric.test.ts`.
- [x] `git stash` baseline confirms the `ajv`/`cheerio`/`undici` full-suite failures flagged on my run are pre-existing, unrelated to this branch.

## Non-breaking

Every previously-working code path still works. `assignPhoneRoute`, `swmlWebhooks.create`, `cxmlWebhooks.create` keep POSTing; only new signal is the one-time `console.warn` with a concrete pointer to the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)