### PR TITLE
docs(drift): excuse Section.to_dict return divergence (mypy re-drift)

### DIFF
--- a/PORT_SIGNATURE_OMISSIONS.md
+++ b/PORT_SIGNATURE_OMISSIONS.md
@@ -455,6 +455,7 @@ signalwire.pom.pom.Section.render_xml: TS `indent` and `section_number` params r
 ## POM SectionData vs dict<string,any>
 
 signalwire.pom.pom.PromptObjectModel.to_dict: TS returns `list<class:signalwire.pom.pom.SectionData>` where SectionData is a typed shape; Python returns the equivalent `list<dict<string,any>>`. Same JSON-serializable structure with stronger TS typing.
+signalwire.pom.pom.Section.to_dict: TS returns `class:signalwire.pom.pom.SectionData` (the typed shape of one serialized section); Python returns the equivalent `dict<string,any>`. Same JSON, stronger TS typing. (Python's return type was firmed up from bare `any` to `dict<string,any>` during the mypy pass; TS already modeled the precise SectionData shape.)
 
 ## Typed payload/serializer shapes vs dict<string,any> (idiomatic TS, same wire)
 


### PR DESCRIPTION
Part of the signalwire-python mypy pass re-drift. The mypy work firmed up `Section.to_dict`'s return from bare `any` → `dict<string,any>`. TS already returns the precise typed `SectionData` shape — same JSON, stronger TS typing. One `PORT_SIGNATURE_OMISSIONS.md` entry (mirrors the existing `PromptObjectModel.to_dict` / `*Dict` idiom). **No code change.**

Coupled to porting-sdk `chore/python-mypy-oracle-redrift` (#40): clean against that oracle, red against main until it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau