### PR TITLE
chore(deps): align @types/node with the >=22 engines floor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
-        "@types/node": "^20.14.0",
+        "@types/node": "^22.0.0",
         "@types/ws": "^8.5.10",
         "cheerio": "^1.2.0",
         "tsx": "^4.21.0",
@@ -28,7 +28,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "cheerio": "^1.2.0"
@@ -873,9 +873,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
-      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20.14.0",
+    "@types/node": "^22.0.0",
     "@types/ws": "^8.5.10",
     "cheerio": "^1.2.0",
     "tsx": "^4.21.0",


### PR DESCRIPTION
`@types/node` was `^20` while `engines.node` is `>=22` — the types described an older API surface than the floor. Renovate's bundled "node v24" would've gone the other way (`^24`), letting Node-24-only APIs type-check then break on the 22 floor (the engine half of that bundle is correctly frozen by the shared preset's `node-version` rule). Pin `@types/node` to `^22` to match the supported floor. Verified: build + examples typecheck clean, vitest 2278/2278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)