### PR TITLE
test(types): give tsc-probe type tests a 30s timeout (flaky under file parallelism)

### DIFF
--- a/tests/SkillToolInference.types.test.ts
+++ b/tests/SkillToolInference.types.test.ts
@@ -54,58 +54,66 @@ function typeCheckProbe(body: string): ts.Diagnostic[] {
 }
 
 describe('defineSkillTool — schema→args inference', () => {
-  it('infers required/optional/enum args precisely (every @ts-expect-error fires)', () => {
-    // Each `@ts-expect-error` asserts a genuine type error on the next line. If
-    // the inference were `any`/open, the marker would be "unused" (TS2578) and
-    // surface as a real diagnostic below.
-    const diags = typeCheckProbe(
-      `import { defineSkillTool } from '${path.resolve(REPO_ROOT, 'src/skills/SkillBase').replace(/\\/g, '/')}';\n` +
-        `import { FunctionResult } from '${path.resolve(REPO_ROOT, 'src/FunctionResult').replace(/\\/g, '/')}';\n` +
-        `defineSkillTool({\n` +
-        `  name: 't', description: 'd',\n` +
-        `  parameters: {\n` +
-        `    query: { type: 'string', description: 'q' },\n` +
-        `    mode: { type: 'string', description: 'm', enum: ['a', 'b'] as const },\n` +
-        `    page: { type: 'integer', description: 'p' },\n` +
-        `  },\n` +
-        `  required: ['query'],\n` +
-        `  handler: (args) => {\n` +
-        `    const q: string = args.query; void q;\n` + // required string — OK
-        `    const m: 'a' | 'b' | undefined = args.mode; void m;\n` + // enum literal, optional — OK
-        `    const p: number | undefined = args.page; void p;\n` + // integer, optional — OK
-        `    // @ts-expect-error required prop is never undefined\n` +
-        `    const bad1: undefined = args.query; void bad1;\n` +
-        `    // @ts-expect-error enum prop is narrowed, not an arbitrary string\n` +
-        `    const bad2: 'c' = args.mode!; void bad2;\n` +
-        `    return new FunctionResult('ok');\n` +
-        `  },\n` +
-        `});\n`,
-    );
-    // No real errors: the only diagnostics permitted are the (now-satisfied)
-    // expect-errors, which TypeScript reports as zero remaining diagnostics when
-    // they fire. Any leftover diagnostic is a genuine failure of the inference.
-    const real = diags.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'));
-    expect(real).toEqual([]);
-  });
+  it(
+    'infers required/optional/enum args precisely (every @ts-expect-error fires)',
+    { timeout: 30000 },
+    () => {
+      // Each `@ts-expect-error` asserts a genuine type error on the next line. If
+      // the inference were `any`/open, the marker would be "unused" (TS2578) and
+      // surface as a real diagnostic below.
+      const diags = typeCheckProbe(
+        `import { defineSkillTool } from '${path.resolve(REPO_ROOT, 'src/skills/SkillBase').replace(/\\/g, '/')}';\n` +
+          `import { FunctionResult } from '${path.resolve(REPO_ROOT, 'src/FunctionResult').replace(/\\/g, '/')}';\n` +
+          `defineSkillTool({\n` +
+          `  name: 't', description: 'd',\n` +
+          `  parameters: {\n` +
+          `    query: { type: 'string', description: 'q' },\n` +
+          `    mode: { type: 'string', description: 'm', enum: ['a', 'b'] as const },\n` +
+          `    page: { type: 'integer', description: 'p' },\n` +
+          `  },\n` +
+          `  required: ['query'],\n` +
+          `  handler: (args) => {\n` +
+          `    const q: string = args.query; void q;\n` + // required string — OK
+          `    const m: 'a' | 'b' | undefined = args.mode; void m;\n` + // enum literal, optional — OK
+          `    const p: number | undefined = args.page; void p;\n` + // integer, optional — OK
+          `    // @ts-expect-error required prop is never undefined\n` +
+          `    const bad1: undefined = args.query; void bad1;\n` +
+          `    // @ts-expect-error enum prop is narrowed, not an arbitrary string\n` +
+          `    const bad2: 'c' = args.mode!; void bad2;\n` +
+          `    return new FunctionResult('ok');\n` +
+          `  },\n` +
+          `});\n`,
+      );
+      // No real errors: the only diagnostics permitted are the (now-satisfied)
+      // expect-errors, which TypeScript reports as zero remaining diagnostics when
+      // they fire. Any leftover diagnostic is a genuine failure of the inference.
+      const real = diags.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'));
+      expect(real).toEqual([]);
+    },
+  );
 
-  it('a loose pre-built Record schema degrades to open args (no false errors)', () => {
-    // Dynamic-schema skills (claude_skills / mcp_gateway / swml_transfer) build
-    // `parameters` imperatively as a `Record`, so it cannot be read at the type
-    // level — args must fall back to the open record, NOT error.
-    const diags = typeCheckProbe(
-      `import { defineSkillTool } from '${path.resolve(REPO_ROOT, 'src/skills/SkillBase').replace(/\\/g, '/')}';\n` +
-        `import { FunctionResult } from '${path.resolve(REPO_ROOT, 'src/FunctionResult').replace(/\\/g, '/')}';\n` +
-        `const dynamic: Record<string, unknown> = { foo: { type: 'string' } };\n` +
-        `defineSkillTool({\n` +
-        `  name: 't', description: 'd',\n` +
-        `  parameters: dynamic,\n` +
-        `  handler: (args) => {\n` +
-        `    const v: unknown = args['foo']; void v;\n` + // open-record access — OK
-        `    return new FunctionResult('ok');\n` +
-        `  },\n` +
-        `});\n`,
-    );
-    const real = diags.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'));
-    expect(real).toEqual([]);
-  });
+  it(
+    'a loose pre-built Record schema degrades to open args (no false errors)',
+    { timeout: 30000 },
+    () => {
+      // Dynamic-schema skills (claude_skills / mcp_gateway / swml_transfer) build
+      // `parameters` imperatively as a `Record`, so it cannot be read at the type
+      // level — args must fall back to the open record, NOT error.
+      const diags = typeCheckProbe(
+        `import { defineSkillTool } from '${path.resolve(REPO_ROOT, 'src/skills/SkillBase').replace(/\\/g, '/')}';\n` +
+          `import { FunctionResult } from '${path.resolve(REPO_ROOT, 'src/FunctionResult').replace(/\\/g, '/')}';\n` +
+          `const dynamic: Record<string, unknown> = { foo: { type: 'string' } };\n` +
+          `defineSkillTool({\n` +
+          `  name: 't', description: 'd',\n` +
+          `  parameters: dynamic,\n` +
+          `  handler: (args) => {\n` +
+          `    const v: unknown = args['foo']; void v;\n` + // open-record access — OK
+          `    return new FunctionResult('ok');\n` +
+          `  },\n` +
+          `});\n`,
+      );
+      const real = diags.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'));
+      expect(real).toEqual([]);
+    },
+  );
 });

