### PR TITLE
chore(deps): update typescript to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,11 @@
         "@types/ws": "^8.5.10",
         "cheerio": "^1.2.0",
         "tsx": "^4.21.0",
-        "typescript": "^5.5.0",
+        "typescript": "^6.0.0",
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "cheerio": "^1.2.0"
@@ -2014,9 +2014,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/ws": "^8.5.10",
     "cheerio": "^1.2.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.5.0",
+    "typescript": "^6.0.0",
     "vitest": "^4.1.5"
   }
 }


### PR DESCRIPTION
Manual TS 5.5→6.0.3 upgrade. Verified locally on Node 24: `tsc` build clean, examples typecheck clean, vitest 2278/2278. Clean drop-in — no code migration needed; only package.json + lockfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)