### PR TITLE
Add Layer B symbol-level surface audit

### DIFF
--- a/.github/workflows/surface-audit.yml
+++ b/.github/workflows/surface-audit.yml
@@ -1,0 +1,60 @@
+name: Surface audit
+
+# Runs the Layer B symbol-level surface audit: enumerate the TypeScript
+# port's public API, diff against porting-sdk/python_surface.json, and fail
+# if any drift is not covered by PORT_OMISSIONS.md or PORT_ADDITIONS.md.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Nightly at 06:00 UTC — keeps us in sync with porting-sdk updates that
+    # follow upstream signalwire-python additions.
+    - cron: '0 6 * * *'
+
+jobs:
+  surface-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout TypeScript SDK
+        uses: actions/checkout@v4
+        with:
+          path: typescript-sdk
+
+      - name: Checkout porting-sdk (contains python_surface.json)
+        uses: actions/checkout@v4
+        with:
+          repository: signalwire/porting-sdk
+          path: porting-sdk
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: typescript-sdk/package-lock.json
+
+      - name: Setup Python (for diff_port_surface.py)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install TS deps
+        working-directory: typescript-sdk
+        run: npm ci
+
+      - name: Enumerate TypeScript public API surface
+        working-directory: typescript-sdk
+        env:
+          PORTING_SDK_PATH: ${{ github.workspace }}/porting-sdk
+        run: npx tsx scripts/enumerate-surface.ts
+
+      - name: Diff against Python reference
+        working-directory: typescript-sdk
+        run: |
+          python3 ${{ github.workspace }}/porting-sdk/scripts/diff_port_surface.py \
+              --reference ${{ github.workspace }}/porting-sdk/python_surface.json \
+              --port-surface port_surface.json \
+              --omissions PORT_OMISSIONS.md \
+              --additions PORT_ADDITIONS.md

--- a/PORT_ADDITIONS.md
+++ b/PORT_ADDITIONS.md
@@ -1,0 +1,342 @@
+# PORT_ADDITIONS.md
+
+This file enumerates every public symbol in the TypeScript port that has
+NO direct Python-reference equivalent.
+
+Each line has the form:
+
+    <fully.qualified.python-style.symbol>: <rationale>
+
+The `diff_port_surface.py` tool treats every listed symbol as an intentional
+port-specific extension. Unlisted extras fail the audit.
+
+Most additions below fall into three buckets:
+  1. TypeScript-native convenience helpers (getters, predicates, richer types)
+  2. SkillManager / SkillRegistry accessors that Python keeps as private fields
+  3. Framework-specific glue (Hono middleware, node:https SSL handling)
+
+---
+
+## Skill-specific additions
+
+signalwire.skills.api_ninjas_trivia.skill.ApiNinjasTriviaSkill.get_hints: TS-specific skill helper method or class
+signalwire.skills.api_ninjas_trivia.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.ask_claude.skill.AskClaudeSkill: TS-specific skill helper method or class
+signalwire.skills.ask_claude.skill.AskClaudeSkill.get_parameter_schema: TS-specific skill helper method or class
+signalwire.skills.ask_claude.skill.AskClaudeSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.ask_claude.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.claude_skills.skill.ClaudeSkillsSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.claude_skills.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.custom_skills.skill.CustomSkillsSkill: TS-specific skill helper method or class
+signalwire.skills.custom_skills.skill.CustomSkillsSkill.__init__: TS-specific skill helper method or class
+signalwire.skills.custom_skills.skill.CustomSkillsSkill.get_compilation_errors: TS-specific skill helper method or class
+signalwire.skills.custom_skills.skill.CustomSkillsSkill.get_parameter_schema: TS-specific skill helper method or class
+signalwire.skills.custom_skills.skill.CustomSkillsSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.custom_skills.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.datasphere.skill.DataSphereSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.datasphere.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.datasphere_serverless.skill.DataSphereServerlessSkill.get_data_map_tools: TS-specific skill helper method or class
+signalwire.skills.datasphere_serverless.skill.DataSphereServerlessSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.datasphere_serverless.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.datetime.skill.DateTimeSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.datetime.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.google_maps.skill.GoogleMapsSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.google_maps.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.info_gatherer.skill.InfoGathererSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.info_gatherer.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.joke.skill.JokeSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.joke.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.math.skill.MathSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.math.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.mcp_gateway.skill.McpGatewaySkill: TS-specific skill helper method or class
+signalwire.skills.mcp_gateway.skill.McpGatewaySkill.get_global_data: TS-specific skill helper method or class
+signalwire.skills.mcp_gateway.skill.McpGatewaySkill.get_hints: TS-specific skill helper method or class
+signalwire.skills.mcp_gateway.skill.McpGatewaySkill.get_parameter_schema: TS-specific skill helper method or class
+signalwire.skills.mcp_gateway.skill.McpGatewaySkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.mcp_gateway.skill.McpGatewaySkill.setup: TS-specific skill helper method or class
+signalwire.skills.mcp_gateway.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.native_vector_search.skill.NativeVectorSearchSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.native_vector_search.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.play_background_file.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.registry.register_builtin_skills: TS-specific skill helper method or class
+signalwire.skills.spider.skill.SpiderSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.spider.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.swml_transfer.skill.SwmlTransferSkill: TS-specific skill helper method or class
+signalwire.skills.swml_transfer.skill.SwmlTransferSkill.get_hints: TS-specific skill helper method or class
+signalwire.skills.swml_transfer.skill.SwmlTransferSkill.get_instance_key: TS-specific skill helper method or class
+signalwire.skills.swml_transfer.skill.SwmlTransferSkill.get_parameter_schema: TS-specific skill helper method or class
+signalwire.skills.swml_transfer.skill.SwmlTransferSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.swml_transfer.skill.SwmlTransferSkill.setup: TS-specific skill helper method or class
+signalwire.skills.swml_transfer.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.weather_api.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.web_search.skill.WebSearchSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.web_search.skill.create_skill: TS-specific skill helper method or class
+signalwire.skills.web_search.skill.extract_text_from_html: TS-specific skill helper method or class
+signalwire.skills.wikipedia_search.skill.WikipediaSearchSkill.get_tools: TS-specific skill helper method or class
+signalwire.skills.wikipedia_search.skill.create_skill: TS-specific skill helper method or class
+
+## Other additions
+
+signalwire.agent_server.AgentServer.get_app: TS port-only helper — functionality has no direct Python equivalent
+signalwire.agent_server.AgentServer.rtc_session: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.agent.prompt.manager.PromptManager.add_section: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.agent.prompt.manager.PromptManager.add_subsection: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.agent.prompt.manager.PromptManager.add_to_section: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.agent.prompt.manager.PromptManager.get_pom_builder: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.agent.prompt.manager.PromptManager.has_section: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.agent.tools.type_inference.parse_function_params: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.data_map.get_allowed_env_prefixes: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.data_map.set_allowed_env_prefixes: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.mixins.serverless_mixin.ServerlessAdapter: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.mixins.serverless_mixin.ServerlessAdapter.__init__: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.mixins.serverless_mixin.ServerlessAdapter.create_azure_handler: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.mixins.serverless_mixin.ServerlessAdapter.create_gcf_handler: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.mixins.serverless_mixin.ServerlessAdapter.create_lambda_handler: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.mixins.serverless_mixin.ServerlessAdapter.detect_platform: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.mixins.serverless_mixin.ServerlessAdapter.generate_url: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.mixins.serverless_mixin.ServerlessAdapter.get_platform: TS port-only helper — functionality has no direct Python equivalent
+signalwire.core.mixins.serverless_mixin.ServerlessAdapter.handle_request: TS port-only helper — functionality has no direct Python equivalent
+signalwire.prefabs.concierge.ConciergeAgent.define_tools: TS port-only helper — functionality has no direct Python equivalent
+signalwire.prefabs.concierge.create_concierge_agent: TS port-only helper — functionality has no direct Python equivalent
+signalwire.prefabs.faq_bot.FAQBotAgent.define_tools: TS port-only helper — functionality has no direct Python equivalent
+signalwire.prefabs.faq_bot.create_faq_bot_agent: TS port-only helper — functionality has no direct Python equivalent
+signalwire.prefabs.info_gatherer.InfoGathererAgent.define_tools: TS port-only helper — functionality has no direct Python equivalent
+signalwire.prefabs.info_gatherer.create_info_gatherer_agent: TS port-only helper — functionality has no direct Python equivalent
+signalwire.prefabs.receptionist.ReceptionistAgent.define_tools: TS port-only helper — functionality has no direct Python equivalent
+signalwire.prefabs.receptionist.create_receptionist_agent: TS port-only helper — functionality has no direct Python equivalent
+signalwire.prefabs.survey.SurveyAgent.define_tools: TS port-only helper — functionality has no direct Python equivalent
+signalwire.prefabs.survey.create_survey_agent: TS port-only helper — functionality has no direct Python equivalent
+signalwire.rest._pagination.paginate: TS port-only helper — functionality has no direct Python equivalent
+signalwire.rest._pagination.paginate_all: TS port-only helper — functionality has no direct Python equivalent
+signalwire.utils.filter_sensitive_headers: TS port-only helper — functionality has no direct Python equivalent
+signalwire.utils.is_private_ip: TS port-only helper — functionality has no direct Python equivalent
+signalwire.utils.is_valid_hostname: TS port-only helper — functionality has no direct Python equivalent
+signalwire.utils.redact_url: TS port-only helper — functionality has no direct Python equivalent
+signalwire.utils.resolve_and_validate_url: TS port-only helper — functionality has no direct Python equivalent
+signalwire.utils.safe_assign: TS port-only helper — functionality has no direct Python equivalent
+signalwire.utils.validate_url: TS port-only helper — functionality has no direct Python equivalent
+signalwire.web.web_service.WebService.get_app: TS port-only helper — functionality has no direct Python equivalent
+signalwire.web.web_service.WebService.ssl_config: TS port-only helper — functionality has no direct Python equivalent
+
+## AgentBase port-specific additions
+
+signalwire.core.agent_base.AgentBase.add_skill_by_name: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.define_typed_tool: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.extract_sip_username: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.get_mcp_servers: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.get_prompt_pom: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.get_registered_tools: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.get_tool: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.get_tools: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.handle_mcp_request: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.is_mcp_server_enabled: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.native_functions: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.prompt_manager: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.remove_skill_by_name: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.render_swml: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.run_serverless: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+signalwire.core.agent_base.AgentBase.skill_manager: TS-native AgentBase accessor / utility — aggregates state that is a private attribute or cross-mixin helper in Python
+
+## LiveWire port-specific
+
+signalwire.livewire.AgentServer.get_agent: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.AgentServer.get_agents: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.AgentServer.register: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.AgentServer.register_global_routing_callback: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.AgentServer.register_sip_username: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.AgentServer.run: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.AgentServer.serve_static_files: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.AgentServer.setup_sip_routing: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.AgentServer.unregister: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.AgentSession.get_sw_agent: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.ServerOptions: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.ServerOptions.__init__: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.WorkerOptions: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.WorkerOptions.__init__: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.define_agent: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+signalwire.livewire.handoff: LiveKit-compat helper exposed by the TS LiveWire shim (extra compatibility surface for @livekit/agents callers)
+
+## Logger (TS-native logging helpers)
+
+signalwire.core.logging_config.Logger: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.Logger.__init__: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.Logger.bind: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.Logger.debug: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.Logger.error: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.Logger.info: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.Logger.warn: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.set_global_log_color: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.set_global_log_format: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.set_global_log_level: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.set_global_log_stream: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+signalwire.core.logging_config.suppress_all_logs: TS Logger module exposes stream / color / level setters that are function-local configuration in Python
+
+## SkillManager port-specific additions
+
+signalwire.core.skill_manager.SkillManager.clear: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.get_all_hints: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.get_all_prompt_sections: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.get_all_tools: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.get_loaded_skill_entries: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.get_merged_global_data: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.has_skill_by_key: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.list_skill_keys: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.load_skill_by_name: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.loaded_skills: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.remove_skill_by_name: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+signalwire.core.skill_manager.SkillManager.size: TS-native SkillManager API — Python keeps most of this state as private; TS exposes richer accessors
+
+## SkillRegistry port-specific additions
+
+signalwire.skills.registry.SkillRegistry.clear: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.create: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.discover_all: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.get_instance: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.get_search_paths: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.get_skill_schema: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.has: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.list_registered: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.lock: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.reset_instance: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.size: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+signalwire.skills.registry.SkillRegistry.unregister: TS-native singleton-style SkillRegistry API (singleton lifecycle, lock / unregister / has, etc.)
+
+## Contexts port-specific
+
+signalwire.core.contexts.Context.get_initial_step: TS ContextBuilder / Context helper with additional navigation / builder methods
+signalwire.core.contexts.Context.get_step_order: TS ContextBuilder / Context helper with additional navigation / builder methods
+signalwire.core.contexts.Context.get_steps: TS ContextBuilder / Context helper with additional navigation / builder methods
+signalwire.core.contexts.Context.get_valid_contexts: TS ContextBuilder / Context helper with additional navigation / builder methods
+signalwire.core.contexts.ContextBuilder.attach_agent: TS ContextBuilder / Context helper with additional navigation / builder methods
+signalwire.core.contexts.GatherInfo.get_completion_action: TS ContextBuilder / Context helper with additional navigation / builder methods
+signalwire.core.contexts.GatherInfo.get_questions: TS ContextBuilder / Context helper with additional navigation / builder methods
+signalwire.core.contexts.Step.get_gather_info: TS ContextBuilder / Context helper with additional navigation / builder methods
+signalwire.core.contexts.Step.get_step_valid_contexts: TS ContextBuilder / Context helper with additional navigation / builder methods
+signalwire.core.contexts.Step.get_valid_steps: TS ContextBuilder / Context helper with additional navigation / builder methods
+
+## SkillBase port-specific additions
+
+signalwire.core.skill_base.SkillBase.get_agent: TS-native SkillBase helper or getter — property / helper method that Python exposes via direct attribute access
+signalwire.core.skill_base.SkillBase.get_config: TS-native SkillBase helper or getter — property / helper method that Python exposes via direct attribute access
+signalwire.core.skill_base.SkillBase.get_data_map_tools: TS-native SkillBase helper or getter — property / helper method that Python exposes via direct attribute access
+signalwire.core.skill_base.SkillBase.get_skill_namespace: TS-native SkillBase helper or getter — property / helper method that Python exposes via direct attribute access
+signalwire.core.skill_base.SkillBase.get_tools: TS-native SkillBase helper or getter — property / helper method that Python exposes via direct attribute access
+signalwire.core.skill_base.SkillBase.has_all_env_vars: TS-native SkillBase helper or getter — property / helper method that Python exposes via direct attribute access
+signalwire.core.skill_base.SkillBase.has_all_packages: TS-native SkillBase helper or getter — property / helper method that Python exposes via direct attribute access
+signalwire.core.skill_base.SkillBase.is_initialized: TS-native SkillBase helper or getter — property / helper method that Python exposes via direct attribute access
+signalwire.core.skill_base.SkillBase.mark_initialized: TS-native SkillBase helper or getter — property / helper method that Python exposes via direct attribute access
+signalwire.core.skill_base.SkillBase.set_agent: TS-native SkillBase helper or getter — property / helper method that Python exposes via direct attribute access
+
+## ConfigLoader port-specific
+
+signalwire.core.config_loader.ConfigLoader.config_paths: TS ConfigLoader has richer accessor helpers (type-narrowed getters, has/set helpers)
+signalwire.core.config_loader.ConfigLoader.get_all: TS ConfigLoader has richer accessor helpers (type-narrowed getters, has/set helpers)
+signalwire.core.config_loader.ConfigLoader.get_file_path: TS ConfigLoader has richer accessor helpers (type-narrowed getters, has/set helpers)
+signalwire.core.config_loader.ConfigLoader.has: TS ConfigLoader has richer accessor helpers (type-narrowed getters, has/set helpers)
+signalwire.core.config_loader.ConfigLoader.interpolate_env_vars: TS ConfigLoader has richer accessor helpers (type-narrowed getters, has/set helpers)
+signalwire.core.config_loader.ConfigLoader.load: TS ConfigLoader has richer accessor helpers (type-narrowed getters, has/set helpers)
+signalwire.core.config_loader.ConfigLoader.load_from_object: TS ConfigLoader has richer accessor helpers (type-narrowed getters, has/set helpers)
+signalwire.core.config_loader.ConfigLoader.search: TS ConfigLoader has richer accessor helpers (type-narrowed getters, has/set helpers)
+signalwire.core.config_loader.ConfigLoader.set: TS ConfigLoader has richer accessor helpers (type-narrowed getters, has/set helpers)
+
+## POM port-specific
+
+signalwire.core.pom_builder.PomBuilder.add_pom_as_subsection: TS POM helper on PomBuilder / PomSection — richer accessors and navigation helpers than the Python equivalent
+signalwire.core.pom_builder.PomBuilder.find_section: TS POM helper on PomBuilder / PomSection — richer accessors and navigation helpers than the Python equivalent
+signalwire.core.pom_builder.PomBuilder.reset: TS POM helper on PomBuilder / PomSection — richer accessors and navigation helpers than the Python equivalent
+signalwire.core.pom_builder.PomSection: TS POM helper on PomBuilder / PomSection — richer accessors and navigation helpers than the Python equivalent
+signalwire.core.pom_builder.PomSection.__init__: TS POM helper on PomBuilder / PomSection — richer accessors and navigation helpers than the Python equivalent
+signalwire.core.pom_builder.PomSection.add_subsection: TS POM helper on PomBuilder / PomSection — richer accessors and navigation helpers than the Python equivalent
+signalwire.core.pom_builder.PomSection.render_markdown: TS POM helper on PomBuilder / PomSection — richer accessors and navigation helpers than the Python equivalent
+signalwire.core.pom_builder.PomSection.render_xml: TS POM helper on PomBuilder / PomSection — richer accessors and navigation helpers than the Python equivalent
+signalwire.core.pom_builder.PomSection.to_dict: TS POM helper on PomBuilder / PomSection — richer accessors and navigation helpers than the Python equivalent
+
+## Relay port-specific
+
+signalwire.relay.call.Call.pass: TS Relay helper or utility (closures, typed events) that Python covers via async iterators / callables
+signalwire.relay.call.Call.to_string: TS Relay helper or utility (closures, typed events) that Python covers via async iterators / callables
+signalwire.relay.deferred.create_deferred: TS Relay helper or utility (closures, typed events) that Python covers via async iterators / callables
+signalwire.relay.deferred.with_timeout: TS Relay helper or utility (closures, typed events) that Python covers via async iterators / callables
+signalwire.relay.message.Message.to_string: TS Relay helper or utility (closures, typed events) that Python covers via async iterators / callables
+signalwire.relay.normalize.normalize_device: TS Relay helper or utility (closures, typed events) that Python covers via async iterators / callables
+signalwire.relay.normalize.normalize_device_plan: TS Relay helper or utility (closures, typed events) that Python covers via async iterators / callables
+signalwire.relay.normalize.normalize_play_item: TS Relay helper or utility (closures, typed events) that Python covers via async iterators / callables
+signalwire.relay.normalize.normalize_play_items: TS Relay helper or utility (closures, typed events) that Python covers via async iterators / callables
+
+## SslConfig (SSL-specific config class, TS port-only)
+
+signalwire.core.security_config.SslConfig: TS splits SSL configuration into a dedicated SslConfig class (Python keeps it inside SecurityConfig); the SslConfig methods are all port-specific SSL helpers
+signalwire.core.security_config.SslConfig.__init__: TS splits SSL configuration into a dedicated SslConfig class (Python keeps it inside SecurityConfig); the SslConfig methods are all port-specific SSL helpers
+signalwire.core.security_config.SslConfig.get_cert: TS splits SSL configuration into a dedicated SslConfig class (Python keeps it inside SecurityConfig); the SslConfig methods are all port-specific SSL helpers
+signalwire.core.security_config.SslConfig.get_hsts_header: TS splits SSL configuration into a dedicated SslConfig class (Python keeps it inside SecurityConfig); the SslConfig methods are all port-specific SSL helpers
+signalwire.core.security_config.SslConfig.get_key: TS splits SSL configuration into a dedicated SslConfig class (Python keeps it inside SecurityConfig); the SslConfig methods are all port-specific SSL helpers
+signalwire.core.security_config.SslConfig.get_server_options: TS splits SSL configuration into a dedicated SslConfig class (Python keeps it inside SecurityConfig); the SslConfig methods are all port-specific SSL helpers
+signalwire.core.security_config.SslConfig.hsts_middleware: TS splits SSL configuration into a dedicated SslConfig class (Python keeps it inside SecurityConfig); the SslConfig methods are all port-specific SSL helpers
+signalwire.core.security_config.SslConfig.is_configured: TS splits SSL configuration into a dedicated SslConfig class (Python keeps it inside SecurityConfig); the SslConfig methods are all port-specific SSL helpers
+
+## SWMLBuilder port-specific additions
+
+signalwire.core.swml_builder.SWMLBuilder.add_verb: TS SwmlBuilder helper method — additional convenience on top of the canonical addVerb() API
+signalwire.core.swml_builder.SWMLBuilder.add_verb_to_section: TS SwmlBuilder helper method — additional convenience on top of the canonical addVerb() API
+signalwire.core.swml_builder.SWMLBuilder.document: TS SwmlBuilder helper method — additional convenience on top of the canonical addVerb() API
+signalwire.core.swml_builder.SWMLBuilder.get_document: TS SwmlBuilder helper method — additional convenience on top of the canonical addVerb() API
+signalwire.core.swml_builder.SWMLBuilder.get_schema_utils: TS SwmlBuilder helper method — additional convenience on top of the canonical addVerb() API
+signalwire.core.swml_builder.SWMLBuilder.render_document: TS SwmlBuilder helper method — additional convenience on top of the canonical addVerb() API
+signalwire.core.swml_builder.SWMLBuilder.set_validation: TS SwmlBuilder helper method — additional convenience on top of the canonical addVerb() API
+
+## AuthHandler port-specific
+
+signalwire.core.auth_handler.AuthHandler.express_middleware: TS AuthHandler exposes Hono-middleware-friendly helpers that Python handles via Flask / FastAPI integrations
+signalwire.core.auth_handler.AuthHandler.has_api_key_auth: TS AuthHandler exposes Hono-middleware-friendly helpers that Python handles via Flask / FastAPI integrations
+signalwire.core.auth_handler.AuthHandler.has_basic_auth: TS AuthHandler exposes Hono-middleware-friendly helpers that Python handles via Flask / FastAPI integrations
+signalwire.core.auth_handler.AuthHandler.has_bearer_auth: TS AuthHandler exposes Hono-middleware-friendly helpers that Python handles via Flask / FastAPI integrations
+signalwire.core.auth_handler.AuthHandler.middleware: TS AuthHandler exposes Hono-middleware-friendly helpers that Python handles via Flask / FastAPI integrations
+signalwire.core.auth_handler.AuthHandler.validate: TS AuthHandler exposes Hono-middleware-friendly helpers that Python handles via Flask / FastAPI integrations
+
+## SchemaUtils port-specific
+
+signalwire.utils.schema_utils.SchemaUtils.clear_cache: TS SchemaUtils helper built on top of Ajv; exposes predicate / accessor methods that Python does inline
+signalwire.utils.schema_utils.SchemaUtils.get_cache_size: TS SchemaUtils helper built on top of Ajv; exposes predicate / accessor methods that Python does inline
+signalwire.utils.schema_utils.SchemaUtils.get_verb_description: TS SchemaUtils helper built on top of Ajv; exposes predicate / accessor methods that Python does inline
+signalwire.utils.schema_utils.SchemaUtils.get_verb_names: TS SchemaUtils helper built on top of Ajv; exposes predicate / accessor methods that Python does inline
+signalwire.utils.schema_utils.SchemaUtils.has_verb: TS SchemaUtils helper built on top of Ajv; exposes predicate / accessor methods that Python does inline
+signalwire.utils.schema_utils.SchemaUtils.validate: TS SchemaUtils helper built on top of Ajv; exposes predicate / accessor methods that Python does inline
+
+## SWMLService port-specific
+
+signalwire.core.swml_service.SWMLService.get_app: TS SWMLService exposes richer handler-registration / config getters
+signalwire.core.swml_service.SWMLService.get_builder: TS SWMLService exposes richer handler-registration / config getters
+signalwire.core.swml_service.SWMLService.render_swml: TS SWMLService exposes richer handler-registration / config getters
+signalwire.core.swml_service.SWMLService.run: TS SWMLService exposes richer handler-registration / config getters
+signalwire.core.swml_service.SWMLService.set_on_request_callback: TS SWMLService exposes richer handler-registration / config getters
+
+## REST namespace additions
+
+signalwire.rest.namespaces.fabric.AutoMaterializedWebhookResource: TS REST namespace exposes an additional helper or utility method on top of the Python surface
+signalwire.rest.namespaces.fabric.AutoMaterializedWebhookResource.__init__: TS REST namespace exposes an additional helper or utility method on top of the Python surface
+signalwire.rest.namespaces.fabric.AutoMaterializedWebhookResource.create: TS REST namespace exposes an additional helper or utility method on top of the Python surface
+signalwire.rest.namespaces.phone_numbers.PhoneNumbersResource.create: TS REST namespace exposes an additional helper or utility method on top of the Python surface
+signalwire.rest.namespaces.phone_numbers.PhoneNumbersResource.update: TS REST namespace exposes an additional helper or utility method on top of the Python surface
+
+## CLI port-specific
+
+signalwire.cli.core.agent_loader.list_agents: TS CLI helper exposed by the TS swaig-test wrapper
+signalwire.cli.core.agent_loader.load_agent: TS CLI helper exposed by the TS swaig-test wrapper
+signalwire.cli.simulation.mock_env.generate_fake_post_data: TS CLI helper exposed by the TS swaig-test wrapper
+signalwire.cli.simulation.mock_env.generate_minimal_post_data: TS CLI helper exposed by the TS swaig-test wrapper
+
+## DataMap port-specific
+
+signalwire.core.data_map.DataMap.enable_env_expansion: TS DataMap helper / accessor
+signalwire.core.data_map.DataMap.register_with_agent: TS DataMap helper / accessor
+signalwire.core.data_map.DataMap.set_allowed_env_prefixes: TS DataMap helper / accessor
+
+## SessionManager port-specific
+
+signalwire.core.security.session_manager.SessionManager.cleanup: TS SessionManager helper — richer accessor for session storage and debug tokens
+signalwire.core.security.session_manager.SessionManager.delete_session_metadata: TS SessionManager helper — richer accessor for session storage and debug tokens
+
+## RestError port-specific
+
+signalwire.rest._base.RestError: TS RestError helper or status accessor
+signalwire.rest._base.RestError.__init__: TS RestError helper or status accessor

--- a/PORT_OMISSIONS.md
+++ b/PORT_OMISSIONS.md
@@ -1,0 +1,470 @@
+# PORT_OMISSIONS.md
+
+This file enumerates every public symbol from `signalwire-python` that the
+TypeScript port does NOT implement, with a one-line rationale per symbol.
+
+Each line has the form:
+
+    <fully.qualified.python.symbol>: <rationale>
+
+The `diff_port_surface.py` tool treats every listed symbol as an
+intentional omission. Unlisted missing symbols fail the audit.
+
+When a symbol is prefixed with `not_yet_implemented:` the omission is
+temporary and a future PR will add it; every other rationale is permanent.
+
+---
+
+## Search subsystem (native RAG / pgvector)
+
+The native vector-search / RAG pipeline is server-side infrastructure:
+document ingestion, embedding indices, migration tooling, PG-vector
+backend, search CLI. The TypeScript SDK exposes the entry-point skill
+(`NativeVectorSearchSkill`) for network-mode queries but does not port
+the Python-specific server/CLI tooling. See `PORTING_GUIDE.md § What to Skip`.
+
+## Search subsystem (native RAG / pgvector)
+
+signalwire.search.document_processor.DocumentProcessor: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.document_processor.DocumentProcessor.__init__: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.document_processor.DocumentProcessor.create_chunks: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.index_builder.IndexBuilder: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.index_builder.IndexBuilder.__init__: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.index_builder.IndexBuilder.build_index: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.index_builder.IndexBuilder.build_index_from_sources: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.index_builder.IndexBuilder.validate_index: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.migration.SearchIndexMigrator: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.migration.SearchIndexMigrator.__init__: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.migration.SearchIndexMigrator.get_index_info: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.migration.SearchIndexMigrator.migrate_pgvector_to_sqlite: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.migration.SearchIndexMigrator.migrate_sqlite_to_pgvector: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.models.resolve_model_alias: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorBackend: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorBackend.__init__: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorBackend.close: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorBackend.create_schema: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorBackend.delete_collection: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorBackend.get_stats: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorBackend.list_collections: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorBackend.store_chunks: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorSearchBackend: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorSearchBackend.__init__: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorSearchBackend.close: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorSearchBackend.fetch_candidates: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorSearchBackend.get_stats: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.pgvector_backend.PgVectorSearchBackend.search: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.query_processor.detect_language: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.query_processor.ensure_nltk_resources: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.query_processor.get_synonyms: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.query_processor.get_wordnet_pos: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.query_processor.load_spacy_model: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.query_processor.preprocess_document_content: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.query_processor.preprocess_query: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.query_processor.remove_duplicate_words: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.query_processor.set_global_model: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.query_processor.vectorize_query: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.search_engine.SearchEngine: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.search_engine.SearchEngine.__init__: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.search_engine.SearchEngine.get_stats: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.search_engine.SearchEngine.search: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.search_service.SearchService: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.search_service.SearchService.__init__: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.search_service.SearchService.search_direct: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.search_service.SearchService.start: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+signalwire.search.search_service.SearchService.stop: deliberately omitted: native RAG/pgvector server subsystem not ported (see PORTING_GUIDE.md § What to Skip)
+
+## Bedrock (AWS-specific agent)
+
+signalwire.agents.bedrock.BedrockAgent: deliberately omitted: AWS Bedrock agent belongs to a Python-specific cloud path (see PORTING_GUIDE.md § What to Skip)
+signalwire.agents.bedrock.BedrockAgent.__init__: deliberately omitted: AWS Bedrock agent belongs to a Python-specific cloud path (see PORTING_GUIDE.md § What to Skip)
+signalwire.agents.bedrock.BedrockAgent.__repr__: deliberately omitted: AWS Bedrock agent belongs to a Python-specific cloud path (see PORTING_GUIDE.md § What to Skip)
+signalwire.agents.bedrock.BedrockAgent.set_inference_params: deliberately omitted: AWS Bedrock agent belongs to a Python-specific cloud path (see PORTING_GUIDE.md § What to Skip)
+signalwire.agents.bedrock.BedrockAgent.set_llm_model: deliberately omitted: AWS Bedrock agent belongs to a Python-specific cloud path (see PORTING_GUIDE.md § What to Skip)
+signalwire.agents.bedrock.BedrockAgent.set_llm_temperature: deliberately omitted: AWS Bedrock agent belongs to a Python-specific cloud path (see PORTING_GUIDE.md § What to Skip)
+signalwire.agents.bedrock.BedrockAgent.set_post_prompt_llm_params: deliberately omitted: AWS Bedrock agent belongs to a Python-specific cloud path (see PORTING_GUIDE.md § What to Skip)
+signalwire.agents.bedrock.BedrockAgent.set_prompt_llm_params: deliberately omitted: AWS Bedrock agent belongs to a Python-specific cloud path (see PORTING_GUIDE.md § What to Skip)
+signalwire.agents.bedrock.BedrockAgent.set_voice: deliberately omitted: AWS Bedrock agent belongs to a Python-specific cloud path (see PORTING_GUIDE.md § What to Skip)
+
+## CLI: init_project
+
+signalwire.cli.init_project.Colors: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.ProjectGenerator: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.ProjectGenerator.__init__: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.ProjectGenerator.generate: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.generate_password: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.get_agent_template: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.get_app_template: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.get_env_credentials: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.get_readme_template: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.get_test_template: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.get_web_index_template: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.main: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.mask_token: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.print_error: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.print_step: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.print_success: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.print_warning: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.prompt: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.prompt_multiselect: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.prompt_select: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.prompt_yes_no: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.run_interactive: deliberately omitted: Python-specific project scaffolding CLI
+signalwire.cli.init_project.run_quick: deliberately omitted: Python-specific project scaffolding CLI
+
+## CLI: dokku
+
+signalwire.cli.dokku.Colors: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.DokkuProjectGenerator: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.DokkuProjectGenerator.__init__: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.DokkuProjectGenerator.generate: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.cmd_config: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.cmd_deploy: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.cmd_init: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.cmd_logs: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.cmd_scale: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.generate_password: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.main: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.print_error: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.print_header: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.print_step: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.print_success: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.print_warning: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.prompt: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+signalwire.cli.dokku.prompt_yes_no: deliberately omitted: Dokku deployment CLI is Python-specific tooling
+
+## CLI: simulation / mock env
+
+signalwire.cli.simulation.data_generation.adapt_for_call_type: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_generation.generate_comprehensive_post_data: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_generation.generate_fake_node_id: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_generation.generate_fake_sip_from: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_generation.generate_fake_sip_to: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_generation.generate_fake_swml_post_data: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_generation.generate_fake_uuid: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_generation.generate_minimal_post_data: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_overrides.apply_convenience_mappings: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_overrides.apply_overrides: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_overrides.parse_value: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.data_overrides.set_nested_value: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockHeaders: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockHeaders.__contains__: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockHeaders.__getitem__: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockHeaders.__init__: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockHeaders.get: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockHeaders.items: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockHeaders.keys: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockHeaders.values: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockQueryParams: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockQueryParams.__contains__: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockQueryParams.__getitem__: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockQueryParams.__init__: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockQueryParams.get: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockQueryParams.items: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockQueryParams.keys: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockQueryParams.values: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockRequest: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockRequest.__init__: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockRequest.body: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockRequest.client: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockRequest.json: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockURL: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockURL.__init__: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.MockURL.__str__: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.ServerlessSimulator: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.ServerlessSimulator.__init__: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.ServerlessSimulator.activate: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.ServerlessSimulator.add_override: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.ServerlessSimulator.deactivate: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.ServerlessSimulator.get_current_env: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.create_mock_request: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+signalwire.cli.simulation.mock_env.load_env_file: deliberately omitted: Python-specific request simulation helpers used only by the Python swaig-test CLI
+
+## CLI: agent/service/argparse loaders
+
+signalwire.cli.core.agent_loader.discover_agents_in_file: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.agent_loader.discover_services_in_file: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.agent_loader.load_agent_from_file: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.agent_loader.load_service_from_file: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.argparse_helpers.CustomArgumentParser: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.argparse_helpers.CustomArgumentParser.__init__: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.argparse_helpers.CustomArgumentParser.error: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.argparse_helpers.CustomArgumentParser.parse_args: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.argparse_helpers.CustomArgumentParser.print_usage: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.argparse_helpers.parse_function_arguments: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.dynamic_config.apply_dynamic_config: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.service_loader.ServiceCapture: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.service_loader.ServiceCapture.__init__: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.service_loader.ServiceCapture.capture: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.service_loader.discover_agents_in_file: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.service_loader.load_agent_from_file: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.service_loader.load_and_simulate_service: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+signalwire.cli.core.service_loader.simulate_request_to_service: deliberately omitted: Python-specific dynamic-import loaders (argparse_helpers, agent_loader, service_loader, dynamic_config)
+
+## CLI: build_search
+
+signalwire.cli.build_search.console_entry_point: deliberately omitted: build_search CLI is tied to the Python native RAG pipeline
+signalwire.cli.build_search.main: deliberately omitted: build_search CLI is tied to the Python native RAG pipeline
+signalwire.cli.build_search.migrate_command: deliberately omitted: build_search CLI is tied to the Python native RAG pipeline
+signalwire.cli.build_search.remote_command: deliberately omitted: build_search CLI is tied to the Python native RAG pipeline
+signalwire.cli.build_search.search_command: deliberately omitted: build_search CLI is tied to the Python native RAG pipeline
+signalwire.cli.build_search.validate_command: deliberately omitted: build_search CLI is tied to the Python native RAG pipeline
+
+## CLI: execution
+
+signalwire.cli.execution.datamap_exec.execute_datamap_function: deliberately omitted: Python-specific serverless exec helpers for swaig-test
+signalwire.cli.execution.datamap_exec.simple_template_expand: deliberately omitted: Python-specific serverless exec helpers for swaig-test
+signalwire.cli.execution.webhook_exec.execute_external_webhook_function: deliberately omitted: Python-specific serverless exec helpers for swaig-test
+
+## CLI: output formatting
+
+signalwire.cli.output.output_formatter.display_agent_tools: deliberately omitted: swaig-test output formatters used only by the Python CLI
+signalwire.cli.output.output_formatter.format_result: deliberately omitted: swaig-test output formatters used only by the Python CLI
+signalwire.cli.output.swml_dump.handle_dump_swml: deliberately omitted: swaig-test output formatters used only by the Python CLI
+signalwire.cli.output.swml_dump.setup_output_suppression: deliberately omitted: swaig-test output formatters used only by the Python CLI
+
+## CLI: test_swaig / swaig_test_wrapper
+
+signalwire.cli.swaig_test_wrapper.main: not_yet_implemented: the full swaig-test CLI is a candidate for a future port; the TS SDK ships a lighter swaig-test bin that covers the core call-simulation use case
+signalwire.cli.test_swaig.console_entry_point: not_yet_implemented: the full swaig-test CLI is a candidate for a future port; the TS SDK ships a lighter swaig-test bin that covers the core call-simulation use case
+signalwire.cli.test_swaig.main: not_yet_implemented: the full swaig-test CLI is a candidate for a future port; the TS SDK ships a lighter swaig-test bin that covers the core call-simulation use case
+signalwire.cli.test_swaig.print_help_examples: not_yet_implemented: the full swaig-test CLI is a candidate for a future port; the TS SDK ships a lighter swaig-test bin that covers the core call-simulation use case
+signalwire.cli.test_swaig.print_help_platforms: not_yet_implemented: the full swaig-test CLI is a candidate for a future port; the TS SDK ships a lighter swaig-test bin that covers the core call-simulation use case
+
+## CLI: type definitions
+
+signalwire.cli.types.AgentInfo: deliberately omitted: CLI type definitions used only by the Python CLI internals
+signalwire.cli.types.CallData: deliberately omitted: CLI type definitions used only by the Python CLI internals
+signalwire.cli.types.DataMapConfig: deliberately omitted: CLI type definitions used only by the Python CLI internals
+signalwire.cli.types.FunctionInfo: deliberately omitted: CLI type definitions used only by the Python CLI internals
+signalwire.cli.types.PostData: deliberately omitted: CLI type definitions used only by the Python CLI internals
+signalwire.cli.types.VarsData: deliberately omitted: CLI type definitions used only by the Python CLI internals
+
+## POM module (low-level PromptObjectModel)
+
+signalwire.pom.pom.PromptObjectModel: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.__init__: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.add_pom_as_subsection: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.add_section: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.find_section: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.from_json: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.from_yaml: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.render_markdown: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.render_xml: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.to_dict: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.to_json: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.PromptObjectModel.to_yaml: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.Section: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.Section.__init__: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.Section.add_body: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.Section.add_bullets: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.Section.add_subsection: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.Section.render_markdown: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.Section.render_xml: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom.Section.to_dict: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom_tool.detect_file_format: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom_tool.load_pom: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom_tool.main: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+signalwire.pom.pom_tool.render_pom: deliberately omitted: TS uses the higher-level PomBuilder/PomSection API rather than the low-level PromptObjectModel class (functionality is equivalent)
+
+## MCP gateway backend (server-side MCP router)
+
+signalwire.mcp_gateway.gateway_service.MCPGateway: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.gateway_service.MCPGateway.__init__: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.gateway_service.MCPGateway.run: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.gateway_service.MCPGateway.shutdown: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.gateway_service.main: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPClient: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPClient.__init__: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPClient.call_method: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPClient.call_tool: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPClient.get_tools: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPClient.start: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPClient.stop: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPManager: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPManager.__init__: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPManager.create_client: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPManager.get_service: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPManager.get_service_tools: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPManager.list_services: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPManager.shutdown: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPManager.validate_services: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPService: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPService.__hash__: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.mcp_manager.MCPService.__post_init__: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.Session: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.Session.is_alive: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.Session.is_expired: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.Session.touch: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.SessionManager: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.SessionManager.__init__: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.SessionManager.close_session: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.SessionManager.create_session: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.SessionManager.get_service_session_count: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.SessionManager.get_session: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.SessionManager.list_sessions: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+signalwire.mcp_gateway.session_manager.SessionManager.shutdown: deliberately omitted: standalone MCP gateway service process is a Python-only server component
+
+## Mixin class identifiers (folded into AgentBase in TS)
+
+signalwire.core.mixins.mcp_server_mixin.MCPServerMixin: TS architecture folds all mixins into AgentBase directly — mixin class names have no TS counterpart (the methods themselves are folded and present on AgentBase)
+signalwire.core.mixins.prompt_mixin.PromptMixin.contexts: TS architecture folds all mixins into AgentBase directly — mixin class names have no TS counterpart (the methods themselves are folded and present on AgentBase)
+signalwire.core.mixins.serverless_mixin.ServerlessMixin: TS architecture folds all mixins into AgentBase directly — mixin class names have no TS counterpart (the methods themselves are folded and present on AgentBase)
+signalwire.core.mixins.serverless_mixin.ServerlessMixin.handle_serverless_request: TS architecture folds all mixins into AgentBase directly — mixin class names have no TS counterpart (the methods themselves are folded and present on AgentBase)
+signalwire.core.mixins.tool_mixin.ToolMixin.tool: TS architecture folds all mixins into AgentBase directly — mixin class names have no TS counterpart (the methods themselves are folded and present on AgentBase)
+signalwire.core.mixins.web_mixin.WebMixin.on_request: TS architecture folds all mixins into AgentBase directly — mixin class names have no TS counterpart (the methods themselves are folded and present on AgentBase)
+
+## Web-search variants (skill_improved / skill_original)
+
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper.__init__: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper.extract_text_from_url: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper.search_and_scrape: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper.search_and_scrape_best: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper.search_google: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.WebSearchSkill: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.WebSearchSkill.get_global_data: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.WebSearchSkill.get_hints: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.WebSearchSkill.get_instance_key: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.WebSearchSkill.get_parameter_schema: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.WebSearchSkill.get_prompt_sections: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.WebSearchSkill.register_tools: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_improved.WebSearchSkill.setup: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.GoogleSearchScraper: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.GoogleSearchScraper.__init__: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.GoogleSearchScraper.extract_text_from_url: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.GoogleSearchScraper.search_and_scrape: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.GoogleSearchScraper.search_google: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.WebSearchSkill: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.WebSearchSkill.get_global_data: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.WebSearchSkill.get_hints: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.WebSearchSkill.get_instance_key: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.WebSearchSkill.get_parameter_schema: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.WebSearchSkill.get_prompt_sections: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.WebSearchSkill.register_tools: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+signalwire.skills.web_search.skill_original.WebSearchSkill.setup: deliberately omitted: Python ships `skill_improved` / `skill_original` historical variants alongside the canonical `skill`; TS keeps only the canonical one
+
+## Skills: explicit register_tools method
+
+signalwire.core.skill_base.SkillBase.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.api_ninjas_trivia.skill.ApiNinjasTriviaSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.claude_skills.skill.ClaudeSkillsSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.datasphere.skill.DataSphereSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.datasphere_serverless.skill.DataSphereServerlessSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.datetime.skill.DateTimeSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.google_maps.skill.GoogleMapsSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.info_gatherer.skill.InfoGathererSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.joke.skill.JokeSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.math.skill.MathSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.mcp_gateway.skill.MCPGatewaySkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.native_vector_search.skill.NativeVectorSearchSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.play_background_file.skill.PlayBackgroundFileSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.spider.skill.SpiderSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.weather_api.skill.WeatherApiSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.web_search.skill.WebSearchSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.web_search.skill_improved.WebSearchSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.web_search.skill_original.WebSearchSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+signalwire.skills.wikipedia_search.skill.WikipediaSearchSkill.register_tools: TS SkillBase handles tool registration automatically inside addSkill() via the getTools() contract; concrete skills do not need to expose a separate register_tools hook
+
+## Prefab tool-handler methods (closure-based in TS)
+
+signalwire.prefabs.concierge.ConciergeAgent.check_availability: prefab tool handler method — TS prefabs use closure-based tools rather than named methods; behavior is equivalent
+signalwire.prefabs.concierge.ConciergeAgent.get_directions: prefab tool handler method — TS prefabs use closure-based tools rather than named methods; behavior is equivalent
+signalwire.prefabs.faq_bot.FAQBotAgent.search_faqs: prefab tool handler method — TS prefabs use closure-based tools rather than named methods; behavior is equivalent
+signalwire.prefabs.info_gatherer.InfoGathererAgent.start_questions: prefab tool handler method — TS prefabs use closure-based tools rather than named methods; behavior is equivalent
+signalwire.prefabs.info_gatherer.InfoGathererAgent.submit_answer: prefab tool handler method — TS prefabs use closure-based tools rather than named methods; behavior is equivalent
+signalwire.prefabs.survey.SurveyAgent.log_response: prefab tool handler method — TS prefabs use closure-based tools rather than named methods; behavior is equivalent
+signalwire.prefabs.survey.SurveyAgent.validate_response: prefab tool handler method — TS prefabs use closure-based tools rather than named methods; behavior is equivalent
+
+## Python dunder methods (no TS equivalent)
+
+signalwire.agents.bedrock.BedrockAgent.__repr__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.cli.simulation.mock_env.MockHeaders.__contains__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.cli.simulation.mock_env.MockHeaders.__getitem__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.cli.simulation.mock_env.MockQueryParams.__contains__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.cli.simulation.mock_env.MockQueryParams.__getitem__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.core.swaig_function.SWAIGFunction.__call__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.core.swml_builder.SWMLBuilder.__getattr__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.core.swml_service.SWMLService.__getattr__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.relay.call.Call.__repr__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.relay.client.RelayClient.__aenter__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.relay.client.RelayClient.__aexit__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.relay.client.RelayClient.__del__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.relay.message.Message.__repr__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.rest._pagination.PaginatedIterator.__iter__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+signalwire.rest._pagination.PaginatedIterator.__next__: Python-specific dunder method with no idiomatic TS equivalent (constructor, iterator, context-manager, and stringification protocols are handled by built-in TS features)
+
+## Individual omissions (case-by-case)
+
+signalwire.RestClient: TS exports the RestClient class directly (`import { RestClient } from "@signalwire/sdk"`); no lazy-import factory wrapper needed
+signalwire.core.agent.prompt.manager.PromptManager.get_contexts: not_yet_implemented: PromptManager currently exposes prompt text but not the contexts map; add a getContexts() accessor in a future PR
+signalwire.core.agent.prompt.manager.PromptManager.get_raw_prompt: not_yet_implemented: expose raw-prompt accessor in a future PR
+signalwire.core.agent.tools.decorator.ToolDecorator: deliberately omitted: Python uses decorators for tool registration; TS uses imperative defineTool() instead, which is idiomatic for TypeScript
+signalwire.core.agent.tools.decorator.ToolDecorator.create_class_decorator: deliberately omitted: see ToolDecorator rationale
+signalwire.core.agent.tools.decorator.ToolDecorator.create_instance_decorator: deliberately omitted: see ToolDecorator rationale
+signalwire.core.agent.tools.registry.ToolRegistry.get_all_functions: not_yet_implemented: expose on a registry accessor in a future PR; today the tool list is accessible via AgentBase.getTools()
+signalwire.core.agent.tools.registry.ToolRegistry.get_function: not_yet_implemented: accessible today as AgentBase.getTool(); registry-level API could be added later
+signalwire.core.agent.tools.registry.ToolRegistry.has_function: not_yet_implemented: derivable from AgentBase.getTool(); registry-level predicate could be added later
+signalwire.core.agent.tools.registry.ToolRegistry.register_class_decorated_tools: deliberately omitted: TS does not use decorator-based tool registration (see ToolDecorator)
+signalwire.core.agent.tools.registry.ToolRegistry.remove_function: not_yet_implemented: remove-by-name not yet exposed; add in a future PR
+signalwire.core.auth_handler.AuthHandler.flask_decorator: deliberately omitted: Flask-specific integration; TS ships Hono-native middleware via AgentBase.getApp() instead
+signalwire.core.auth_handler.AuthHandler.get_fastapi_dependency: deliberately omitted: FastAPI-specific integration; TS ships Hono-native middleware
+signalwire.core.logging_config.configure_logging: TS uses Logger module-level configuration (setGlobalLogLevel / setGlobalLogFormat / resetLoggingConfiguration); no top-level configure_logging wrapper needed
+signalwire.core.security_config.SecurityConfig.get_cors_config: not_yet_implemented: SecurityConfig exposes SSL + auth today; CORS helpers can be added in a follow-up
+signalwire.core.security_config.SecurityConfig.get_security_headers: not_yet_implemented: TS applies security headers in WebService directly; centralized helper not yet ported
+signalwire.core.security_config.SecurityConfig.get_ssl_context_kwargs: deliberately omitted: TS uses SslConfig.getServerOptions() for node:https; kwargs translation is Python-specific
+signalwire.core.security_config.SecurityConfig.get_url_scheme: not_yet_implemented: trivial to add (sslEnabled ? "https" : "http"); follow-up PR
+signalwire.core.security_config.SecurityConfig.load_from_env: TS SecurityConfig loads from env in its constructor; no separate load_from_env classmethod needed
+signalwire.core.security_config.SecurityConfig.log_config: not_yet_implemented: add a diagnostic logger in a follow-up PR
+signalwire.core.security_config.SecurityConfig.should_allow_host: not_yet_implemented: host-allowlist check not yet exposed; add when needed
+signalwire.core.swml_builder.SWMLBuilder.ai: not_yet_implemented: SwmlBuilder today uses addVerb(); dedicated .ai() convenience wrapper can be added later
+signalwire.core.swml_builder.SWMLBuilder.answer: not_yet_implemented: same as .ai() — future convenience wrapper
+signalwire.core.swml_builder.SWMLBuilder.hangup: not_yet_implemented: same as .ai() — future convenience wrapper
+signalwire.core.swml_builder.SWMLBuilder.play: not_yet_implemented: same as .ai() — future convenience wrapper
+signalwire.core.swml_renderer.SwmlRenderer: deliberately omitted: TS folds SWML rendering into AgentBase.renderSwml() / SWMLService.render() — no free-standing SwmlRenderer class needed
+signalwire.core.swml_renderer.SwmlRenderer.render_function_response_swml: deliberately omitted: see SwmlRenderer rationale
+signalwire.core.swml_renderer.SwmlRenderer.render_swml: deliberately omitted: see SwmlRenderer rationale
+signalwire.relay.call.Call.pass_: deliberately omitted: Python uses `pass_` because `pass` is a reserved word; TS uses `pass()` directly which maps to `pass` in Python (enumerator emits it under the TS name)
+signalwire.rest._base.SignalWireRestError: TS consolidates to a single RestError class exported from @signalwire/sdk; SignalWireRestError is an alias that diverges only by class name
+signalwire.rest._base.SignalWireRestError.__init__: see SignalWireRestError rationale
+signalwire.rest._pagination.PaginatedIterator: TS uses the paginate() / paginateAll() async generator helpers instead of a class-based iterator (functionally equivalent; more idiomatic for JS)
+signalwire.rest._pagination.PaginatedIterator.__init__: see PaginatedIterator rationale
+signalwire.rest.call_handler.PhoneCallHandler: TS exports PhoneCallHandler as a string literal type rather than a Python-style enum class; the value set (flow, cxml, webhook, relay) is the same
+signalwire.rest.namespaces.fabric.AutoMaterializedWebhook: deliberately omitted: TS uses the AutoMaterializedWebhookResource alias to avoid collision with the TS string literal type of the same idea; the Resource class covers the create() flow
+signalwire.rest.namespaces.fabric.AutoMaterializedWebhook.create: see AutoMaterializedWebhook rationale
+signalwire.skills.google_maps.skill.GoogleMapsClient: deliberately omitted: GoogleMapsClient is a Python-only helper class; TS GoogleMapsSkill calls the Maps HTTP API directly via fetch
+signalwire.skills.google_maps.skill.GoogleMapsClient.__init__: see GoogleMapsClient rationale
+signalwire.skills.google_maps.skill.GoogleMapsClient.compute_route: see GoogleMapsClient rationale
+signalwire.skills.google_maps.skill.GoogleMapsClient.validate_address: see GoogleMapsClient rationale
+signalwire.skills.mcp_gateway.skill.MCPGatewaySkill: TS spelling is McpGatewaySkill (camelCase initialism); TS diff enumerator records it under the TS name — see PORT_ADDITIONS.md
+signalwire.skills.mcp_gateway.skill.MCPGatewaySkill.get_global_data: see MCPGatewaySkill rationale
+signalwire.skills.mcp_gateway.skill.MCPGatewaySkill.get_hints: see MCPGatewaySkill rationale
+signalwire.skills.mcp_gateway.skill.MCPGatewaySkill.get_parameter_schema: see MCPGatewaySkill rationale
+signalwire.skills.mcp_gateway.skill.MCPGatewaySkill.get_prompt_sections: see MCPGatewaySkill rationale
+signalwire.skills.mcp_gateway.skill.MCPGatewaySkill.setup: see MCPGatewaySkill rationale
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill: TS spelling is SwmlTransferSkill (camelCase); see PORT_ADDITIONS.md for the port-side alias
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.get_hints: see SWMLTransferSkill rationale
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.get_instance_key: see SWMLTransferSkill rationale
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.get_parameter_schema: see SWMLTransferSkill rationale
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.get_prompt_sections: see SWMLTransferSkill rationale
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.setup: see SWMLTransferSkill rationale
+signalwire.skills.web_search.skill.GoogleSearchScraper: deliberately omitted: Python Google-scrape helper class; TS WebSearchSkill uses the official Google Custom Search API via fetch and does not scrape HTML directly
+signalwire.skills.web_search.skill.GoogleSearchScraper.__init__: see GoogleSearchScraper rationale
+signalwire.skills.web_search.skill.GoogleSearchScraper.extract_html_content: see GoogleSearchScraper rationale
+signalwire.skills.web_search.skill.GoogleSearchScraper.extract_reddit_content: see GoogleSearchScraper rationale
+signalwire.skills.web_search.skill.GoogleSearchScraper.extract_text_from_url: see GoogleSearchScraper rationale
+signalwire.skills.web_search.skill.GoogleSearchScraper.is_reddit_url: see GoogleSearchScraper rationale
+signalwire.skills.web_search.skill.GoogleSearchScraper.search_and_scrape: see GoogleSearchScraper rationale
+signalwire.skills.web_search.skill.GoogleSearchScraper.search_and_scrape_best: see GoogleSearchScraper rationale
+signalwire.skills.web_search.skill.GoogleSearchScraper.search_google: see GoogleSearchScraper rationale
+signalwire.utils.is_serverless_mode: TS uses ServerlessAdapter.detectPlatform() instead (returns "lambda" | "gcf" | "azure" | null); boolean helper not needed
+signalwire.utils.schema_utils.SchemaUtils.full_validation_available: deliberately omitted: Python boolean flag indicating whether jsonschema is installed; TS always has Ajv, so the flag is always true
+signalwire.utils.schema_utils.SchemaUtils.generate_method_body: deliberately omitted: Python code-generation helper used by generateVerbTypes.ts; TS emits the generated file directly rather than via a SchemaUtils method
+signalwire.utils.schema_utils.SchemaUtils.generate_method_signature: deliberately omitted: see generate_method_body rationale
+signalwire.utils.schema_utils.SchemaUtils.get_all_verb_names: not_yet_implemented: trivial convenience accessor; can be added in a follow-up
+signalwire.utils.schema_utils.SchemaUtils.get_verb_parameters: not_yet_implemented: convenience accessor; add when needed
+signalwire.utils.schema_utils.SchemaUtils.load_schema: TS SchemaUtils loads schema in the constructor (see SchemaUtils constructor); no separate load_schema classmethod needed
+signalwire.utils.schema_utils.SchemaUtils.validate_document: TS SchemaUtils uses validate() which takes the same shape (string | object); method name differs
+signalwire.utils.schema_utils.SchemaValidationError: TS uses plain Error subclasses; no dedicated SchemaValidationError class needed — see PORT_ADDITIONS.md for RestError / AjvError equivalents
+signalwire.utils.schema_utils.SchemaValidationError.__init__: see SchemaValidationError rationale
+signalwire.utils.url_validator.validate_url: TS validateUrl lives in SecurityUtils, not in a separate url_validator module — see PORT_ADDITIONS.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.14.0",
         "@types/ws": "^8.5.10",
+        "tsx": "^4.21.0",
         "typescript": "^5.5.0",
         "vitest": "^4.1.5"
       },
@@ -62,6 +63,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -205,9 +648,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -225,9 +665,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -245,9 +682,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -265,9 +699,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -285,9 +716,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -305,9 +733,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,6 +1224,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -872,6 +1339,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/hono": {
@@ -1087,9 +1567,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1111,9 +1588,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1135,9 +1609,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1159,9 +1630,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1383,6 +1851,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.16",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
@@ -1505,6 +1983,26 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.14.0",
     "@types/ws": "^8.5.10",
+    "tsx": "^4.21.0",
     "typescript": "^5.5.0",
     "vitest": "^4.1.5"
   }

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,0 +1,1938 @@
+{
+  "version": "1",
+  "generated_from": "signalwire-typescript @ e171e47c9535ea8856c2cd4b01d159df6ebd954f",
+  "typescript_version": "5.9.3",
+  "modules": {
+    "signalwire": {
+      "classes": {},
+      "functions": [
+        "add_skill_directory",
+        "list_skills",
+        "list_skills_with_params",
+        "register_skill",
+        "run_agent",
+        "start_agent"
+      ]
+    },
+    "signalwire.agent_server": {
+      "classes": {
+        "AgentServer": [
+          "__init__",
+          "get_agent",
+          "get_agents",
+          "get_app",
+          "register",
+          "register_global_routing_callback",
+          "register_sip_username",
+          "rtc_session",
+          "run",
+          "serve_static_files",
+          "setup_sip_routing",
+          "unregister"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.cli.core.agent_loader": {
+      "classes": {},
+      "functions": [
+        "list_agents",
+        "load_agent"
+      ]
+    },
+    "signalwire.cli.simulation.mock_env": {
+      "classes": {},
+      "functions": [
+        "generate_fake_post_data",
+        "generate_minimal_post_data"
+      ]
+    },
+    "signalwire.core.agent.prompt.manager": {
+      "classes": {
+        "PromptManager": [
+          "__init__",
+          "add_section",
+          "add_subsection",
+          "add_to_section",
+          "define_contexts",
+          "get_pom_builder",
+          "get_post_prompt",
+          "get_prompt",
+          "has_section",
+          "prompt_add_section",
+          "prompt_add_subsection",
+          "prompt_add_to_section",
+          "prompt_has_section",
+          "set_post_prompt",
+          "set_prompt_pom",
+          "set_prompt_text"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.agent.tools.registry": {
+      "classes": {
+        "ToolRegistry": [
+          "__init__",
+          "define_tool",
+          "register_swaig_function"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.agent.tools.type_inference": {
+      "classes": {},
+      "functions": [
+        "create_typed_handler_wrapper",
+        "infer_schema",
+        "parse_function_params"
+      ]
+    },
+    "signalwire.core.agent_base": {
+      "classes": {
+        "AgentBase": [
+          "__init__",
+          "add_answer_verb",
+          "add_post_ai_verb",
+          "add_post_answer_verb",
+          "add_pre_answer_verb",
+          "add_skill_by_name",
+          "add_swaig_query_params",
+          "auto_map_sip_usernames",
+          "clear_post_ai_verbs",
+          "clear_post_answer_verbs",
+          "clear_pre_answer_verbs",
+          "clear_swaig_query_params",
+          "define_typed_tool",
+          "enable_sip_routing",
+          "extract_sip_username",
+          "get_full_url",
+          "get_mcp_servers",
+          "get_name",
+          "get_prompt_pom",
+          "get_registered_tools",
+          "get_tool",
+          "get_tools",
+          "handle_mcp_request",
+          "is_mcp_server_enabled",
+          "native_functions",
+          "on_debug_event",
+          "on_summary",
+          "prompt_manager",
+          "register_sip_username",
+          "remove_skill_by_name",
+          "render_swml",
+          "run_serverless",
+          "set_post_prompt_url",
+          "set_web_hook_url",
+          "skill_manager"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.auth_handler": {
+      "classes": {
+        "AuthHandler": [
+          "__init__",
+          "express_middleware",
+          "get_auth_info",
+          "has_api_key_auth",
+          "has_basic_auth",
+          "has_bearer_auth",
+          "middleware",
+          "validate",
+          "verify_api_key",
+          "verify_basic_auth",
+          "verify_bearer_token"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.config_loader": {
+      "classes": {
+        "ConfigLoader": [
+          "__init__",
+          "config_paths",
+          "find_config_file",
+          "get",
+          "get_all",
+          "get_config",
+          "get_config_file",
+          "get_file_path",
+          "get_section",
+          "has",
+          "has_config",
+          "interpolate_env_vars",
+          "load",
+          "load_from_object",
+          "merge_with_env",
+          "search",
+          "set",
+          "substitute_vars"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.contexts": {
+      "classes": {
+        "GatherQuestion": [
+          "__init__",
+          "to_dict"
+        ],
+        "GatherInfo": [
+          "__init__",
+          "add_question",
+          "get_completion_action",
+          "get_questions",
+          "to_dict"
+        ],
+        "Step": [
+          "__init__",
+          "add_bullets",
+          "add_gather_question",
+          "add_section",
+          "clear_sections",
+          "get_gather_info",
+          "get_step_valid_contexts",
+          "get_valid_steps",
+          "set_end",
+          "set_functions",
+          "set_gather_info",
+          "set_reset_consolidate",
+          "set_reset_full_reset",
+          "set_reset_system_prompt",
+          "set_reset_user_prompt",
+          "set_skip_to_next_step",
+          "set_skip_user_turn",
+          "set_step_criteria",
+          "set_text",
+          "set_valid_contexts",
+          "set_valid_steps",
+          "to_dict"
+        ],
+        "Context": [
+          "__init__",
+          "add_bullets",
+          "add_enter_filler",
+          "add_exit_filler",
+          "add_section",
+          "add_step",
+          "add_system_bullets",
+          "add_system_section",
+          "get_initial_step",
+          "get_step",
+          "get_step_order",
+          "get_steps",
+          "get_valid_contexts",
+          "move_step",
+          "remove_step",
+          "set_consolidate",
+          "set_enter_fillers",
+          "set_exit_fillers",
+          "set_full_reset",
+          "set_initial_step",
+          "set_isolated",
+          "set_post_prompt",
+          "set_prompt",
+          "set_system_prompt",
+          "set_user_prompt",
+          "set_valid_contexts",
+          "set_valid_steps",
+          "to_dict"
+        ],
+        "ContextBuilder": [
+          "__init__",
+          "add_context",
+          "attach_agent",
+          "get_context",
+          "reset",
+          "to_dict",
+          "validate"
+        ]
+      },
+      "functions": [
+        "create_simple_context"
+      ]
+    },
+    "signalwire.core.data_map": {
+      "classes": {
+        "DataMap": [
+          "__init__",
+          "body",
+          "description",
+          "enable_env_expansion",
+          "error_keys",
+          "expression",
+          "fallback_output",
+          "foreach",
+          "global_error_keys",
+          "output",
+          "parameter",
+          "params",
+          "purpose",
+          "register_with_agent",
+          "set_allowed_env_prefixes",
+          "to_swaig_function",
+          "webhook",
+          "webhook_expressions"
+        ]
+      },
+      "functions": [
+        "create_expression_tool",
+        "create_simple_api_tool",
+        "get_allowed_env_prefixes",
+        "set_allowed_env_prefixes"
+      ]
+    },
+    "signalwire.core.function_result": {
+      "classes": {
+        "FunctionResult": [
+          "__init__",
+          "add_action",
+          "add_actions",
+          "add_dynamic_hints",
+          "clear_dynamic_hints",
+          "connect",
+          "create_payment_action",
+          "create_payment_parameter",
+          "create_payment_prompt",
+          "enable_extensive_data",
+          "enable_functions_on_timeout",
+          "execute_rpc",
+          "execute_swml",
+          "hangup",
+          "hold",
+          "join_conference",
+          "join_room",
+          "pay",
+          "play_background_file",
+          "record_call",
+          "remove_global_data",
+          "remove_metadata",
+          "replace_in_history",
+          "rpc_ai_message",
+          "rpc_ai_unhold",
+          "rpc_dial",
+          "say",
+          "send_sms",
+          "set_end_of_speech_timeout",
+          "set_metadata",
+          "set_post_process",
+          "set_response",
+          "set_speech_event_timeout",
+          "simulate_user_input",
+          "sip_refer",
+          "stop",
+          "stop_background_file",
+          "stop_record_call",
+          "stop_tap",
+          "switch_context",
+          "swml_change_context",
+          "swml_change_step",
+          "swml_transfer",
+          "swml_user_event",
+          "tap",
+          "to_dict",
+          "toggle_functions",
+          "update_global_data",
+          "update_settings",
+          "wait_for_user"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.logging_config": {
+      "classes": {
+        "Logger": [
+          "__init__",
+          "bind",
+          "debug",
+          "error",
+          "info",
+          "warn"
+        ]
+      },
+      "functions": [
+        "get_execution_mode",
+        "get_logger",
+        "reset_logging_configuration",
+        "set_global_log_color",
+        "set_global_log_format",
+        "set_global_log_level",
+        "set_global_log_stream",
+        "strip_control_chars",
+        "suppress_all_logs"
+      ]
+    },
+    "signalwire.core.mixins.ai_config_mixin": {
+      "classes": {
+        "AIConfigMixin": [
+          "add_function_include",
+          "add_hint",
+          "add_hints",
+          "add_internal_filler",
+          "add_language",
+          "add_mcp_server",
+          "add_pattern_hint",
+          "add_pronunciation",
+          "enable_debug_events",
+          "enable_mcp_server",
+          "set_function_includes",
+          "set_global_data",
+          "set_internal_fillers",
+          "set_languages",
+          "set_native_functions",
+          "set_param",
+          "set_params",
+          "set_post_prompt_llm_params",
+          "set_prompt_llm_params",
+          "set_pronunciations",
+          "update_global_data"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.mixins.auth_mixin": {
+      "classes": {
+        "AuthMixin": [
+          "get_basic_auth_credentials",
+          "validate_basic_auth"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.mixins.prompt_mixin": {
+      "classes": {
+        "PromptMixin": [
+          "define_contexts",
+          "get_post_prompt",
+          "get_prompt",
+          "prompt_add_section",
+          "prompt_add_subsection",
+          "prompt_add_to_section",
+          "prompt_has_section",
+          "reset_contexts",
+          "set_post_prompt",
+          "set_prompt_pom",
+          "set_prompt_text"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.mixins.serverless_mixin": {
+      "classes": {
+        "ServerlessAdapter": [
+          "__init__",
+          "create_azure_handler",
+          "create_gcf_handler",
+          "create_lambda_handler",
+          "detect_platform",
+          "generate_url",
+          "get_platform",
+          "handle_request"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.mixins.skill_mixin": {
+      "classes": {
+        "SkillMixin": [
+          "add_skill",
+          "has_skill",
+          "list_skills",
+          "remove_skill"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.mixins.state_mixin": {
+      "classes": {
+        "StateMixin": [
+          "validate_tool_token"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.mixins.tool_mixin": {
+      "classes": {
+        "ToolMixin": [
+          "define_tool",
+          "define_tools",
+          "on_function_call",
+          "register_swaig_function"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.mixins.web_mixin": {
+      "classes": {
+        "WebMixin": [
+          "as_router",
+          "enable_debug_routes",
+          "get_app",
+          "manual_set_proxy_url",
+          "on_swml_request",
+          "register_routing_callback",
+          "run",
+          "serve",
+          "set_dynamic_config_callback",
+          "setup_graceful_shutdown"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.pom_builder": {
+      "classes": {
+        "PomSection": [
+          "__init__",
+          "add_subsection",
+          "render_markdown",
+          "render_xml",
+          "to_dict"
+        ],
+        "PomBuilder": [
+          "__init__",
+          "add_pom_as_subsection",
+          "add_section",
+          "add_subsection",
+          "add_to_section",
+          "find_section",
+          "from_sections",
+          "get_section",
+          "has_section",
+          "render_markdown",
+          "render_xml",
+          "reset",
+          "to_dict",
+          "to_json"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.security.session_manager": {
+      "classes": {
+        "SessionManager": [
+          "__init__",
+          "activate_session",
+          "cleanup",
+          "create_session",
+          "create_tool_token",
+          "debug_token",
+          "delete_session_metadata",
+          "end_session",
+          "generate_token",
+          "get_session_metadata",
+          "set_session_metadata",
+          "validate_token",
+          "validate_tool_token"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.security_config": {
+      "classes": {
+        "SecurityConfig": [
+          "__init__",
+          "get_basic_auth",
+          "validate_ssl_config"
+        ],
+        "SslConfig": [
+          "__init__",
+          "get_cert",
+          "get_hsts_header",
+          "get_key",
+          "get_server_options",
+          "hsts_middleware",
+          "is_configured"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.skill_base": {
+      "classes": {
+        "SkillBase": [
+          "__init__",
+          "cleanup",
+          "define_tool",
+          "get_agent",
+          "get_config",
+          "get_data_map_tools",
+          "get_global_data",
+          "get_hints",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "get_skill_data",
+          "get_skill_namespace",
+          "get_tools",
+          "has_all_env_vars",
+          "has_all_packages",
+          "is_initialized",
+          "mark_initialized",
+          "set_agent",
+          "setup",
+          "update_skill_data",
+          "validate_env_vars",
+          "validate_packages"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.skill_manager": {
+      "classes": {
+        "SkillManager": [
+          "__init__",
+          "clear",
+          "get_all_hints",
+          "get_all_prompt_sections",
+          "get_all_tools",
+          "get_loaded_skill_entries",
+          "get_merged_global_data",
+          "get_skill",
+          "has_skill",
+          "has_skill_by_key",
+          "list_loaded_skills",
+          "list_skill_keys",
+          "load_skill",
+          "load_skill_by_name",
+          "loaded_skills",
+          "remove_skill_by_name",
+          "size",
+          "unload_skill"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.swaig_function": {
+      "classes": {
+        "SWAIGFunction": [
+          "__init__",
+          "execute",
+          "to_swaig",
+          "validate_args"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.swml_builder": {
+      "classes": {
+        "SWMLBuilder": [
+          "__init__",
+          "add_section",
+          "add_verb",
+          "add_verb_to_section",
+          "build",
+          "document",
+          "get_document",
+          "get_schema_utils",
+          "render",
+          "render_document",
+          "reset",
+          "say",
+          "set_validation"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.swml_handler": {
+      "classes": {
+        "SWMLVerbHandler": [
+          "build_config",
+          "get_verb_name",
+          "validate_config"
+        ],
+        "AIVerbHandler": [
+          "build_config",
+          "get_verb_name",
+          "validate_config"
+        ],
+        "VerbHandlerRegistry": [
+          "__init__",
+          "get_handler",
+          "has_handler",
+          "register_handler"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.swml_service": {
+      "classes": {
+        "SWMLService": [
+          "__init__",
+          "add_section",
+          "add_verb",
+          "add_verb_to_section",
+          "as_router",
+          "extract_sip_username",
+          "full_validation_enabled",
+          "get_app",
+          "get_basic_auth_credentials",
+          "get_builder",
+          "get_document",
+          "manual_set_proxy_url",
+          "on_request",
+          "register_routing_callback",
+          "register_verb_handler",
+          "render_document",
+          "render_swml",
+          "reset_document",
+          "run",
+          "serve",
+          "set_on_request_callback",
+          "stop"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.livewire": {
+      "classes": {
+        "Agent": [
+          "__init__",
+          "llm_node",
+          "on_enter",
+          "on_exit",
+          "on_user_turn_completed",
+          "session",
+          "stt_node",
+          "tts_node",
+          "update_instructions",
+          "update_tools"
+        ],
+        "RunContext": [
+          "__init__",
+          "userdata"
+        ],
+        "AgentSession": [
+          "__init__",
+          "generate_reply",
+          "get_sw_agent",
+          "history",
+          "interrupt",
+          "say",
+          "start",
+          "update_agent",
+          "userdata"
+        ],
+        "AgentHandoff": [
+          "__init__"
+        ],
+        "StopResponse": [],
+        "ToolError": [],
+        "JobProcess": [
+          "__init__"
+        ],
+        "Room": [],
+        "JobContext": [
+          "__init__",
+          "connect",
+          "wait_for_participant"
+        ],
+        "WorkerOptions": [
+          "__init__"
+        ],
+        "ServerOptions": [
+          "__init__"
+        ],
+        "AgentServer": [
+          "__init__",
+          "get_agent",
+          "get_agents",
+          "register",
+          "register_global_routing_callback",
+          "register_sip_username",
+          "rtc_session",
+          "run",
+          "serve_static_files",
+          "setup_sip_routing",
+          "unregister"
+        ],
+        "InferenceSTT": [
+          "__init__"
+        ],
+        "InferenceLLM": [
+          "__init__"
+        ],
+        "InferenceTTS": [
+          "__init__"
+        ],
+        "ChatContext": [
+          "__init__",
+          "append"
+        ]
+      },
+      "functions": [
+        "define_agent",
+        "function_tool",
+        "handoff",
+        "run_app"
+      ]
+    },
+    "signalwire.livewire.plugins": {
+      "classes": {
+        "DeepgramSTT": [
+          "__init__"
+        ],
+        "OpenAILLM": [
+          "__init__"
+        ],
+        "CartesiaTTS": [
+          "__init__"
+        ],
+        "ElevenLabsTTS": [
+          "__init__"
+        ],
+        "SileroVAD": [
+          "__init__",
+          "load"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.prefabs.concierge": {
+      "classes": {
+        "ConciergeAgent": [
+          "__init__",
+          "define_tools",
+          "on_summary"
+        ]
+      },
+      "functions": [
+        "create_concierge_agent"
+      ]
+    },
+    "signalwire.prefabs.faq_bot": {
+      "classes": {
+        "FAQBotAgent": [
+          "__init__",
+          "define_tools",
+          "on_summary"
+        ]
+      },
+      "functions": [
+        "create_faq_bot_agent"
+      ]
+    },
+    "signalwire.prefabs.info_gatherer": {
+      "classes": {
+        "InfoGathererAgent": [
+          "__init__",
+          "define_tools",
+          "on_swml_request",
+          "set_question_callback"
+        ]
+      },
+      "functions": [
+        "create_info_gatherer_agent"
+      ]
+    },
+    "signalwire.prefabs.receptionist": {
+      "classes": {
+        "ReceptionistAgent": [
+          "__init__",
+          "define_tools",
+          "on_summary"
+        ]
+      },
+      "functions": [
+        "create_receptionist_agent"
+      ]
+    },
+    "signalwire.prefabs.survey": {
+      "classes": {
+        "SurveyAgent": [
+          "__init__",
+          "define_tools",
+          "on_summary"
+        ]
+      },
+      "functions": [
+        "create_survey_agent"
+      ]
+    },
+    "signalwire.relay.call": {
+      "classes": {
+        "Action": [
+          "__init__",
+          "is_done",
+          "wait"
+        ],
+        "PlayAction": [
+          "__init__",
+          "pause",
+          "resume",
+          "stop",
+          "volume"
+        ],
+        "RecordAction": [
+          "__init__",
+          "pause",
+          "resume",
+          "stop"
+        ],
+        "DetectAction": [
+          "__init__",
+          "stop"
+        ],
+        "CollectAction": [
+          "__init__",
+          "start_input_timers",
+          "stop",
+          "volume"
+        ],
+        "StandaloneCollectAction": [
+          "__init__",
+          "start_input_timers",
+          "stop"
+        ],
+        "FaxAction": [
+          "__init__",
+          "stop"
+        ],
+        "TapAction": [
+          "__init__",
+          "stop"
+        ],
+        "StreamAction": [
+          "__init__",
+          "stop"
+        ],
+        "PayAction": [
+          "__init__",
+          "stop"
+        ],
+        "TranscribeAction": [
+          "__init__",
+          "stop"
+        ],
+        "AIAction": [
+          "__init__",
+          "stop"
+        ],
+        "Call": [
+          "__init__",
+          "ai",
+          "ai_hold",
+          "ai_message",
+          "ai_unhold",
+          "amazon_bedrock",
+          "answer",
+          "bind_digit",
+          "clear_digit_bindings",
+          "collect",
+          "connect",
+          "denoise",
+          "denoise_stop",
+          "detect",
+          "disconnect",
+          "echo",
+          "hangup",
+          "hold",
+          "join_conference",
+          "join_room",
+          "leave_conference",
+          "leave_room",
+          "live_transcribe",
+          "live_translate",
+          "on",
+          "pass",
+          "pay",
+          "play",
+          "play_and_collect",
+          "queue_enter",
+          "queue_leave",
+          "receive_fax",
+          "record",
+          "refer",
+          "send_digits",
+          "send_fax",
+          "stream",
+          "tap",
+          "to_string",
+          "transcribe",
+          "transfer",
+          "unhold",
+          "user_event",
+          "wait_for",
+          "wait_for_ended"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.relay.client": {
+      "classes": {
+        "RelayClient": [
+          "__init__",
+          "connect",
+          "dial",
+          "disconnect",
+          "execute",
+          "on_call",
+          "on_message",
+          "receive",
+          "relay_protocol",
+          "run",
+          "send_message",
+          "unreceive"
+        ],
+        "RelayError": [
+          "__init__"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.relay.deferred": {
+      "classes": {},
+      "functions": [
+        "create_deferred",
+        "with_timeout"
+      ]
+    },
+    "signalwire.relay.event": {
+      "classes": {
+        "RelayEvent": [
+          "from_payload"
+        ],
+        "CallStateEvent": [
+          "from_payload"
+        ],
+        "CallReceiveEvent": [
+          "from_payload"
+        ],
+        "PlayEvent": [
+          "from_payload"
+        ],
+        "RecordEvent": [
+          "from_payload"
+        ],
+        "CollectEvent": [
+          "from_payload"
+        ],
+        "ConnectEvent": [
+          "from_payload"
+        ],
+        "DetectEvent": [
+          "from_payload"
+        ],
+        "FaxEvent": [
+          "from_payload"
+        ],
+        "TapEvent": [
+          "from_payload"
+        ],
+        "StreamEvent": [
+          "from_payload"
+        ],
+        "SendDigitsEvent": [
+          "from_payload"
+        ],
+        "DialEvent": [
+          "from_payload"
+        ],
+        "ReferEvent": [
+          "from_payload"
+        ],
+        "DenoiseEvent": [
+          "from_payload"
+        ],
+        "PayEvent": [
+          "from_payload"
+        ],
+        "QueueEvent": [
+          "from_payload"
+        ],
+        "EchoEvent": [
+          "from_payload"
+        ],
+        "TranscribeEvent": [
+          "from_payload"
+        ],
+        "HoldEvent": [
+          "from_payload"
+        ],
+        "ConferenceEvent": [
+          "from_payload"
+        ],
+        "CallingErrorEvent": [
+          "from_payload"
+        ],
+        "MessageReceiveEvent": [
+          "from_payload"
+        ],
+        "MessageStateEvent": [
+          "from_payload"
+        ]
+      },
+      "functions": [
+        "parse_event"
+      ]
+    },
+    "signalwire.relay.message": {
+      "classes": {
+        "Message": [
+          "__init__",
+          "is_done",
+          "on",
+          "result",
+          "to_string",
+          "wait"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.relay.normalize": {
+      "classes": {},
+      "functions": [
+        "normalize_device",
+        "normalize_device_plan",
+        "normalize_play_item",
+        "normalize_play_items"
+      ]
+    },
+    "signalwire.rest._base": {
+      "classes": {
+        "HttpClient": [
+          "__init__",
+          "delete",
+          "get",
+          "patch",
+          "post",
+          "put"
+        ],
+        "RestError": [
+          "__init__"
+        ],
+        "BaseResource": [
+          "__init__"
+        ],
+        "CrudResource": [
+          "create",
+          "delete",
+          "get",
+          "list",
+          "update"
+        ],
+        "CrudWithAddresses": [
+          "list_addresses"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest._pagination": {
+      "classes": {},
+      "functions": [
+        "paginate",
+        "paginate_all"
+      ]
+    },
+    "signalwire.rest.client": {
+      "classes": {
+        "RestClient": [
+          "__init__"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.addresses": {
+      "classes": {
+        "AddressesResource": [
+          "__init__",
+          "create",
+          "delete",
+          "get",
+          "list"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.calling": {
+      "classes": {
+        "CallingNamespace": [
+          "__init__",
+          "ai_hold",
+          "ai_message",
+          "ai_stop",
+          "ai_unhold",
+          "collect",
+          "collect_start_input_timers",
+          "collect_stop",
+          "denoise",
+          "denoise_stop",
+          "detect",
+          "detect_stop",
+          "dial",
+          "disconnect",
+          "end",
+          "live_transcribe",
+          "live_translate",
+          "play",
+          "play_pause",
+          "play_resume",
+          "play_stop",
+          "play_volume",
+          "receive_fax_stop",
+          "record",
+          "record_pause",
+          "record_resume",
+          "record_stop",
+          "refer",
+          "send_fax_stop",
+          "stream",
+          "stream_stop",
+          "tap",
+          "tap_stop",
+          "transcribe",
+          "transcribe_stop",
+          "transfer",
+          "update",
+          "user_event"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.chat": {
+      "classes": {
+        "ChatResource": [
+          "__init__",
+          "create_token"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.compat": {
+      "classes": {
+        "CompatAccounts": [
+          "__init__",
+          "create",
+          "get",
+          "list",
+          "update"
+        ],
+        "CompatCalls": [
+          "start_recording",
+          "start_stream",
+          "stop_stream",
+          "update",
+          "update_recording"
+        ],
+        "CompatMessages": [
+          "delete_media",
+          "get_media",
+          "list_media",
+          "update"
+        ],
+        "CompatFaxes": [
+          "delete_media",
+          "get_media",
+          "list_media",
+          "update"
+        ],
+        "CompatConferences": [
+          "delete_recording",
+          "get",
+          "get_participant",
+          "get_recording",
+          "list",
+          "list_participants",
+          "list_recordings",
+          "remove_participant",
+          "start_stream",
+          "stop_stream",
+          "update",
+          "update_participant",
+          "update_recording"
+        ],
+        "CompatPhoneNumbers": [
+          "__init__",
+          "delete",
+          "get",
+          "import_number",
+          "list",
+          "list_available_countries",
+          "purchase",
+          "search_local",
+          "search_toll_free",
+          "update"
+        ],
+        "CompatApplications": [
+          "update"
+        ],
+        "CompatLamlBins": [
+          "update"
+        ],
+        "CompatQueues": [
+          "dequeue_member",
+          "get_member",
+          "list_members",
+          "update"
+        ],
+        "CompatRecordings": [
+          "delete",
+          "get",
+          "list"
+        ],
+        "CompatTranscriptions": [
+          "delete",
+          "get",
+          "list"
+        ],
+        "CompatTokens": [
+          "create",
+          "delete",
+          "update"
+        ],
+        "CompatNamespace": [
+          "__init__"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.datasphere": {
+      "classes": {
+        "DatasphereDocuments": [
+          "__init__",
+          "delete_chunk",
+          "get_chunk",
+          "list_chunks",
+          "search"
+        ],
+        "DatasphereNamespace": [
+          "__init__"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.fabric": {
+      "classes": {
+        "FabricResource": [],
+        "FabricResourcePUT": [],
+        "CallFlowsResource": [
+          "deploy_version",
+          "list_addresses",
+          "list_versions"
+        ],
+        "ConferenceRoomsResource": [
+          "list_addresses"
+        ],
+        "SubscribersResource": [
+          "create_sip_endpoint",
+          "delete_sip_endpoint",
+          "get_sip_endpoint",
+          "list_sip_endpoints",
+          "update_sip_endpoint"
+        ],
+        "CxmlApplicationsResource": [
+          "create"
+        ],
+        "AutoMaterializedWebhookResource": [
+          "__init__",
+          "create"
+        ],
+        "SwmlWebhooksResource": [],
+        "CxmlWebhooksResource": [],
+        "GenericResources": [
+          "assign_domain_application",
+          "assign_phone_route",
+          "delete",
+          "get",
+          "list",
+          "list_addresses"
+        ],
+        "FabricAddresses": [
+          "get",
+          "list"
+        ],
+        "FabricTokens": [
+          "__init__",
+          "create_embed_token",
+          "create_guest_token",
+          "create_invite_token",
+          "create_subscriber_token",
+          "refresh_subscriber_token"
+        ],
+        "FabricNamespace": [
+          "__init__"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.imported_numbers": {
+      "classes": {
+        "ImportedNumbersResource": [
+          "__init__",
+          "create"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.logs": {
+      "classes": {
+        "MessageLogs": [
+          "get",
+          "list"
+        ],
+        "VoiceLogs": [
+          "get",
+          "list",
+          "list_events"
+        ],
+        "FaxLogs": [
+          "get",
+          "list"
+        ],
+        "ConferenceLogs": [
+          "list"
+        ],
+        "LogsNamespace": [
+          "__init__"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.lookup": {
+      "classes": {
+        "LookupResource": [
+          "__init__",
+          "phone_number"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.mfa": {
+      "classes": {
+        "MfaResource": [
+          "__init__",
+          "call",
+          "sms",
+          "verify"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.number_groups": {
+      "classes": {
+        "NumberGroupsResource": [
+          "__init__",
+          "add_membership",
+          "delete_membership",
+          "get_membership",
+          "list_memberships"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.phone_numbers": {
+      "classes": {
+        "PhoneNumbersResource": [
+          "__init__",
+          "create",
+          "search",
+          "set_ai_agent",
+          "set_call_flow",
+          "set_cxml_application",
+          "set_cxml_webhook",
+          "set_relay_application",
+          "set_relay_topic",
+          "set_swml_webhook",
+          "update"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.project": {
+      "classes": {
+        "ProjectTokens": [
+          "__init__",
+          "create",
+          "delete",
+          "update"
+        ],
+        "ProjectNamespace": [
+          "__init__"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.pubsub": {
+      "classes": {
+        "PubSubResource": [
+          "__init__",
+          "create_token"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.queues": {
+      "classes": {
+        "QueuesResource": [
+          "__init__",
+          "get_member",
+          "get_next_member",
+          "list_members"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.recordings": {
+      "classes": {
+        "RecordingsResource": [
+          "__init__",
+          "delete",
+          "get",
+          "list"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.registry": {
+      "classes": {
+        "RegistryBrands": [
+          "create",
+          "create_campaign",
+          "get",
+          "list",
+          "list_campaigns"
+        ],
+        "RegistryCampaigns": [
+          "create_order",
+          "get",
+          "list_numbers",
+          "list_orders",
+          "update"
+        ],
+        "RegistryOrders": [
+          "get"
+        ],
+        "RegistryNumbers": [
+          "delete"
+        ],
+        "RegistryNamespace": [
+          "__init__"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.short_codes": {
+      "classes": {
+        "ShortCodesResource": [
+          "__init__",
+          "get",
+          "list",
+          "update"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.sip_profile": {
+      "classes": {
+        "SipProfileResource": [
+          "__init__",
+          "get",
+          "update"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.verified_callers": {
+      "classes": {
+        "VerifiedCallersResource": [
+          "__init__",
+          "redial_verification",
+          "submit_verification"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.video": {
+      "classes": {
+        "VideoRooms": [
+          "create_stream",
+          "list_streams"
+        ],
+        "VideoRoomTokens": [
+          "create"
+        ],
+        "VideoRoomSessions": [
+          "get",
+          "list",
+          "list_events",
+          "list_members",
+          "list_recordings"
+        ],
+        "VideoRoomRecordings": [
+          "delete",
+          "get",
+          "list",
+          "list_events"
+        ],
+        "VideoConferences": [
+          "create_stream",
+          "list_conference_tokens",
+          "list_streams"
+        ],
+        "VideoConferenceTokens": [
+          "get",
+          "reset"
+        ],
+        "VideoStreams": [
+          "delete",
+          "get",
+          "update"
+        ],
+        "VideoNamespace": [
+          "__init__"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.skills.api_ninjas_trivia.skill": {
+      "classes": {
+        "ApiNinjasTriviaSkill": [
+          "__init__",
+          "get_hints",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.ask_claude.skill": {
+      "classes": {
+        "AskClaudeSkill": [
+          "get_parameter_schema",
+          "get_tools"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.claude_skills.skill": {
+      "classes": {
+        "ClaudeSkillsSkill": [
+          "get_hints",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.custom_skills.skill": {
+      "classes": {
+        "CustomSkillsSkill": [
+          "__init__",
+          "get_compilation_errors",
+          "get_parameter_schema",
+          "get_tools"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.datasphere.skill": {
+      "classes": {
+        "DataSphereSkill": [
+          "cleanup",
+          "get_global_data",
+          "get_hints",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.datasphere_serverless.skill": {
+      "classes": {
+        "DataSphereServerlessSkill": [
+          "get_data_map_tools",
+          "get_global_data",
+          "get_hints",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.datetime.skill": {
+      "classes": {
+        "DateTimeSkill": [
+          "get_hints",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.google_maps.skill": {
+      "classes": {
+        "GoogleMapsSkill": [
+          "get_hints",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.info_gatherer.skill": {
+      "classes": {
+        "InfoGathererSkill": [
+          "get_global_data",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.joke.skill": {
+      "classes": {
+        "JokeSkill": [
+          "get_global_data",
+          "get_hints",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.math.skill": {
+      "classes": {
+        "MathSkill": [
+          "get_hints",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.mcp_gateway.skill": {
+      "classes": {
+        "McpGatewaySkill": [
+          "get_global_data",
+          "get_hints",
+          "get_parameter_schema",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.native_vector_search.skill": {
+      "classes": {
+        "NativeVectorSearchSkill": [
+          "cleanup",
+          "get_global_data",
+          "get_hints",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.play_background_file.skill": {
+      "classes": {
+        "PlayBackgroundFileSkill": [
+          "__init__",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.registry": {
+      "classes": {
+        "SkillRegistry": [
+          "__init__",
+          "add_skill_directory",
+          "clear",
+          "create",
+          "discover_all",
+          "discover_skills",
+          "get_all_skills_schema",
+          "get_instance",
+          "get_search_paths",
+          "get_skill_class",
+          "get_skill_schema",
+          "has",
+          "list_all_skill_sources",
+          "list_registered",
+          "list_skills",
+          "lock",
+          "register_skill",
+          "reset_instance",
+          "size",
+          "unregister"
+        ]
+      },
+      "functions": [
+        "register_builtin_skills"
+      ]
+    },
+    "signalwire.skills.spider.skill": {
+      "classes": {
+        "SpiderSkill": [
+          "__init__",
+          "cleanup",
+          "get_hints",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.swml_transfer.skill": {
+      "classes": {
+        "SwmlTransferSkill": [
+          "get_hints",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.weather_api.skill": {
+      "classes": {
+        "WeatherApiSkill": [
+          "__init__",
+          "get_parameter_schema",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.skills.web_search.skill": {
+      "classes": {
+        "WebSearchSkill": [
+          "get_global_data",
+          "get_hints",
+          "get_instance_key",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "get_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill",
+        "extract_text_from_html"
+      ]
+    },
+    "signalwire.skills.wikipedia_search.skill": {
+      "classes": {
+        "WikipediaSearchSkill": [
+          "get_hints",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "get_tools",
+          "search_wiki",
+          "setup"
+        ]
+      },
+      "functions": [
+        "create_skill"
+      ]
+    },
+    "signalwire.utils": {
+      "classes": {},
+      "functions": [
+        "filter_sensitive_headers",
+        "is_private_ip",
+        "is_valid_hostname",
+        "redact_url",
+        "resolve_and_validate_url",
+        "safe_assign",
+        "validate_url"
+      ]
+    },
+    "signalwire.utils.schema_utils": {
+      "classes": {
+        "SchemaUtils": [
+          "__init__",
+          "clear_cache",
+          "get_cache_size",
+          "get_verb_description",
+          "get_verb_names",
+          "get_verb_properties",
+          "get_verb_required_properties",
+          "has_verb",
+          "validate",
+          "validate_verb"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.web.web_service": {
+      "classes": {
+        "WebService": [
+          "__init__",
+          "add_directory",
+          "get_app",
+          "remove_directory",
+          "ssl_config",
+          "start",
+          "stop"
+        ]
+      },
+      "functions": []
+    }
+  }
+}

--- a/scripts/enumerate-surface.ts
+++ b/scripts/enumerate-surface.ts
@@ -1,0 +1,796 @@
+#!/usr/bin/env node
+/**
+ * enumerate-surface.ts — emit a JSON snapshot of this SDK's public API.
+ *
+ * Walks `src/**\/*.ts` and produces `port_surface.json` in the same shape as
+ * the porting-sdk's `python_surface.json`. Class / method names are
+ * translated to the Python-reference form so the two files can be diffed
+ * directly:
+ *
+ *   - Class names stay as-is (`AgentBase`, `FunctionResult`).
+ *   - Method names: camelCase → snake_case; constructor → __init__.
+ *   - Module names: mapped to Python's dotted form. For classes that exist
+ *     in the Python reference we emit them under Python's canonical module
+ *     (e.g. `AgentBase` from `src/AgentBase.ts` goes under
+ *     `signalwire.core.agent_base`). Port-only classes are emitted under
+ *     a module name derived from their file path.
+ *
+ * Only public top-level exports are considered (`export class`,
+ * `export function`, `export const`). Public methods on classes are those
+ * without a leading underscore — `__init__` (the TS `constructor`) is kept.
+ *
+ * Usage:
+ *   npx tsx scripts/enumerate-surface.ts              # write port_surface.json
+ *   npx tsx scripts/enumerate-surface.ts --stdout     # print to stdout
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ---------------------------------------------------------------------------
+// Name translation helpers
+// ---------------------------------------------------------------------------
+
+/** camelCase / PascalCase → snake_case. Preserves runs of uppercase (e.g.
+ *  `renderSWML` → `render_swml`, `parseURL` → `parse_url`). */
+function camelToSnake(name: string): string {
+  // Replace transitions between lower-to-upper and upper-to-upper-then-lower.
+  return name
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase();
+}
+
+/** File path `src/AgentBase.ts` → `signalwire.core.agent_base` (when the file
+ *  only contains an AgentBase class that's known to Python). For files whose
+ *  classes are NOT in Python, we fall back to a Python-ish module path derived
+ *  from the file path.
+ *
+ *  Example fallback: `src/rest/callHandler.ts` → `signalwire.rest.call_handler`.
+ */
+function fallbackModuleName(fileRelPath: string): string {
+  // Drop the leading "src/" segment and the ".ts" suffix.
+  let rel = fileRelPath.replace(/^src\//, '').replace(/\.ts$/, '');
+  // Break into parts, snake_case each.
+  const parts = rel.split('/').map((p) => camelToSnake(p).replace(/-/g, '_'));
+  return ['signalwire', ...parts].join('.');
+}
+
+// ---------------------------------------------------------------------------
+// Python-reference lookup: load python_surface.json once and build a
+// class-name → module map. When a TS class name exists in Python under one
+// module, we emit it there. When it's ambiguous (same name under multiple
+// Python modules), we prefer whichever module best matches the TS file path.
+// ---------------------------------------------------------------------------
+
+interface PythonSurface {
+  version: string;
+  modules: Record<string, { classes: Record<string, string[]>; functions: string[] }>;
+}
+
+/** Load the Python reference and build three lookup tables:
+ *
+ *   classToModules:      class name      → [candidate modules…]
+ *   methodToOwners:      method name     → [(mod, class)…] (all Python owners)
+ *   agentBaseFold:       method name     → (mod, class) pairs where TS folds
+ *                                          the method into AgentBase.
+ */
+function loadPythonReference(pythonSurfacePath: string): {
+  classToModules: Map<string, string[]>;
+  methodToOwners: Map<string, Array<{ mod: string; cls: string }>>;
+  pythonModules: Set<string>;
+  pythonClasses: Map<string, { mod: string; cls: string }[]>;
+  pythonMethodsByOwner: Map<string, Set<string>>; // key: `${mod}.${cls}`
+} {
+  if (!fs.existsSync(pythonSurfacePath)) {
+    return {
+      classToModules: new Map(),
+      methodToOwners: new Map(),
+      pythonModules: new Set(),
+      pythonClasses: new Map(),
+      pythonMethodsByOwner: new Map(),
+    };
+  }
+  const data: PythonSurface = JSON.parse(fs.readFileSync(pythonSurfacePath, 'utf-8'));
+  const classToModules = new Map<string, string[]>();
+  const methodToOwners = new Map<string, Array<{ mod: string; cls: string }>>();
+  const pythonModules = new Set<string>();
+  const pythonClasses = new Map<string, { mod: string; cls: string }[]>();
+  const pythonMethodsByOwner = new Map<string, Set<string>>();
+  for (const [mod, entry] of Object.entries(data.modules)) {
+    pythonModules.add(mod);
+    for (const [cls, methods] of Object.entries(entry.classes ?? {})) {
+      if (!classToModules.has(cls)) classToModules.set(cls, []);
+      classToModules.get(cls)!.push(mod);
+
+      const key = `${mod}.${cls}`;
+      pythonMethodsByOwner.set(key, new Set(methods));
+      if (!pythonClasses.has(cls)) pythonClasses.set(cls, []);
+      pythonClasses.get(cls)!.push({ mod, cls });
+
+      for (const m of methods) {
+        if (!methodToOwners.has(m)) methodToOwners.set(m, []);
+        methodToOwners.get(m)!.push({ mod, cls });
+      }
+    }
+  }
+  return {
+    classToModules,
+    methodToOwners,
+    pythonModules,
+    pythonClasses,
+    pythonMethodsByOwner,
+  };
+}
+
+/** Score how closely a Python module matches a TS file path. Higher = better.
+ *  Used to disambiguate when one class name appears under multiple Python
+ *  modules. */
+function moduleMatchScore(pythonMod: string, tsFileRelPath: string): number {
+  const fileSlug = camelToSnake(
+    tsFileRelPath.replace(/^src\//, '').replace(/\.ts$/, '').split('/').pop() ?? '',
+  );
+  const pyTail = pythonMod.split('.').pop() ?? '';
+  if (pyTail === fileSlug) return 100;
+  // Match by dir hint: "rest" in TS path → "rest" in Python module.
+  const tsDirs = tsFileRelPath.replace(/^src\//, '').split('/').slice(0, -1);
+  let score = 0;
+  for (const d of tsDirs) {
+    const ds = camelToSnake(d).replace(/-/g, '_');
+    if (pythonMod.includes(`.${ds}.`) || pythonMod.includes(`.${ds}`)) score += 10;
+  }
+  return score;
+}
+
+/** Canonical module-name remap for TS paths that don't naturally map to Python
+ *  module paths. Applied AFTER class lookup fails (the class isn't in Python),
+ *  so port-only classes end up under a sensible dotted name. */
+const TS_MODULE_ALIASES: Record<string, string> = {
+  // Top-level TS files that are "core" in Python.
+  'src/AgentBase.ts': 'signalwire.core.agent_base',
+  'src/AgentServer.ts': 'signalwire.agent_server',
+  'src/AuthHandler.ts': 'signalwire.core.auth_handler',
+  'src/ConfigLoader.ts': 'signalwire.core.config_loader',
+  'src/ContextBuilder.ts': 'signalwire.core.contexts',
+  'src/DataMap.ts': 'signalwire.core.data_map',
+  'src/FunctionResult.ts': 'signalwire.core.function_result',
+  'src/Logger.ts': 'signalwire.core.logging_config',
+  'src/PomBuilder.ts': 'signalwire.core.pom_builder',
+  'src/PromptManager.ts': 'signalwire.core.agent.prompt.manager',
+  'src/SchemaUtils.ts': 'signalwire.utils.schema_utils',
+  'src/SecurityUtils.ts': 'signalwire.utils',
+  'src/ServerlessAdapter.ts': 'signalwire.core.mixins.serverless_mixin',
+  'src/SessionManager.ts': 'signalwire.core.security.session_manager',
+  'src/SslConfig.ts': 'signalwire.core.security_config',
+  'src/SwaigFunction.ts': 'signalwire.core.swaig_function',
+  'src/SwmlBuilder.ts': 'signalwire.core.swml_builder',
+  'src/SWMLHandler.ts': 'signalwire.core.swml_handler',
+  'src/SWMLService.ts': 'signalwire.core.swml_service',
+  'src/TypeInference.ts': 'signalwire.core.agent.tools.type_inference',
+  'src/WebService.ts': 'signalwire.web.web_service',
+  // Relay
+  'src/relay/Action.ts': 'signalwire.relay.call',
+  'src/relay/Call.ts': 'signalwire.relay.call',
+  'src/relay/Message.ts': 'signalwire.relay.message',
+  'src/relay/RelayClient.ts': 'signalwire.relay.client',
+  'src/relay/RelayError.ts': 'signalwire.relay.client',
+  'src/relay/RelayEvent.ts': 'signalwire.relay.event',
+  // REST
+  'src/rest/index.ts': 'signalwire.rest.client',
+  'src/rest/HttpClient.ts': 'signalwire.rest._base',
+  'src/rest/RestError.ts': 'signalwire.rest._base',
+  'src/rest/callHandler.ts': 'signalwire.rest.call_handler',
+  'src/rest/pagination.ts': 'signalwire.rest._pagination',
+  'src/rest/base/BaseResource.ts': 'signalwire.rest._base',
+  'src/rest/base/CrudResource.ts': 'signalwire.rest._base',
+  'src/rest/base/CrudWithAddresses.ts': 'signalwire.rest._base',
+  // Skills
+  'src/skills/SkillBase.ts': 'signalwire.core.skill_base',
+  'src/skills/SkillManager.ts': 'signalwire.core.skill_manager',
+  'src/skills/SkillRegistry.ts': 'signalwire.skills.registry',
+  // Prefabs
+  'src/prefabs/ConciergeAgent.ts': 'signalwire.prefabs.concierge',
+  'src/prefabs/FAQBotAgent.ts': 'signalwire.prefabs.faq_bot',
+  'src/prefabs/InfoGathererAgent.ts': 'signalwire.prefabs.info_gatherer',
+  'src/prefabs/ReceptionistAgent.ts': 'signalwire.prefabs.receptionist',
+  'src/prefabs/SurveyAgent.ts': 'signalwire.prefabs.survey',
+  // LiveWire (flat in Python; namespaces in TS handled by ns flattening below)
+  'src/livewire/index.ts': 'signalwire.livewire',
+  // CLI
+  'src/cli/swaig-test.ts': 'signalwire.cli.test_swaig',
+  'src/cli/agent-loader.ts': 'signalwire.cli.core.agent_loader',
+  'src/cli/mock-data.ts': 'signalwire.cli.simulation.mock_env',
+  // index.ts barrel exports — top-level module functions go under `signalwire`.
+  'src/index.ts': 'signalwire',
+};
+
+/** Class-name translations where the TS spelling differs from Python's.
+ *  Applied ONLY when the class appears in the Python reference under the
+ *  mapped name and the TS name maps to that same intended class. */
+const CLASS_NAME_ALIASES: Record<string, string> = {
+  // TS keeps PascalCase consistency (Swml…) while Python uses SCREAMING
+  // initialisms (SWML…) for these specific classes.
+  SwaigFunction: 'SWAIGFunction',
+  SwmlBuilder: 'SWMLBuilder',
+  // Note: SWMLService, SWMLVerbHandler, AIVerbHandler keep their ALL-CAPS
+  // spelling on both sides.
+};
+
+/** Method-name aliases for known TS↔Python naming mismatches that are one-off
+ *  lexical differences rather than functional gaps. Applied when emitting a
+ *  method for a class that exists in the Python reference. */
+const METHOD_NAME_ALIASES: Record<string, Record<string, string>> = {
+  // `userData` getter is snake_cased to `user_data` by camelToSnake, but
+  // Python spells it as a flat `userdata` (no underscore).
+  'signalwire.livewire.AgentSession': { user_data: 'userdata' },
+  'signalwire.livewire.RunContext': { user_data: 'userdata' },
+
+  // SkillManager: TS renamed for TypeScript idiom but the semantics match.
+  'signalwire.core.skill_manager.SkillManager': {
+    add_skill: 'load_skill',              // TS addSkill(SkillInstance) ~ Python load_skill
+    remove_skill: 'unload_skill',         // TS removeSkill(instanceId) ~ Python unload_skill
+    list_skills: 'list_loaded_skills',    // TS listSkills ~ Python list_loaded_skills
+  },
+
+  // SkillRegistry: TS singleton-style names map to Python methods.
+  'signalwire.skills.registry.SkillRegistry': {
+    register: 'register_skill',               // TS register(cls) ~ Python register_skill
+    add_search_path: 'add_skill_directory',   // TS addSearchPath ~ Python add_skill_directory
+    discover_from_directory: 'discover_skills', // ~ Python discover_skills
+    // get_skill_class matches verbatim after camelToSnake.
+    // listSkills → list_skills (matches verbatim).
+    // has / clear / lock / unregister / create / size / reset_instance / get_instance are TS-only additions.
+  },
+};
+
+/** Method aliases applied to every subclass of a given base class (by
+ *  Python-module key `mod.cls`). Currently empty — early versions of this
+ *  script aliased `get_tools` → `register_tools` but those are distinct
+ *  methods in Python (one returns defs, the other runs registration). */
+const SKILL_METHOD_ALIASES: Record<string, string> = {};
+
+/** Function-name aliases on a per-module basis. */
+const FUNCTION_NAME_ALIASES: Record<string, Record<string, string>> = {
+  // TS's `tool` is Python's `function_tool` (LiveKit compat shim).
+  'signalwire.livewire': { tool: 'function_tool' },
+};
+
+/** Skills (builtin): `src/skills/builtin/<name>.ts` maps to
+ *  `signalwire.skills.<name>.skill` per the Python layout. */
+function builtinSkillModule(fileRel: string): string | null {
+  const m = fileRel.match(/^src\/skills\/builtin\/([A-Za-z0-9_]+)\.ts$/);
+  if (!m) return null;
+  const baseName = m[1];
+  if (baseName === 'index') return 'signalwire.skills.registry';
+  // Python uses signalwire.skills.<name>.skill.
+  return `signalwire.skills.${baseName}.skill`;
+}
+
+/** REST namespace: `src/rest/namespaces/<name>.ts` → `signalwire.rest.namespaces.<name>` */
+function restNamespaceModule(fileRel: string): string | null {
+  const m = fileRel.match(/^src\/rest\/namespaces\/([A-Za-z0-9_-]+)\.ts$/);
+  if (!m) return null;
+  const py = m[1].replace(/-/g, '_');
+  return `signalwire.rest.namespaces.${py}`;
+}
+
+// ---------------------------------------------------------------------------
+// TypeScript AST traversal
+// ---------------------------------------------------------------------------
+
+interface ClassInfo {
+  name: string;
+  methods: string[];
+  extendsName?: string;
+}
+
+interface FileSurface {
+  classes: ClassInfo[];
+  functions: string[];
+}
+
+/** Walk a source file and collect exported classes (with their public methods)
+ *  and exported top-level functions / const arrow-functions. Descends into
+ *  `export namespace X { ... }` blocks; classes inside are collected with a
+ *  translated name ("inference" + "STT" → "InferenceSTT") when the namespace
+ *  is `inference` in the Python-compat livewire map. */
+function enumerateFile(file: string): FileSurface {
+  const text = fs.readFileSync(file, 'utf-8');
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.ES2022, true);
+
+  const classes: ClassInfo[] = [];
+  const functions: string[] = [];
+
+  function collectClass(node: ts.ClassDeclaration, nameOverride?: string): void {
+    if (!node.name) return;
+    const rawName = nameOverride ?? node.name.text;
+    const methods = new Set<string>();
+    for (const member of node.members) {
+      // Skip private/protected? No — filter only on leading underscore, per
+      // Python convention. TS `private` keyword is orthogonal to public API.
+      if (ts.isConstructorDeclaration(member)) {
+        methods.add('__init__');
+        continue;
+      }
+      // Method declaration.
+      if (ts.isMethodDeclaration(member) && member.name && ts.isIdentifier(member.name)) {
+        const mName = member.name.text;
+        if (mName.startsWith('_')) continue;
+        // Skip private methods marked with `private` keyword; they are
+        // implementation detail per TS convention even though JS still lets
+        // you call them.
+        const mods = ts.getCombinedModifierFlags(member);
+        if (mods & ts.ModifierFlags.Private) continue;
+        methods.add(camelToSnake(mName));
+      }
+      // Getter / setter.
+      if ((ts.isGetAccessor(member) || ts.isSetAccessor(member)) && member.name && ts.isIdentifier(member.name)) {
+        const mName = member.name.text;
+        if (mName.startsWith('_')) continue;
+        const mods = ts.getCombinedModifierFlags(member);
+        if (mods & ts.ModifierFlags.Private) continue;
+        methods.add(camelToSnake(mName));
+      }
+    }
+    // Extract the extended class name (simple identifier case only; no
+    // generic arguments are tracked for inheritance purposes).
+    let extendsName: string | undefined;
+    if (node.heritageClauses) {
+      for (const hc of node.heritageClauses) {
+        if (hc.token === ts.SyntaxKind.ExtendsKeyword && hc.types.length > 0) {
+          const parent = hc.types[0]!.expression;
+          if (ts.isIdentifier(parent)) extendsName = parent.text;
+          else if (ts.isPropertyAccessExpression(parent) && ts.isIdentifier(parent.name)) {
+            extendsName = parent.name.text;
+          }
+        }
+      }
+    }
+    classes.push({ name: rawName, methods: Array.from(methods).sort(), extendsName });
+  }
+
+  function collectFunction(name: string): void {
+    if (name.startsWith('_')) return;
+    functions.push(camelToSnake(name));
+  }
+
+  /** Is this statement exported at the top level? */
+  function isExported(node: ts.Node): boolean {
+    const mods = ts.getCombinedModifierFlags(node as ts.Declaration);
+    return (mods & ts.ModifierFlags.Export) !== 0;
+  }
+
+  /** Walk top-level statements + descend into exported namespaces. */
+  function walk(container: ts.Node, nsPath: string[] = []): void {
+    const forEachStatement = (node: ts.Node): void => {
+      if (ts.isClassDeclaration(node) && isExported(node) && node.name) {
+        const nm = nsPath.length > 0
+          ? `${nsPath.join('')}${node.name.text}` // namespace-prefixed (e.g. "Inference" + "STT")
+          : node.name.text;
+        collectClass(node, nm);
+      } else if (ts.isFunctionDeclaration(node) && isExported(node) && node.name) {
+        // Only care about concrete functions (they have a body). Overload
+        // declarations without a body are parsed as separate nodes.
+        if (!node.body) return;
+        collectFunction(node.name.text);
+      } else if (ts.isVariableStatement(node) && isExported(node)) {
+        for (const decl of node.declarationList.declarations) {
+          if (!ts.isIdentifier(decl.name)) continue;
+          // Only export-const-arrow-function and export-const-function-expression
+          // count as "callable exports". Plain const values are not API surface.
+          if (!decl.initializer) continue;
+          if (
+            ts.isArrowFunction(decl.initializer) ||
+            ts.isFunctionExpression(decl.initializer)
+          ) {
+            collectFunction(decl.name.text);
+          }
+        }
+      } else if (ts.isModuleDeclaration(node) && isExported(node) && node.body && ts.isModuleBlock(node.body)) {
+        // `export namespace plugins { ... }`. Descend — classes inside still
+        // count as exports, but we need to translate their names to match
+        // Python. For the `inference` namespace in livewire, Python uses
+        // `InferenceSTT`, `InferenceLLM`, `InferenceTTS`. For `plugins`,
+        // Python already uses the raw class names inside
+        // `signalwire.livewire.plugins`.
+        const nsName = node.name.getText(sf);
+        // For "inference", concat the namespace prefix so "STT" becomes
+        // "InferenceSTT". For "plugins", leave as-is (the classes go under a
+        // separate module, handled by the caller).
+        if (nsName === 'inference') {
+          walk(node.body, ['Inference']);
+        } else {
+          // For other namespaces, pass through but mark the namespace.
+          for (const stmt of node.body.statements) {
+            if (ts.isClassDeclaration(stmt) && isExported(stmt) && stmt.name) {
+              // Class inside `plugins` is emitted as-is; the caller assigns
+              // it to the `signalwire.livewire.plugins` module.
+              classes.push({ name: `__NS__${nsName}__${stmt.name.text}`, methods: collectMethodsFor(stmt) });
+            }
+          }
+        }
+      }
+    };
+    ts.forEachChild(container, forEachStatement);
+  }
+
+  function collectMethodsFor(node: ts.ClassDeclaration): string[] {
+    const methods = new Set<string>();
+    for (const member of node.members) {
+      if (ts.isConstructorDeclaration(member)) { methods.add('__init__'); continue; }
+      if ((ts.isMethodDeclaration(member) || ts.isGetAccessor(member) || ts.isSetAccessor(member))
+          && member.name && ts.isIdentifier(member.name)) {
+        const nm = member.name.text;
+        if (nm.startsWith('_')) continue;
+        const mods = ts.getCombinedModifierFlags(member);
+        if (mods & ts.ModifierFlags.Private) continue;
+        methods.add(camelToSnake(nm));
+      }
+    }
+    return Array.from(methods).sort();
+  }
+
+  walk(sf);
+
+  return { classes, functions };
+}
+
+// ---------------------------------------------------------------------------
+// Module assignment
+// ---------------------------------------------------------------------------
+
+/** Decide which Python-reference module a class belongs to. Order of
+ *  precedence:
+ *    1. Explicit TS_MODULE_ALIASES for the file path (hard override).
+ *    2. Class name matches one in python_surface.json → use that module,
+ *       disambiguating by file-path similarity if multiple candidates.
+ *    3. Fall back to fallbackModuleName().
+ */
+function pickModule(
+  className: string,
+  tsFileRel: string,
+  classToModules: Map<string, string[]>,
+): string {
+  // Builtin skills live under their own per-skill module — don't let class
+  // name lookup override that.
+  const skillMod = builtinSkillModule(tsFileRel);
+  if (skillMod) return skillMod;
+
+  const restNs = restNamespaceModule(tsFileRel);
+  if (restNs) return restNs;
+
+  const candidates = classToModules.get(className);
+  if (candidates && candidates.length > 0) {
+    if (candidates.length === 1) return candidates[0]!;
+    // Disambiguate by file path similarity.
+    let best = candidates[0]!;
+    let bestScore = -1;
+    for (const c of candidates) {
+      const s = moduleMatchScore(c, tsFileRel);
+      if (s > bestScore) {
+        bestScore = s;
+        best = c;
+      }
+    }
+    return best;
+  }
+
+  // Fall through to file-path aliases / derivation.
+  if (TS_MODULE_ALIASES[tsFileRel]) return TS_MODULE_ALIASES[tsFileRel]!;
+  return fallbackModuleName(tsFileRel);
+}
+
+/** Similar picker for top-level module functions (no class to look up by). */
+function pickModuleForFunction(tsFileRel: string): string {
+  const skillMod = builtinSkillModule(tsFileRel);
+  if (skillMod) return skillMod;
+  const restNs = restNamespaceModule(tsFileRel);
+  if (restNs) return restNs;
+  if (TS_MODULE_ALIASES[tsFileRel]) return TS_MODULE_ALIASES[tsFileRel]!;
+  return fallbackModuleName(tsFileRel);
+}
+
+// ---------------------------------------------------------------------------
+// Walk the repo
+// ---------------------------------------------------------------------------
+
+function findSourceFiles(root: string): string[] {
+  const out: string[] = [];
+  function walkDir(dir: string): void {
+    for (const name of fs.readdirSync(dir)) {
+      const full = path.join(dir, name);
+      const st = fs.statSync(full);
+      if (st.isDirectory()) {
+        if (name === 'node_modules' || name === 'dist' || name === '.git') continue;
+        walkDir(full);
+      } else if (name.endsWith('.ts') && !name.endsWith('.d.ts')) {
+        // Skip codegen artifacts.
+        if (name === 'SwmlVerbMethods.generated.ts') continue;
+        if (name === 'generateVerbTypes.ts') continue;
+        out.push(full);
+      }
+    }
+  }
+  walkDir(root);
+  return out.sort();
+}
+
+/** Resolve the path to python_surface.json. Priority:
+ *    1. $PYTHON_SURFACE_PATH
+ *    2. $PORTING_SDK_PATH/python_surface.json
+ *    3. sibling ../porting-sdk/python_surface.json
+ *    4. ~/src/porting-sdk/python_surface.json
+ */
+function resolvePythonSurfacePath(repoRoot: string): string {
+  const envPath = process.env['PYTHON_SURFACE_PATH'];
+  if (envPath && fs.existsSync(envPath)) return envPath;
+  const portingSdkEnv = process.env['PORTING_SDK_PATH'];
+  if (portingSdkEnv) {
+    const candidate = path.join(portingSdkEnv, 'python_surface.json');
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  const sibling = path.resolve(repoRoot, '..', 'porting-sdk', 'python_surface.json');
+  if (fs.existsSync(sibling)) return sibling;
+  const home = process.env['HOME'] ?? '';
+  if (home) {
+    const src = path.join(home, 'src', 'porting-sdk', 'python_surface.json');
+    if (fs.existsSync(src)) return src;
+  }
+  return sibling; // non-existent, will cause loadPythonReference to no-op.
+}
+
+function getGitSha(repoRoot: string): string {
+  try {
+    return execSync('git rev-parse HEAD', { cwd: repoRoot, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString().trim();
+  } catch {
+    return 'N/A';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const writeStdout = argv.includes('--stdout');
+  const outputArgIdx = argv.indexOf('--output');
+  const repoRoot = path.resolve(__dirname, '..');
+  const outputPath = outputArgIdx >= 0
+    ? path.resolve(argv[outputArgIdx + 1]!)
+    : path.join(repoRoot, 'port_surface.json');
+
+  const srcDir = path.join(repoRoot, 'src');
+  const files = findSourceFiles(srcDir);
+
+  const pythonSurfacePath = resolvePythonSurfacePath(repoRoot);
+  const { classToModules, methodToOwners, pythonMethodsByOwner } = loadPythonReference(pythonSurfacePath);
+
+  interface ModuleEntry {
+    classes: Record<string, string[]>;
+    functions: string[];
+  }
+  const modules: Record<string, ModuleEntry> = {};
+
+  // First pass: collect every file's raw classes so we can resolve
+  // `extends` chains across files before emitting.
+  interface RawClass {
+    fileRel: string;
+    name: string;
+    methods: string[];
+    extendsName?: string;
+  }
+  const rawClasses: RawClass[] = [];
+  const rawFunctions: Array<{ fileRel: string; fns: string[] }> = [];
+  for (const abs of files) {
+    const rel = path.relative(repoRoot, abs).replace(/\\/g, '/');
+    const fs2 = enumerateFile(abs);
+    for (const c of fs2.classes) {
+      rawClasses.push({ fileRel: rel, name: c.name, methods: c.methods, extendsName: c.extendsName });
+    }
+    if (fs2.functions.length > 0) rawFunctions.push({ fileRel: rel, fns: fs2.functions });
+  }
+
+  // Build a name → methods map for inheritance lookups (TS-class-name keyed).
+  const classMethods = new Map<string, Set<string>>();
+  for (const c of rawClasses) {
+    const cleanName = c.name.startsWith('__NS__')
+      ? c.name.split('__').pop()!
+      : c.name;
+    if (!classMethods.has(cleanName)) classMethods.set(cleanName, new Set());
+    for (const m of c.methods) classMethods.get(cleanName)!.add(m);
+  }
+
+  function resolveInherited(name: string, seen = new Set<string>()): Set<string> {
+    if (seen.has(name)) return new Set();
+    seen.add(name);
+    const own = classMethods.get(name) ?? new Set();
+    const full = new Set(own);
+    // Find my own record(s) to get extendsName
+    for (const c of rawClasses) {
+      const cleanName = c.name.startsWith('__NS__') ? c.name.split('__').pop()! : c.name;
+      if (cleanName === name && c.extendsName) {
+        for (const m of resolveInherited(c.extendsName, seen)) full.add(m);
+      }
+    }
+    return full;
+  }
+
+  // Expand every class's method list to include inherited ones, but only
+  // the ones that Python's equivalent class declares. Python enumerates
+  // only *declared* methods per class, so if TS inherits a method from a
+  // base class we only want to emit it when Python's version of the same
+  // class also explicitly declares it — avoiding a flood of inherited
+  // methods that wouldn't be in Python's surface anyway.
+  for (const c of rawClasses) {
+    const cleanName = c.name.startsWith('__NS__') ? c.name.split('__').pop()! : c.name;
+    const emitName = CLASS_NAME_ALIASES[cleanName] ?? cleanName;
+    const candidateMods = classToModules.get(emitName);
+    const pythonSet = new Set<string>();
+    if (candidateMods) {
+      for (const m of candidateMods) {
+        for (const meth of pythonMethodsByOwner.get(`${m}.${emitName}`) ?? []) {
+          pythonSet.add(meth);
+        }
+      }
+    }
+    const inherited = resolveInherited(cleanName);
+    // Apply skill aliases to the inherited set so the method names line up
+    // against Python (e.g. `get_tools` → `register_tools`).
+    const moduleGuess = pickModule(emitName, c.fileRel, classToModules);
+    const skillCtx = moduleGuess === 'signalwire.core.skill_base' || moduleGuess.startsWith('signalwire.skills.');
+    const toAlias = (m: string): string => {
+      if (skillCtx && SKILL_METHOD_ALIASES[m]) return SKILL_METHOD_ALIASES[m]!;
+      return m;
+    };
+    const inheritedFiltered = new Set<string>();
+    for (const m of inherited) {
+      const aliased = toAlias(m);
+      if (pythonSet.has(aliased)) inheritedFiltered.add(m);
+    }
+    c.methods = Array.from(new Set([...c.methods, ...inheritedFiltered])).sort();
+  }
+
+  function ensureModule(mod: string): ModuleEntry {
+    if (!modules[mod]) modules[mod] = { classes: {}, functions: [] };
+    return modules[mod]!;
+  }
+
+  // Emit classes.
+  for (const cls of rawClasses) {
+    const rel = cls.fileRel;
+
+    // Handle nested-namespace marker: "__NS__plugins__DeepgramSTT" → class
+    // "DeepgramSTT" under `signalwire.livewire.plugins` when the file is
+    // the livewire index.
+    const nsMatch = cls.name.match(/^__NS__([A-Za-z0-9_]+)__(.+)$/);
+    if (nsMatch) {
+      const [, nsName, realName] = nsMatch;
+      const mod = (rel === 'src/livewire/index.ts' && nsName === 'plugins')
+        ? 'signalwire.livewire.plugins'
+        : fallbackModuleName(rel) + '.' + nsName;
+      const entry = ensureModule(mod);
+      const existing = new Set(entry.classes[realName!] ?? []);
+      for (const me of cls.methods) existing.add(me);
+      entry.classes[realName!] = Array.from(existing).sort();
+      continue;
+    }
+
+    // Apply class-name alias (e.g. SwaigFunction → SWAIGFunction).
+    let emitName = CLASS_NAME_ALIASES[cls.name] ?? cls.name;
+    const mod = pickModule(emitName, rel, classToModules);
+    // Apply method-name aliases keyed on the final {module, class} pair.
+    const methodAliases = METHOD_NAME_ALIASES[`${mod}.${emitName}`];
+    let emitMethods = cls.methods;
+    if (methodAliases) {
+      emitMethods = emitMethods.map((m) => methodAliases[m] ?? m);
+    }
+    if (mod === 'signalwire.core.skill_base' || mod.startsWith('signalwire.skills.')) {
+      emitMethods = emitMethods.map((m) => SKILL_METHOD_ALIASES[m] ?? m);
+    }
+
+    if (emitName === 'AgentBase' && mod === 'signalwire.core.agent_base') {
+      const keepOnAgentBase = new Set<string>(['__init__']);
+      const pythonAgentBaseMethods = new Set<string>();
+      for (const [m, owners] of methodToOwners.entries()) {
+        for (const o of owners) {
+          if (o.mod === 'signalwire.core.agent_base' && o.cls === 'AgentBase') {
+            pythonAgentBaseMethods.add(m);
+          }
+        }
+      }
+      for (const m of emitMethods) {
+        if (m === '__init__') continue;
+        const owners = methodToOwners.get(m);
+        if (!owners) {
+          keepOnAgentBase.add(m);
+          continue;
+        }
+        let foldedSomewhere = false;
+        for (const { mod: ownerMod, cls: ownerCls } of owners) {
+          if (!ownerMod.includes('.mixins.') && !ownerMod.startsWith('signalwire.core.agent.')) continue;
+          const subEntry = ensureModule(ownerMod);
+          const subExisting = new Set(subEntry.classes[ownerCls] ?? []);
+          subExisting.add(m);
+          subEntry.classes[ownerCls] = Array.from(subExisting).sort();
+          foldedSomewhere = true;
+        }
+        if (pythonAgentBaseMethods.has(m)) keepOnAgentBase.add(m);
+        if (!foldedSomewhere && !pythonAgentBaseMethods.has(m)) keepOnAgentBase.add(m);
+      }
+      const entry = ensureModule(mod);
+      const existing = new Set(entry.classes[emitName] ?? []);
+      for (const me of keepOnAgentBase) existing.add(me);
+      entry.classes[emitName] = Array.from(existing).sort();
+    } else {
+      const entry = ensureModule(mod);
+      const existing = new Set(entry.classes[emitName] ?? []);
+      for (const me of emitMethods) existing.add(me);
+      entry.classes[emitName] = Array.from(existing).sort();
+    }
+  }
+
+  // Emit functions.
+  for (const f of rawFunctions) {
+    const mod = pickModuleForFunction(f.fileRel);
+    const aliases = FUNCTION_NAME_ALIASES[mod] ?? {};
+    const entry = ensureModule(mod);
+    const existing = new Set(entry.functions);
+    for (const fn of f.fns) existing.add(aliases[fn] ?? fn);
+    entry.functions = Array.from(existing).sort();
+  }
+
+  // Post-process: Python enumerator only emits `__init__` when the class
+  // body explicitly defines `def __init__`. TS classes always have a
+  // constructor (implicit or explicit). Normalize to Python's behavior:
+  //   * If Python has the class AND defines `__init__`, keep it in TS.
+  //   * If Python has the class AND doesn't define `__init__`, strip it
+  //     from TS (constructor is implicit both sides).
+  //   * If Python doesn't have the class (port-only), leave as-is.
+  //
+  // Also: if Python has `__init__` but TS doesn't explicitly declare a
+  // constructor, add it back — the class is constructible either way.
+  for (const [mod, entry] of Object.entries(modules)) {
+    for (const [cls, methods] of Object.entries(entry.classes)) {
+      const key = `${mod}.${cls}`;
+      const pythonMethods = pythonMethodsByOwner.get(key);
+      if (!pythonMethods) continue; // port-only class — keep as-is.
+      const current = new Set(methods);
+      if (pythonMethods.has('__init__')) {
+        current.add('__init__');
+      } else {
+        current.delete('__init__');
+      }
+      entry.classes[cls] = Array.from(current).sort();
+    }
+  }
+
+  // Sort module keys for deterministic output.
+  const sortedModules: Record<string, ModuleEntry> = {};
+  for (const k of Object.keys(modules).sort()) sortedModules[k] = modules[k]!;
+
+  const snapshot = {
+    version: '1',
+    generated_from: `signalwire-typescript @ ${getGitSha(repoRoot)}`,
+    typescript_version: ts.version,
+    modules: sortedModules,
+  };
+
+  const rendered = JSON.stringify(snapshot, null, 2) + '\n';
+
+  if (writeStdout) {
+    process.stdout.write(rendered);
+  } else {
+    fs.writeFileSync(outputPath, rendered, 'utf-8');
+    process.stderr.write(`wrote ${outputPath}\n`);
+  }
+}
+
+main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,6 +186,60 @@ export * as livewire from './livewire/index.js';
 
 // CLI helpers — convenience wrappers matching Python's start_agent / run_agent API
 import type { AgentBase as _AgentBase } from './AgentBase.js';
+import { SkillRegistry as _SkillRegistry } from './skills/SkillRegistry.js';
+import type { SkillSchemaInfo as _SkillSchemaInfo } from './skills/SkillRegistry.js';
+import type { SkillBase as _SkillBase } from './skills/SkillBase.js';
+
+/**
+ * List metadata for all registered skills.
+ *
+ * Equivalent to Python's `list_skills()` — proxies to the singleton
+ * {@link SkillRegistry}. Python's version returns a plain dict keyed by
+ * skill name; this returns an array of {@link _SkillSchemaInfo} entries
+ * (the TS shape is richer and includes the name field).
+ *
+ * @returns Array of skill metadata entries.
+ */
+export function listSkills(): _SkillSchemaInfo[] {
+  return _SkillRegistry.getInstance().listSkills();
+}
+
+/**
+ * Get full schema for all registered skills, including parameter metadata.
+ *
+ * Equivalent to Python's `list_skills_with_params()`. Useful for GUI
+ * configuration tools, API documentation, and programmatic skill discovery.
+ *
+ * @returns Map of skill name to {@link _SkillSchemaInfo | schema info}.
+ */
+export function listSkillsWithParams(): Record<string, _SkillSchemaInfo> {
+  return _SkillRegistry.getInstance().getAllSkillsSchema();
+}
+
+/**
+ * Register a custom skill class with the global {@link SkillRegistry}.
+ *
+ * Equivalent to Python's `register_skill(skill_class)`. Allows third-party
+ * code to register skills directly, bypassing the built-in directory scan.
+ *
+ * @param skillClass - Skill class to register (a subclass of {@link SkillBase}).
+ */
+export function registerSkill(skillClass: typeof _SkillBase): void {
+  _SkillRegistry.getInstance().register(skillClass);
+}
+
+/**
+ * Register a directory to search for additional skill modules.
+ *
+ * Equivalent to Python's `add_skill_directory(path)`. Proxies to
+ * `SkillRegistry.addSearchPath()`. Callers who want on-disk dynamic
+ * discovery can pair this with `SkillRegistry.discoverFromDirectory()`.
+ *
+ * @param path - Absolute path to a directory containing skill files.
+ */
+export function addSkillDirectory(path: string): void {
+  _SkillRegistry.getInstance().addSearchPath(path);
+}
 
 /**
  * Start an agent's HTTP server.


### PR DESCRIPTION
## Summary

Wires Layer B of the porting-sdk's symbol-parity contract. Every public class and method in the Python reference SDK (`signalwire-python`) is now either present in this port or explicitly listed in `PORT_OMISSIONS.md` with a concrete rationale. Drift fails CI.

- **`scripts/enumerate-surface.ts`** — TypeScript Compiler API walker. Extracts public classes/functions from `src/**/*.ts`, applies camelCase → snake_case translation, constructor → `__init__`, resolves `extends` chains, and folds Python's mixin-split AgentBase API back onto the TS flat `AgentBase` for diffability.
- **`port_surface.json`** — 1262 symbols in the shape of `porting-sdk/python_surface.json`.
- **`PORT_OMISSIONS.md`** — 382 Python symbols deliberately not implemented, grouped by rationale (search subsystem, CLI suite, MCP gateway backend, POM low-level classes, bedrock, web_search variants, skill hooks, prefab tool handlers, and per-symbol cases). Every line has concrete reasoning.
- **`PORT_ADDITIONS.md`** — 258 TS-only helpers (AgentBase accessors, SkillManager/SkillRegistry singleton API, Hono glue, etc.) with rationales.
- **`.github/workflows/surface-audit.yml`** — runs the enumerator + diff on every PR, push to main, and nightly at 06:00 UTC. Clones `signalwire/porting-sdk` alongside. Non-zero exit on unexcused drift.

## Test plan

- [x] `port match Python reference (1262 symbols; 382 excused omissions, 258 excused additions)` — diff exits 0 on this branch.
- [x] `npx vitest run` — 1713 pass. 8 pre-existing failures on `main` confirmed unrelated to this branch via `git stash` / checkout verification.
- [x] No new runtime dependencies. Uses the `typescript` package already present.

## Context

This PR is the TypeScript side of Layer B Phase 2 in the porting-sdk. See porting-sdk `CHECKLIST_TEMPLATE.md` Phase 13 § Symbol-level surface parity and `PORTING_GUIDE.md` § Automated surface audit (Layer B) for the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)