--- a/tests/TypedToolHandler.types.test.ts
+++ b/tests/TypedToolHandler.types.test.ts
@@ -85,41 +85,53 @@ function typeCheckHandler(body: string): Map<number, string> {
 }
 
 describe('TypedToolHandler — precise typed-tool handler signature', () => {
-  it('accepts every legitimate handler shape (string / record / FunctionResult / async)', () => {
-    const errs = typeCheckHandler(
-      `const h1: TypedToolHandler = (city: string) => 'ok'; void h1;\n` + // line 0 → diag 2
-        `const h2: TypedToolHandler = (city: string, n = 1) => ({ response: 'ok' }); void h2;\n` + // line 1 → diag 3
-        `const h3: TypedToolHandler = () => new FunctionResult(); void h3;\n` + // line 2 → diag 4
-        `const h4: TypedToolHandler = async (q: string) => 'later'; void h4;`, // line 3 → diag 5
-    );
-    expect(errs.get(2)).toBeUndefined(); // string return
-    expect(errs.get(3)).toBeUndefined(); // record return
-    expect(errs.get(4)).toBeUndefined(); // FunctionResult return
-    expect(errs.get(5)).toBeUndefined(); // async (Promise) return
-  });
+  it(
+    'accepts every legitimate handler shape (string / record / FunctionResult / async)',
+    { timeout: 30000 },
+    () => {
+      const errs = typeCheckHandler(
+        `const h1: TypedToolHandler = (city: string) => 'ok'; void h1;\n` + // line 0 → diag 2
+          `const h2: TypedToolHandler = (city: string, n = 1) => ({ response: 'ok' }); void h2;\n` + // line 1 → diag 3
+          `const h3: TypedToolHandler = () => new FunctionResult(); void h3;\n` + // line 2 → diag 4
+          `const h4: TypedToolHandler = async (q: string) => 'later'; void h4;`, // line 3 → diag 5
+      );
+      expect(errs.get(2)).toBeUndefined(); // string return
+      expect(errs.get(3)).toBeUndefined(); // record return
+      expect(errs.get(4)).toBeUndefined(); // FunctionResult return
+      expect(errs.get(5)).toBeUndefined(); // async (Promise) return
+    },
+  );
 
-  it('REJECTS a non-callable (the bare `Function` would too — but as `unknown`, not a SWAIG result)', () => {
-    const errs = typeCheckHandler(
-      `const notFn: TypedToolHandler = 42; void notFn;\n` + // line 0 → diag 2
-        `const obj: TypedToolHandler = { run() {} }; void obj;`, // line 1 → diag 3
-    );
-    expect(errs.get(2)).toBeDefined();
-    expect(errs.get(2)!).toMatch(/not assignable to type 'TypedToolHandler'/);
-    expect(errs.get(3)).toBeDefined();
-  });
+  it(
+    'REJECTS a non-callable (the bare `Function` would too — but as `unknown`, not a SWAIG result)',
+    { timeout: 30000 },
+    () => {
+      const errs = typeCheckHandler(
+        `const notFn: TypedToolHandler = 42; void notFn;\n` + // line 0 → diag 2
+          `const obj: TypedToolHandler = { run() {} }; void obj;`, // line 1 → diag 3
+      );
+      expect(errs.get(2)).toBeDefined();
+      expect(errs.get(2)!).toMatch(/not assignable to type 'TypedToolHandler'/);
+      expect(errs.get(3)).toBeDefined();
+    },
+  );
 
-  it('REJECTS a callable whose return cannot be a SWAIG result (void / boolean)', () => {
-    const errs = typeCheckHandler(
-      `const voidH: TypedToolHandler = (city: string): void => { void city; }; void voidH;\n` + // line 0 → diag 2
-        `const boolH: TypedToolHandler = (city: string): boolean => true; void boolH;`, // line 1 → diag 3
-    );
-    // A `() => void` / `() => boolean` is NOT assignable to a handler whose
-    // declared return is FunctionResult | record | string | Promise<…>.
-    expect(errs.get(2)).toBeDefined();
-    expect(errs.get(2)!).toMatch(/not assignable to type 'TypedToolHandler'/);
-    expect(errs.get(3)).toBeDefined();
-    expect(errs.get(3)!).toMatch(/not assignable to type 'TypedToolHandler'/);
-  });
+  it(
+    'REJECTS a callable whose return cannot be a SWAIG result (void / boolean)',
+    { timeout: 30000 },
+    () => {
+      const errs = typeCheckHandler(
+        `const voidH: TypedToolHandler = (city: string): void => { void city; }; void voidH;\n` + // line 0 → diag 2
+          `const boolH: TypedToolHandler = (city: string): boolean => true; void boolH;`, // line 1 → diag 3
+      );
+      // A `() => void` / `() => boolean` is NOT assignable to a handler whose
+      // declared return is FunctionResult | record | string | Promise<…>.
+      expect(errs.get(2)).toBeDefined();
+      expect(errs.get(2)!).toMatch(/not assignable to type 'TypedToolHandler'/);
+      expect(errs.get(3)).toBeDefined();
+      expect(errs.get(3)!).toMatch(/not assignable to type 'TypedToolHandler'/);
+    },
+  );
 
   it('runtime: a valid typed handler drives inferSchema + wrapper for real', () => {
     const captured: unknown[] = [];


### PR DESCRIPTION
## What

Follow-up to #128. The two `tests/*.types.test.ts` files (`SkillToolInference`,
`TypedToolHandler`) verify type inference by building a **real TypeScript program
in-process** (`ts.createProgram` + `getPreEmitDiagnostics`, resolving the whole
`src/` import graph). That's seconds of CPU+IO per test.

Once `fileParallelism: true` landed in #128, these run concurrently with all 16
workers and the in-process compiler **intermittently exceeded vitest's default
5000ms test timeout** — failing ~2-in-5 full-suite runs. Diagnosed via the JSON
reporter: the failure was a pure timeout at `dur ≈ 5025ms`, not a type-inference
error (they pass reliably in isolation, and the inference is always correct).

## Fix

Give the 5 compiler-probe `it()` blocks a 30s timeout. The default 5s was always
the wrong budget for a full `tsc` program build — file parallelism just exposed
it.

## Verification

Full suite under `--fileParallelism`: **2331/2331 across 6 consecutive runs**
(was ~2/5 failing before). tsc/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)