### PR TITLE
deps: security ws floor + @hono/node-server v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.11.0",
+        "@hono/node-server": "^2.0.0",
         "ajv": "^8.18.0",
         "cheerio": "^1.2.0",
         "hono": "^4.4.0",
         "js-yaml": "^4.1.1",
-        "ws": "^8.17.0"
+        "ws": "^8.17.1"
       },
       "bin": {
         "swaig-test": "dist/cli/swaig-test.js"
@@ -29,7 +29,7 @@
         "yaml": "^2.4.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -509,12 +509,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.4.tgz",
+      "integrity": "sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     "enumerate:doc-surface": "npx tsx scripts/enumerate-doc-surface.ts"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "license": "MIT",
   "dependencies": {
-    "@hono/node-server": "^1.11.0",
+    "@hono/node-server": "^2.0.0",
     "ajv": "^8.18.0",
     "cheerio": "^1.2.0",
     "hono": "^4.4.0",
     "js-yaml": "^4.1.1",
-    "ws": "^8.17.0"
+    "ws": "^8.17.1"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
Dependency security + currency bumps. All 6 CI gates pass (`bash scripts/run-ci.sh`); `npx tsc --noEmit` clean; no `port_signatures.json` drift.

## Security
- **`ws` `^8.17.0` → `^8.17.1`** — floor below the CVE-2024-37890 (DoS) fix. Resolves to 8.19.0.

## Version currency
- **`@hono/node-server` `^1.11.0` → `^2.0.0`** (resolves 2.0.4). **No source changes needed** — v2's `serve({fetch,port,hostname})` and `getRequestListener(fetch)` signatures are unchanged from v1, so the call sites in `SWMLService.ts` / `AgentServer.ts` / `WebService.ts` / `AgentBase.ts` (incl. the HTTPS `getRequestListener`+`createServer` path) work as-is.
- **`engines.node` `>=18` → `>=20`** — required because @hono/node-server v2 drops Node 18 (EOL). CI runs Node 22, local Node 24. **This is a consumer-facing floor raise.**

Note: TypeScript 5.5→6.0 (dev) is deferred to a separate pass; not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)