### PR TITLE
test(rest): full success+error REST coverage (286/307) + gate

### DIFF
--- a/REST_COVERAGE_GAPS.md
+++ b/REST_COVERAGE_GAPS.md
@@ -1,0 +1,47 @@
+# REST coverage — signalwire-typescript accepted SDK gaps
+
+Canonical REST routes the **TypeScript SDK** does not implement, so they cannot
+reach success+error coverage here. These are the per-port half of the
+`REST-COVERAGE` allowlist (type `sdk-gap`); the universal gaps (the two
+doubled-path spec artifacts + the video.get_room routing collision) live in
+`porting-sdk/REST_COVERAGE_BASELINE.md` and are NOT repeated here.
+
+Format: `<endpoint_id>: sdk-gap — <rationale>`. Each entry is a contract for why
+TS doesn't cover it; if a method is later added, the route becomes coverable and
+the checker fails on the now-stale entry until it's removed.
+
+These 18 gaps are identical to the signalwire-python reference's accepted gaps —
+TS reached the same 286/307 coverable set with NO SDK source changes (its REST
+surface was already at parity: FabricResource addresses/PATCH-PUT, datasphere
+PATCH, phone_numbers path, chat/pubsub tokens, verifiedCallers, lookup all
+already correct).
+
+## fabric — dialogflow_agents resource not wired
+
+fabric.list_dialogflow_agents: sdk-gap — no dialogflow_agents resource on the fabric namespace (same gap python carries).
+fabric.get_dialogflow_agent: sdk-gap — no dialogflow_agents resource.
+fabric.update_dialogflow_agent: sdk-gap — no dialogflow_agents resource.
+fabric.delete_dialogflow_agent: sdk-gap — no dialogflow_agents resource.
+fabric.list_dialogflow_agent_addresses: sdk-gap — no dialogflow_agents resource.
+
+## relay-rest — SIP endpoints + domain applications have no relay-rest namespace
+
+relay-rest.list_sip_endpoints: sdk-gap — no SDK namespace for /api/relay/rest/endpoints/sip; SIP endpoints live under the Fabric base path instead (same as python).
+relay-rest.create_sip_endpoint: sdk-gap — see above.
+relay-rest.retrieve_sip_endpoint: sdk-gap — see above.
+relay-rest.update_sip_endpoint: sdk-gap — see above.
+relay-rest.delete_sip_endpoint: sdk-gap — see above.
+relay-rest.list_domain_applications: sdk-gap — no SDK namespace for /api/relay/rest/domain_applications; only a Fabric assignDomainApplication exists (same as python).
+relay-rest.create_domain_application: sdk-gap — see above.
+relay-rest.retrieve_domain_application: sdk-gap — see above.
+relay-rest.update_domain_application: sdk-gap — see above.
+relay-rest.delete_domain_application: sdk-gap — see above.
+
+## video — video logs have no accessor
+
+video.list_logs: sdk-gap — client.video exposes no logs accessor for GET /api/video/logs (same as python).
+video.get_log: sdk-gap — no video logs accessor (see above).
+
+## compatibility — bare per-country available-numbers node
+
+compatibility.list_available_phone_number_resources_by_country: sdk-gap — the phoneNumbers namespace exposes the /Local + /TollFree searches but no method for the bare /AvailablePhoneNumbers/{IsoCountry} node (same as python).

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -169,6 +169,43 @@ run_gate "GEN-FRESH" "generated types match canonical schema (--check)" genfresh
 run_gate "NO-CHEAT" "audit_no_cheat_tests" \
     python3 "$PORTING_SDK_DIR/scripts/audit_no_cheat_tests.py" --root "$PORT_ROOT"
 
+# Gate 5b: REST-COVERAGE — every canonical REST route the SDK implements must be
+# exercised with BOTH a success (2xx) AND an error (4xx/5xx) response on the
+# correct on-the-wire path (parity). Measured by replaying the mock journal of a
+# REST-suite run through porting-sdk's rest_coverage checker. Accepted gaps —
+# routes with no SDK method, malformed canonical routes, mock-router collisions —
+# are allowlisted: the shared baseline (porting-sdk/REST_COVERAGE_BASELINE.md) +
+# this port's REST_COVERAGE_GAPS.md. A stale entry (route now actually covered)
+# fails the gate. Self-contained: spins its own mock, runs the rest suite serially
+# against it (MOCK_SIGNALWIRE_PORT so all traffic lands in one journal), then
+# checks that journal. Same shape as python's/java's gate.
+rest_coverage_gate() {
+    local port=8769
+    local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
+    export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
+    python3 -m mock_signalwire --host 127.0.0.1 --port "$port" --log-level error \
+        >/tmp/rest_cov_mock.$$.log 2>&1 &
+    local mock_pid=$!
+    # shellcheck disable=SC2064
+    trap "kill $mock_pid 2>/dev/null" RETURN
+    local i
+    for i in $(seq 1 60); do
+        if python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:$port/__mock__/health',timeout=1)" 2>/dev/null; then
+            break
+        fi
+        sleep 0.5
+    done
+    python3 -c "import urllib.request; urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:$port/__mock__/journal/reset',method='POST'),timeout=5).read()"
+    MOCK_SIGNALWIRE_PORT="$port" npx vitest run tests/rest --no-file-parallelism || return 1
+    python3 -m mock_signalwire.rest_coverage \
+        --mock-url "http://127.0.0.1:$port" \
+        --spec-root "$PORTING_SDK_DIR/rest-apis" \
+        --allowlist "$PORTING_SDK_DIR/REST_COVERAGE_BASELINE.md" \
+        --allowlist "$PORT_ROOT/REST_COVERAGE_GAPS.md"
+}
+run_gate "REST-COVERAGE" "every implemented REST route covered success+error (parity + allowlist)" \
+    rest_coverage_gate
+
 # Gate 6: emission — byte-compare FunctionResult serialisation vs the Python
 # to_dict() oracle over the shared corpus (scripts/emit-corpus.ts builds the
 # native dump). Pure serialisation: no mock servers, no network — just

--- a/tests/rest/compat_coverage_mock.test.ts
+++ b/tests/rest/compat_coverage_mock.test.ts
@@ -1,0 +1,1278 @@
+/**
+ * Full REST success + error coverage for the `compatibility` spec group
+ * (the Twilio-compatible LaML 2010-04-01 Accounts API).
+ *
+ * Mirrors the proven python/java suites and the fabric coverage idiom: every
+ * coverable canonical `compatibility.*` route (78 of 79) gets BOTH a success
+ * (2xx) test and an error (4xx/5xx) test, asserting method, path,
+ * matched_route, and (for errors) response_status against the mock journal.
+ *
+ * Compat paths embed the project as the AccountSid. The scoped collections
+ * live under `/api/laml/2010-04-01/Accounts/<project>/...`; the top-level
+ * Accounts collection (`/Accounts`, `/Accounts/{Sid}`) carries no AccountSid
+ * prefix. The project is read from `mock.project` (never hard-coded).
+ *
+ * Gap (1, same as python/java — NOT faked):
+ *   - compatibility.list_available_phone_number_resources_by_country
+ *     (bare GET /AvailablePhoneNumbers/{IsoCountry}) — no SDK surface; the
+ *     namespace only exposes the `/Local` and `/TollFree` searches.
+ *
+ * Companion to tests/rest/compat_accounts_mock.test.ts (idiom); self-contained.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { newMockClient } from './mocktest.js';
+import type { RestClient } from '../../src/rest/index.js';
+import type { JournalEntry, MockHarness } from './mocktest.js';
+import { RestError } from '../../src/rest/RestError.js';
+
+let client: RestClient;
+let mock: MockHarness;
+
+beforeEach(async () => {
+  ({ client, mock } = await newMockClient());
+});
+
+// ---- DRY helpers -------------------------------------------------------
+//
+// Each helper RETURNS the journal entry (and/or response) so the calling
+// `it()` body holds its own real assertions — the no-cheat auditor is
+// intra-function.
+
+/**
+ * Await an SDK call, then return its response body alongside the last journal
+ * entry. The caller asserts on both.
+ */
+async function callOk<T>(fn: () => Promise<T>): Promise<{ body: T; last: JournalEntry }> {
+  const body = await fn();
+  const last = await mock.last();
+  return { body, last };
+}
+
+/**
+ * Arm a one-shot error scenario for `endpointId`, assert the SDK call rejects
+ * with RestError, and return the recorded journal entry for body assertions.
+ */
+async function callErr(
+  endpointId: string,
+  status: number,
+  fn: () => Promise<unknown>,
+): Promise<JournalEntry> {
+  await mock.pushScenario(endpointId, status, { error: 'x' });
+  await expect(fn()).rejects.toThrow(RestError);
+  return mock.last();
+}
+
+/** Account-scoped path prefix for this test's client (`.../Accounts/<project>`). */
+function base(): string {
+  return `/api/laml/2010-04-01/Accounts/${mock.project}`;
+}
+
+// ---- Accounts (top-level collection — no AccountSid prefix) -------------
+
+describe('Compat Accounts', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.accounts.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/laml/2010-04-01/Accounts');
+    expect(last.matched_route).toBe('compatibility.list_accounts');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_accounts', 500, () =>
+      client.compat.accounts.list(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_accounts');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create subproject success', async () => {
+    const { last } = await callOk(() => client.compat.accounts.create({ FriendlyName: 'Sub' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/laml/2010-04-01/Accounts');
+    expect(last.matched_route).toBe('compatibility.create_subprojects');
+  });
+  it('create subproject error 422', async () => {
+    const last = await callErr('compatibility.create_subprojects', 422, () =>
+      client.compat.accounts.create({ FriendlyName: 'Sub' }),
+    );
+    expect(last.matched_route).toBe('compatibility.create_subprojects');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.accounts.get('AC123'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/laml/2010-04-01/Accounts/AC123');
+    expect(last.matched_route).toBe('compatibility.get_account');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.get_account', 404, () =>
+      client.compat.accounts.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.get_account');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (POST)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.accounts.update('AC123', { FriendlyName: 'Renamed' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/laml/2010-04-01/Accounts/AC123');
+    expect(last.matched_route).toBe('compatibility.update_account');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('compatibility.update_account', 404, () =>
+      client.compat.accounts.update('missing', { FriendlyName: 'x' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_account');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Calls (with recording + stream sub-resources) ---------------------
+
+describe('Compat Calls', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.calls.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Calls`);
+    expect(last.matched_route).toBe('compatibility.list_all_calls');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_all_calls', 500, () =>
+      client.compat.calls.list(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_all_calls');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() =>
+      client.compat.calls.create({ To: '+15553334444', From: '+15551112222', Url: 'http://x' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Calls`);
+    expect(last.matched_route).toBe('compatibility.create_a_call');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('compatibility.create_a_call', 422, () =>
+      client.compat.calls.create({ To: '+1', From: '+1', Url: 'http://x' }),
+    );
+    expect(last.matched_route).toBe('compatibility.create_a_call');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.calls.get('CA1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Calls/CA1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_a_call');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.retrieve_a_call', 404, () =>
+      client.compat.calls.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_a_call');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (POST)', async () => {
+    const { last } = await callOk(() => client.compat.calls.update('CA1', { Status: 'completed' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Calls/CA1`);
+    expect(last.matched_route).toBe('compatibility.update_a_call');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('compatibility.update_a_call', 404, () =>
+      client.compat.calls.update('missing', { Status: 'completed' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_a_call');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.compat.calls.delete('CA1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Calls/CA1`);
+    expect(last.matched_route).toBe('compatibility.delete_a_call');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('compatibility.delete_a_call', 404, () =>
+      client.compat.calls.delete('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_a_call');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('start recording success', async () => {
+    const { last } = await callOk(() => client.compat.calls.startRecording('CA1', {}));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Calls/CA1/Recordings`);
+    expect(last.matched_route).toBe('compatibility.create_recording');
+  });
+  it('start recording error 422', async () => {
+    const last = await callErr('compatibility.create_recording', 422, () =>
+      client.compat.calls.startRecording('CA1', {}),
+    );
+    expect(last.matched_route).toBe('compatibility.create_recording');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('update recording success', async () => {
+    const { last } = await callOk(() =>
+      client.compat.calls.updateRecording('CA1', 'RE1', { Status: 'stopped' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Calls/CA1/Recordings/RE1`);
+    expect(last.matched_route).toBe('compatibility.update_recording');
+  });
+  it('update recording error 404', async () => {
+    const last = await callErr('compatibility.update_recording', 404, () =>
+      client.compat.calls.updateRecording('CA1', 'missing', { Status: 'stopped' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_recording');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('start stream success', async () => {
+    const { last } = await callOk(() => client.compat.calls.startStream('CA1', { Url: 'wss://x' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Calls/CA1/Streams`);
+    expect(last.matched_route).toBe('compatibility.create_stream');
+  });
+  it('start stream error 422', async () => {
+    const last = await callErr('compatibility.create_stream', 422, () =>
+      client.compat.calls.startStream('CA1', {}),
+    );
+    expect(last.matched_route).toBe('compatibility.create_stream');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('stop stream success (POST)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.calls.stopStream('CA1', 'MZ1', { Status: 'stopped' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Calls/CA1/Streams/MZ1`);
+    expect(last.matched_route).toBe('compatibility.update_stream');
+  });
+  it('stop stream error 404', async () => {
+    const last = await callErr('compatibility.update_stream', 404, () =>
+      client.compat.calls.stopStream('CA1', 'missing', { Status: 'stopped' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_stream');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Messages (with media sub-resources) -------------------------------
+
+describe('Compat Messages', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.messages.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Messages`);
+    expect(last.matched_route).toBe('compatibility.list_messages');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_messages', 500, () =>
+      client.compat.messages.list(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_messages');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() =>
+      client.compat.messages.create({ To: '+15553334444', From: '+15551112222', Body: 'hi' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Messages`);
+    expect(last.matched_route).toBe('compatibility.create_message');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('compatibility.create_message', 422, () =>
+      client.compat.messages.create({ To: '+1', From: '+1', Body: 'hi' }),
+    );
+    expect(last.matched_route).toBe('compatibility.create_message');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.messages.get('SM1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Messages/SM1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_message');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.retrieve_message', 404, () =>
+      client.compat.messages.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_message');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (POST)', async () => {
+    const { last } = await callOk(() => client.compat.messages.update('SM1', { Body: 'edited' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Messages/SM1`);
+    expect(last.matched_route).toBe('compatibility.update_message');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('compatibility.update_message', 404, () =>
+      client.compat.messages.update('missing', { Body: 'edited' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_message');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.compat.messages.delete('SM1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Messages/SM1`);
+    expect(last.matched_route).toBe('compatibility.delete_message');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('compatibility.delete_message', 404, () =>
+      client.compat.messages.delete('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_message');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list media success', async () => {
+    const { body, last } = await callOk(() => client.compat.messages.listMedia('SM1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Messages/SM1/Media`);
+    expect(last.matched_route).toBe('compatibility.list_media');
+  });
+  it('list media error 500', async () => {
+    const last = await callErr('compatibility.list_media', 500, () =>
+      client.compat.messages.listMedia('SM1'),
+    );
+    expect(last.matched_route).toBe('compatibility.list_media');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get media success', async () => {
+    const { last } = await callOk(() => client.compat.messages.getMedia('SM1', 'ME1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Messages/SM1/Media/ME1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_media');
+  });
+  it('get media error 404', async () => {
+    const last = await callErr('compatibility.retrieve_media', 404, () =>
+      client.compat.messages.getMedia('SM1', 'missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_media');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete media success', async () => {
+    const { last } = await callOk(() => client.compat.messages.deleteMedia('SM1', 'ME1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Messages/SM1/Media/ME1`);
+    expect(last.matched_route).toBe('compatibility.delete_message_media');
+  });
+  it('delete media error 404', async () => {
+    const last = await callErr('compatibility.delete_message_media', 404, () =>
+      client.compat.messages.deleteMedia('SM1', 'missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_message_media');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Faxes (with media sub-resources) ----------------------------------
+
+describe('Compat Faxes', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.faxes.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Faxes`);
+    expect(last.matched_route).toBe('compatibility.list_all_faxes');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_all_faxes', 500, () =>
+      client.compat.faxes.list(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_all_faxes');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('send (create) success', async () => {
+    const { last } = await callOk(() =>
+      client.compat.faxes.create({
+        To: '+15553334444',
+        From: '+15551112222',
+        MediaUrl: 'http://x',
+      }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Faxes`);
+    expect(last.matched_route).toBe('compatibility.send_fax');
+  });
+  it('send (create) error 422', async () => {
+    const last = await callErr('compatibility.send_fax', 422, () =>
+      client.compat.faxes.create({ To: '+1', From: '+1', MediaUrl: 'http://x' }),
+    );
+    expect(last.matched_route).toBe('compatibility.send_fax');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.faxes.get('FX1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Faxes/FX1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_fax');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.retrieve_fax', 404, () =>
+      client.compat.faxes.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_fax');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (POST)', async () => {
+    const { last } = await callOk(() => client.compat.faxes.update('FX1', { Status: 'canceled' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Faxes/FX1`);
+    expect(last.matched_route).toBe('compatibility.update_fax');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('compatibility.update_fax', 404, () =>
+      client.compat.faxes.update('missing', { Status: 'canceled' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_fax');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.compat.faxes.delete('FX1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Faxes/FX1`);
+    expect(last.matched_route).toBe('compatibility.delete_fax');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('compatibility.delete_fax', 404, () =>
+      client.compat.faxes.delete('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_fax');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list media success', async () => {
+    const { body, last } = await callOk(() => client.compat.faxes.listMedia('FX1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Faxes/FX1/Media`);
+    expect(last.matched_route).toBe('compatibility.list_all_fax_media');
+  });
+  it('list media error 500', async () => {
+    const last = await callErr('compatibility.list_all_fax_media', 500, () =>
+      client.compat.faxes.listMedia('FX1'),
+    );
+    expect(last.matched_route).toBe('compatibility.list_all_fax_media');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get media success', async () => {
+    const { last } = await callOk(() => client.compat.faxes.getMedia('FX1', 'ME1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Faxes/FX1/Media/ME1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_medias');
+  });
+  it('get media error 404', async () => {
+    const last = await callErr('compatibility.retrieve_medias', 404, () =>
+      client.compat.faxes.getMedia('FX1', 'missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_medias');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete media success', async () => {
+    const { last } = await callOk(() => client.compat.faxes.deleteMedia('FX1', 'ME1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Faxes/FX1/Media/ME1`);
+    expect(last.matched_route).toBe('compatibility.delete_fax_media');
+  });
+  it('delete media error 404', async () => {
+    const last = await callErr('compatibility.delete_fax_media', 404, () =>
+      client.compat.faxes.deleteMedia('FX1', 'missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_fax_media');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Conferences (participants, recordings, streams) -------------------
+
+describe('Compat Conferences', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.conferences.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Conferences`);
+    expect(last.matched_route).toBe('compatibility.list_all_conferences');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_all_conferences', 500, () =>
+      client.compat.conferences.list(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_all_conferences');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.conferences.get('CF1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Conferences/CF1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_conference');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.retrieve_conference', 404, () =>
+      client.compat.conferences.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_conference');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (POST)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.conferences.update('CF1', { Status: 'completed' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Conferences/CF1`);
+    expect(last.matched_route).toBe('compatibility.update_conference');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('compatibility.update_conference', 404, () =>
+      client.compat.conferences.update('missing', { Status: 'completed' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_conference');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list participants success', async () => {
+    const { body, last } = await callOk(() => client.compat.conferences.listParticipants('CF1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Conferences/CF1/Participants`);
+    expect(last.matched_route).toBe('compatibility.list_all_participants');
+  });
+  it('list participants error 500', async () => {
+    const last = await callErr('compatibility.list_all_participants', 500, () =>
+      client.compat.conferences.listParticipants('CF1'),
+    );
+    expect(last.matched_route).toBe('compatibility.list_all_participants');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get participant success', async () => {
+    const { last } = await callOk(() => client.compat.conferences.getParticipant('CF1', 'CA1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Conferences/CF1/Participants/CA1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_participant');
+  });
+  it('get participant error 404', async () => {
+    const last = await callErr('compatibility.retrieve_participant', 404, () =>
+      client.compat.conferences.getParticipant('CF1', 'missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_participant');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update participant success (POST)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.conferences.updateParticipant('CF1', 'CA1', { Muted: 'true' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Conferences/CF1/Participants/CA1`);
+    expect(last.matched_route).toBe('compatibility.update_participant');
+  });
+  it('update participant error 404', async () => {
+    const last = await callErr('compatibility.update_participant', 404, () =>
+      client.compat.conferences.updateParticipant('CF1', 'missing', { Muted: 'true' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_participant');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('remove participant success', async () => {
+    const { last } = await callOk(() => client.compat.conferences.removeParticipant('CF1', 'CA1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Conferences/CF1/Participants/CA1`);
+    expect(last.matched_route).toBe('compatibility.delete_participant');
+  });
+  it('remove participant error 404', async () => {
+    const last = await callErr('compatibility.delete_participant', 404, () =>
+      client.compat.conferences.removeParticipant('CF1', 'missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_participant');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list recordings success', async () => {
+    const { body, last } = await callOk(() => client.compat.conferences.listRecordings('CF1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Conferences/CF1/Recordings`);
+    expect(last.matched_route).toBe('compatibility.list_conference_recordings');
+  });
+  it('list recordings error 500', async () => {
+    const last = await callErr('compatibility.list_conference_recordings', 500, () =>
+      client.compat.conferences.listRecordings('CF1'),
+    );
+    expect(last.matched_route).toBe('compatibility.list_conference_recordings');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get recording success', async () => {
+    const { last } = await callOk(() => client.compat.conferences.getRecording('CF1', 'RE1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Conferences/CF1/Recordings/RE1`);
+    expect(last.matched_route).toBe('compatibility.get_conference_recording');
+  });
+  it('get recording error 404', async () => {
+    const last = await callErr('compatibility.get_conference_recording', 404, () =>
+      client.compat.conferences.getRecording('CF1', 'missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.get_conference_recording');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update recording success (POST)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.conferences.updateRecording('CF1', 'RE1', { Status: 'stopped' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Conferences/CF1/Recordings/RE1`);
+    expect(last.matched_route).toBe('compatibility.update_conference_recording');
+  });
+  it('update recording error 404', async () => {
+    const last = await callErr('compatibility.update_conference_recording', 404, () =>
+      client.compat.conferences.updateRecording('CF1', 'missing', { Status: 'stopped' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_conference_recording');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete recording success', async () => {
+    const { last } = await callOk(() => client.compat.conferences.deleteRecording('CF1', 'RE1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Conferences/CF1/Recordings/RE1`);
+    expect(last.matched_route).toBe('compatibility.delete_conference_recording');
+  });
+  it('delete recording error 404', async () => {
+    const last = await callErr('compatibility.delete_conference_recording', 404, () =>
+      client.compat.conferences.deleteRecording('CF1', 'missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_conference_recording');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('start stream success', async () => {
+    const { last } = await callOk(() =>
+      client.compat.conferences.startStream('CF1', { Url: 'wss://x' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Conferences/CF1/Streams`);
+    expect(last.matched_route).toBe('compatibility.create_conference_stream');
+  });
+  it('start stream error 422', async () => {
+    const last = await callErr('compatibility.create_conference_stream', 422, () =>
+      client.compat.conferences.startStream('CF1', {}),
+    );
+    expect(last.matched_route).toBe('compatibility.create_conference_stream');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('stop stream success (POST)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.conferences.stopStream('CF1', 'MZ1', { Status: 'stopped' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Conferences/CF1/Streams/MZ1`);
+    expect(last.matched_route).toBe('compatibility.update_conference_stream');
+  });
+  it('stop stream error 404', async () => {
+    const last = await callErr('compatibility.update_conference_stream', 404, () =>
+      client.compat.conferences.stopStream('CF1', 'missing', { Status: 'stopped' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_conference_stream');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Phone Numbers (incoming + imported + available search) ------------
+
+describe('Compat Phone Numbers', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.phoneNumbers.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/IncomingPhoneNumbers`);
+    expect(last.matched_route).toBe('compatibility.list_incoming_phone_numbers');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_incoming_phone_numbers', 500, () =>
+      client.compat.phoneNumbers.list(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_incoming_phone_numbers');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('purchase success', async () => {
+    const { last } = await callOk(() =>
+      client.compat.phoneNumbers.purchase({ PhoneNumber: '+15551112222' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/IncomingPhoneNumbers`);
+    expect(last.matched_route).toBe('compatibility.create_incoming_phone_number');
+  });
+  it('purchase error 422', async () => {
+    const last = await callErr('compatibility.create_incoming_phone_number', 422, () =>
+      client.compat.phoneNumbers.purchase({ PhoneNumber: '+1' }),
+    );
+    expect(last.matched_route).toBe('compatibility.create_incoming_phone_number');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.phoneNumbers.get('PN1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/IncomingPhoneNumbers/PN1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_incoming_phone_number');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.retrieve_incoming_phone_number', 404, () =>
+      client.compat.phoneNumbers.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_incoming_phone_number');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (POST)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.phoneNumbers.update('PN1', { FriendlyName: 'x' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/IncomingPhoneNumbers/PN1`);
+    expect(last.matched_route).toBe('compatibility.update_incoming_phone_number');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('compatibility.update_incoming_phone_number', 404, () =>
+      client.compat.phoneNumbers.update('missing', { FriendlyName: 'x' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_incoming_phone_number');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.compat.phoneNumbers.delete('PN1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/IncomingPhoneNumbers/PN1`);
+    expect(last.matched_route).toBe('compatibility.delete_incoming_phone_number');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('compatibility.delete_incoming_phone_number', 404, () =>
+      client.compat.phoneNumbers.delete('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_incoming_phone_number');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('import number success', async () => {
+    const { last } = await callOk(() =>
+      client.compat.phoneNumbers.importNumber({
+        number: '+15551112222',
+        number_type: 'longcode',
+      }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/ImportedPhoneNumbers`);
+    expect(last.matched_route).toBe('compatibility.create_imported_phone_number');
+  });
+  it('import number error 422', async () => {
+    const last = await callErr('compatibility.create_imported_phone_number', 422, () =>
+      client.compat.phoneNumbers.importNumber({ number: '+1', number_type: 'longcode' }),
+    );
+    expect(last.matched_route).toBe('compatibility.create_imported_phone_number');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('list available countries success', async () => {
+    const { body, last } = await callOk(() => client.compat.phoneNumbers.listAvailableCountries());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/AvailablePhoneNumbers`);
+    expect(last.matched_route).toBe('compatibility.list_available_phone_number_resources');
+  });
+  it('list available countries error 500', async () => {
+    const last = await callErr('compatibility.list_available_phone_number_resources', 500, () =>
+      client.compat.phoneNumbers.listAvailableCountries(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_available_phone_number_resources');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('search local success', async () => {
+    const { body, last } = await callOk(() => client.compat.phoneNumbers.searchLocal('US'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/AvailablePhoneNumbers/US/Local`);
+    expect(last.matched_route).toBe('compatibility.search_local_available_phone_numbers');
+  });
+  it('search local error 500', async () => {
+    const last = await callErr('compatibility.search_local_available_phone_numbers', 500, () =>
+      client.compat.phoneNumbers.searchLocal('US'),
+    );
+    expect(last.matched_route).toBe('compatibility.search_local_available_phone_numbers');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('search toll-free success', async () => {
+    const { body, last } = await callOk(() => client.compat.phoneNumbers.searchTollFree('US'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/AvailablePhoneNumbers/US/TollFree`);
+    expect(last.matched_route).toBe('compatibility.search_toll_free_available_phone_numbers');
+  });
+  it('search toll-free error 500', async () => {
+    const last = await callErr('compatibility.search_toll_free_available_phone_numbers', 500, () =>
+      client.compat.phoneNumbers.searchTollFree('US'),
+    );
+    expect(last.matched_route).toBe('compatibility.search_toll_free_available_phone_numbers');
+    expect(last.response_status).toBe(500);
+  });
+
+  // GAP: compatibility.list_available_phone_number_resources_by_country
+  // (bare GET /AvailablePhoneNumbers/{IsoCountry}) has no SDK surface — the
+  // namespace exposes only the /Local and /TollFree searches. Same accepted
+  // gap as python/java; not faked.
+});
+
+// ---- Applications ------------------------------------------------------
+
+describe('Compat Applications', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.applications.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Applications`);
+    expect(last.matched_route).toBe('compatibility.list_applications');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_applications', 500, () =>
+      client.compat.applications.list(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_applications');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.compat.applications.create({ FriendlyName: 'app' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Applications`);
+    expect(last.matched_route).toBe('compatibility.create_application');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('compatibility.create_application', 422, () =>
+      client.compat.applications.create({ FriendlyName: 'app' }),
+    );
+    expect(last.matched_route).toBe('compatibility.create_application');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.applications.get('AP1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Applications/AP1`);
+    expect(last.matched_route).toBe('compatibility.get_application');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.get_application', 404, () =>
+      client.compat.applications.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.get_application');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (POST)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.applications.update('AP1', { FriendlyName: 'x' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Applications/AP1`);
+    expect(last.matched_route).toBe('compatibility.update_application');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('compatibility.update_application', 404, () =>
+      client.compat.applications.update('missing', { FriendlyName: 'x' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_application');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.compat.applications.delete('AP1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Applications/AP1`);
+    expect(last.matched_route).toBe('compatibility.delete_application');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('compatibility.delete_application', 404, () =>
+      client.compat.applications.delete('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_application');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- LaML Bins (cXML scripts) ------------------------------------------
+
+describe('Compat LaML Bins', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.lamlBins.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/LamlBins`);
+    expect(last.matched_route).toBe('compatibility.list_cxml_scripts');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_cxml_scripts', 500, () =>
+      client.compat.lamlBins.list(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_cxml_scripts');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() =>
+      client.compat.lamlBins.create({ Name: 'bin', Contents: '<Response/>' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/LamlBins`);
+    expect(last.matched_route).toBe('compatibility.create_cxml_script');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('compatibility.create_cxml_script', 422, () =>
+      client.compat.lamlBins.create({ Name: 'bin', Contents: '<Response/>' }),
+    );
+    expect(last.matched_route).toBe('compatibility.create_cxml_script');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.lamlBins.get('LA1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/LamlBins/LA1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_cxml_script');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.retrieve_cxml_script', 404, () =>
+      client.compat.lamlBins.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_cxml_script');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (POST)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.lamlBins.update('LA1', { Contents: '<Response/>' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/LamlBins/LA1`);
+    expect(last.matched_route).toBe('compatibility.update_cxml_script');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('compatibility.update_cxml_script', 404, () =>
+      client.compat.lamlBins.update('missing', { Contents: '<Response/>' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_cxml_script');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.compat.lamlBins.delete('LA1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/LamlBins/LA1`);
+    expect(last.matched_route).toBe('compatibility.delete_cxml_script');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('compatibility.delete_cxml_script', 404, () =>
+      client.compat.lamlBins.delete('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_cxml_script');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Queues (with member operations) -----------------------------------
+
+describe('Compat Queues', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.queues.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Queues`);
+    expect(last.matched_route).toBe('compatibility.list_queues');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_queues', 500, () => client.compat.queues.list());
+    expect(last.matched_route).toBe('compatibility.list_queues');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.compat.queues.create({ FriendlyName: 'support' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Queues`);
+    expect(last.matched_route).toBe('compatibility.create_queue');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('compatibility.create_queue', 422, () =>
+      client.compat.queues.create({ FriendlyName: 'support' }),
+    );
+    expect(last.matched_route).toBe('compatibility.create_queue');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.queues.get('QU1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Queues/QU1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_queue');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.retrieve_queue', 404, () =>
+      client.compat.queues.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_queue');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (POST)', async () => {
+    const { last } = await callOk(() => client.compat.queues.update('QU1', { FriendlyName: 'x' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Queues/QU1`);
+    expect(last.matched_route).toBe('compatibility.update_queue');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('compatibility.update_queue', 404, () =>
+      client.compat.queues.update('missing', { FriendlyName: 'x' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_queue');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.compat.queues.delete('QU1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Queues/QU1`);
+    expect(last.matched_route).toBe('compatibility.delete_queue');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('compatibility.delete_queue', 404, () =>
+      client.compat.queues.delete('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_queue');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list members success', async () => {
+    const { body, last } = await callOk(() => client.compat.queues.listMembers('QU1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Queues/QU1/Members`);
+    expect(last.matched_route).toBe('compatibility.list_all_queue_members');
+  });
+  it('list members error 500', async () => {
+    const last = await callErr('compatibility.list_all_queue_members', 500, () =>
+      client.compat.queues.listMembers('QU1'),
+    );
+    expect(last.matched_route).toBe('compatibility.list_all_queue_members');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get member success', async () => {
+    const { last } = await callOk(() => client.compat.queues.getMember('QU1', 'CA1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Queues/QU1/Members/CA1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_queue_member');
+  });
+  it('get member error 404', async () => {
+    const last = await callErr('compatibility.retrieve_queue_member', 404, () =>
+      client.compat.queues.getMember('QU1', 'missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_queue_member');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('dequeue member success (POST)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.queues.dequeueMember('QU1', 'CA1', { Url: 'http://x' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/Queues/QU1/Members/CA1`);
+    expect(last.matched_route).toBe('compatibility.update_queue_member');
+  });
+  it('dequeue member error 404', async () => {
+    const last = await callErr('compatibility.update_queue_member', 404, () =>
+      client.compat.queues.dequeueMember('QU1', 'missing', { Url: 'http://x' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_queue_member');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Recordings (list / get / delete) ----------------------------------
+
+describe('Compat Recordings', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.recordings.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Recordings`);
+    expect(last.matched_route).toBe('compatibility.list_recordings');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_recordings', 500, () =>
+      client.compat.recordings.list(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_recordings');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.recordings.get('RE1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Recordings/RE1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_recording');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.retrieve_recording', 404, () =>
+      client.compat.recordings.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_recording');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.compat.recordings.delete('RE1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Recordings/RE1`);
+    expect(last.matched_route).toBe('compatibility.delete_recording');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('compatibility.delete_recording', 404, () =>
+      client.compat.recordings.delete('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_recording');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Transcriptions (list / get / delete) ------------------------------
+
+describe('Compat Transcriptions', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.compat.transcriptions.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Transcriptions`);
+    expect(last.matched_route).toBe('compatibility.list_transcriptions');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('compatibility.list_transcriptions', 500, () =>
+      client.compat.transcriptions.list(),
+    );
+    expect(last.matched_route).toBe('compatibility.list_transcriptions');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.compat.transcriptions.get('TR1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe(`${base()}/Transcriptions/TR1`);
+    expect(last.matched_route).toBe('compatibility.retrieve_transcription');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('compatibility.retrieve_transcription', 404, () =>
+      client.compat.transcriptions.get('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.retrieve_transcription');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.compat.transcriptions.delete('TR1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/Transcriptions/TR1`);
+    expect(last.matched_route).toBe('compatibility.delete_transcription');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('compatibility.delete_transcription', 404, () =>
+      client.compat.transcriptions.delete('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_transcription');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Tokens (create / update PATCH / delete) ---------------------------
+
+describe('Compat Tokens', () => {
+  it('create success', async () => {
+    const { last } = await callOk(() =>
+      client.compat.tokens.create({ name: 'tok', permissions: ['calling'] }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe(`${base()}/tokens`);
+    expect(last.matched_route).toBe('compatibility.create_token');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('compatibility.create_token', 422, () =>
+      client.compat.tokens.create({ name: 'tok', permissions: ['calling'] }),
+    );
+    expect(last.matched_route).toBe('compatibility.create_token');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('update success (PATCH)', async () => {
+    const { last } = await callOk(() =>
+      client.compat.tokens.update('tok-1', { FriendlyName: 'x' }),
+    );
+    expect(last.method).toBe('PATCH');
+    expect(last.path).toBe(`${base()}/tokens/tok-1`);
+    expect(last.matched_route).toBe('compatibility.update_token');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('compatibility.update_token', 404, () =>
+      client.compat.tokens.update('missing', { FriendlyName: 'x' }),
+    );
+    expect(last.matched_route).toBe('compatibility.update_token');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.compat.tokens.delete('tok-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe(`${base()}/tokens/tok-1`);
+    expect(last.matched_route).toBe('compatibility.delete_token');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('compatibility.delete_token', 404, () =>
+      client.compat.tokens.delete('missing'),
+    );
+    expect(last.matched_route).toBe('compatibility.delete_token');
+    expect(last.response_status).toBe(404);
+  });
+});

--- a/tests/rest/datasphere_coverage_mock.test.ts
+++ b/tests/rest/datasphere_coverage_mock.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Full REST success + error coverage for the `datasphere` spec group.
+ *
+ * Mirrors the proven python/java suites and the canonical
+ * tests/rest/fabric_coverage_mock.test.ts style: every coverable canonical
+ * datasphere route (9 of 9 — ZERO gaps, matching python/java) gets BOTH a
+ * success (2xx) test and an error (4xx/5xx) test, asserting method, path,
+ * matched_route, and (for errors) response_status against the mock journal.
+ *
+ * Routes covered (9):
+ *   datasphere.list_documents          GET    /api/datasphere/documents
+ *   datasphere.create_document         POST   /api/datasphere/documents
+ *   datasphere.search_documents        POST   /api/datasphere/documents/search
+ *   datasphere.list_document_chunks    GET    /api/datasphere/documents/{documentId}/chunks
+ *   datasphere.get_document_chunk      GET    /api/datasphere/documents/{documentId}/chunks/{chunkId}
+ *   datasphere.delete_document_chunk   DELETE /api/datasphere/documents/{documentId}/chunks/{chunkId}
+ *   datasphere.get_document            GET    /api/datasphere/documents/{id}
+ *   datasphere.update_document         PATCH  /api/datasphere/documents/{id}
+ *   datasphere.delete_document         DELETE /api/datasphere/documents/{id}
+ *
+ * Companion to tests/rest/datasphere.test.ts (idiom); self-contained.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { newMockClient } from './mocktest.js';
+import type { RestClient } from '../../src/rest/index.js';
+import type { JournalEntry, MockHarness } from './mocktest.js';
+import { RestError } from '../../src/rest/RestError.js';
+
+let client: RestClient;
+let mock: MockHarness;
+
+beforeEach(async () => {
+  ({ client, mock } = await newMockClient());
+});
+
+// ---- DRY helpers -------------------------------------------------------
+//
+// Each helper RETURNS the journal entry (or response) so the calling `it()`
+// body holds its own real assertions — the no-cheat auditor is intra-function.
+
+/**
+ * Await an SDK call, then return its response body alongside the last journal
+ * entry. The caller asserts on both.
+ */
+async function callOk<T>(fn: () => Promise<T>): Promise<{ body: T; last: JournalEntry }> {
+  const body = await fn();
+  const last = await mock.last();
+  return { body, last };
+}
+
+/**
+ * Arm a one-shot error scenario for `endpointId`, assert the SDK call rejects
+ * with RestError, and return the recorded journal entry for body assertions.
+ */
+async function callErr(
+  endpointId: string,
+  status: number,
+  fn: () => Promise<unknown>,
+): Promise<JournalEntry> {
+  await mock.pushScenario(endpointId, status, { error: 'x' });
+  await expect(fn()).rejects.toThrow(RestError);
+  return mock.last();
+}
+
+// ---- Datasphere Documents ----------------------------------------------
+
+describe('Datasphere Documents', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.datasphere.documents.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/datasphere/documents');
+    expect(last.matched_route).toBe('datasphere.list_documents');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('datasphere.list_documents', 500, () =>
+      client.datasphere.documents.list(),
+    );
+    expect(last.matched_route).toBe('datasphere.list_documents');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() =>
+      client.datasphere.documents.create({ url: 'https://example.com/doc.pdf' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/datasphere/documents');
+    expect(last.matched_route).toBe('datasphere.create_document');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('datasphere.create_document', 422, () =>
+      client.datasphere.documents.create({ url: 'https://example.com/doc.pdf' }),
+    );
+    expect(last.matched_route).toBe('datasphere.create_document');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('search success', async () => {
+    const { last } = await callOk(() =>
+      client.datasphere.documents.search({ query_string: 'find me', count: 3 }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/datasphere/documents/search');
+    expect(last.matched_route).toBe('datasphere.search_documents');
+  });
+  it('search error 422', async () => {
+    const last = await callErr('datasphere.search_documents', 422, () =>
+      client.datasphere.documents.search({ query_string: 'find me' }),
+    );
+    expect(last.matched_route).toBe('datasphere.search_documents');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('list chunks success', async () => {
+    const { body, last } = await callOk(() => client.datasphere.documents.listChunks('doc-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/datasphere/documents/doc-1/chunks');
+    expect(last.matched_route).toBe('datasphere.list_document_chunks');
+  });
+  it('list chunks error 500', async () => {
+    const last = await callErr('datasphere.list_document_chunks', 500, () =>
+      client.datasphere.documents.listChunks('doc-1'),
+    );
+    expect(last.matched_route).toBe('datasphere.list_document_chunks');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get chunk success', async () => {
+    const { last } = await callOk(() => client.datasphere.documents.getChunk('doc-1', 'ch-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/datasphere/documents/doc-1/chunks/ch-1');
+    expect(last.matched_route).toBe('datasphere.get_document_chunk');
+  });
+  it('get chunk error 404', async () => {
+    const last = await callErr('datasphere.get_document_chunk', 404, () =>
+      client.datasphere.documents.getChunk('doc-1', 'missing'),
+    );
+    expect(last.matched_route).toBe('datasphere.get_document_chunk');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete chunk success', async () => {
+    const { last } = await callOk(() => client.datasphere.documents.deleteChunk('doc-1', 'ch-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/datasphere/documents/doc-1/chunks/ch-1');
+    expect(last.matched_route).toBe('datasphere.delete_document_chunk');
+  });
+  it('delete chunk error 404', async () => {
+    const last = await callErr('datasphere.delete_document_chunk', 404, () =>
+      client.datasphere.documents.deleteChunk('doc-1', 'missing'),
+    );
+    expect(last.matched_route).toBe('datasphere.delete_document_chunk');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.datasphere.documents.get('doc-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/datasphere/documents/doc-1');
+    expect(last.matched_route).toBe('datasphere.get_document');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('datasphere.get_document', 404, () =>
+      client.datasphere.documents.get('missing'),
+    );
+    expect(last.matched_route).toBe('datasphere.get_document');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PATCH)', async () => {
+    const { last } = await callOk(() =>
+      client.datasphere.documents.update('doc-1', { tags: ['renamed'] }),
+    );
+    expect(last.method).toBe('PATCH');
+    expect(last.path).toBe('/api/datasphere/documents/doc-1');
+    expect(last.matched_route).toBe('datasphere.update_document');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('datasphere.update_document', 404, () =>
+      client.datasphere.documents.update('missing', { tags: ['renamed'] }),
+    );
+    expect(last.matched_route).toBe('datasphere.update_document');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.datasphere.documents.delete('doc-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/datasphere/documents/doc-1');
+    expect(last.matched_route).toBe('datasphere.delete_document');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('datasphere.delete_document', 404, () =>
+      client.datasphere.documents.delete('missing'),
+    );
+    expect(last.matched_route).toBe('datasphere.delete_document');
+    expect(last.response_status).toBe(404);
+  });
+});

--- a/tests/rest/fabric_coverage_mock.test.ts
+++ b/tests/rest/fabric_coverage_mock.test.ts
@@ -1,0 +1,1531 @@
+/**
+ * Full REST success + error coverage for the `fabric` spec group.
+ *
+ * Mirrors the proven python/java suites: every coverable canonical fabric
+ * route (96 of 103) gets BOTH a success (2xx) test and an error (4xx/5xx)
+ * test, asserting method, path, matched_route, and (for errors)
+ * response_status against the mock journal.
+ *
+ * Gaps (7, same as python/java — NOT faked):
+ *   - fabric.list_dialogflow_agents / get / update / delete /
+ *     list_dialogflow_agent_addresses (5) — no SDK surface.
+ *   - fabric.list_sip_gateway_addresses (doubled-path artifact:
+ *     /sip_gateways/resources/sip_gateways/{resource_id}/addresses).
+ *   - fabric.assign_resource_sip_endpoint (doubled-path artifact:
+ *     /sip_endpoints/resources/{id}/sip_endpoints).
+ *
+ * Companion to tests/rest/fabric_mock.test.ts (idiom); self-contained.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { newMockClient } from './mocktest.js';
+import type { RestClient } from '../../src/rest/index.js';
+import type { JournalEntry, MockHarness } from './mocktest.js';
+import { RestError } from '../../src/rest/RestError.js';
+
+let client: RestClient;
+let mock: MockHarness;
+
+beforeEach(async () => {
+  ({ client, mock } = await newMockClient());
+});
+
+// ---- DRY helpers -------------------------------------------------------
+//
+// Each helper RETURNS the journal entry (or response) so the calling `it()`
+// body holds its own real assertions — the no-cheat auditor is intra-function.
+
+/**
+ * Await an SDK call, then return its response body alongside the last journal
+ * entry. The caller asserts on both.
+ */
+async function callOk<T>(fn: () => Promise<T>): Promise<{ body: T; last: JournalEntry }> {
+  const body = await fn();
+  const last = await mock.last();
+  return { body, last };
+}
+
+/**
+ * Arm a one-shot error scenario for `endpointId`, assert the SDK call rejects
+ * with RestError, and return the recorded journal entry for body assertions.
+ */
+async function callErr(
+  endpointId: string,
+  status: number,
+  fn: () => Promise<unknown>,
+): Promise<JournalEntry> {
+  await mock.pushScenario(endpointId, status, { error: 'x' });
+  await expect(fn()).rejects.toThrow(RestError);
+  return mock.last();
+}
+
+// ---- Fabric Addresses --------------------------------------------------
+
+describe('Fabric Addresses', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.addresses.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/addresses');
+    expect(last.matched_route).toBe('fabric.list_fabric_addresses');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_fabric_addresses', 500, () =>
+      client.fabric.addresses.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_fabric_addresses');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.addresses.get('addr-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/addresses/addr-1');
+    expect(last.matched_route).toBe('fabric.get_fabric_address');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_fabric_address', 404, () =>
+      client.fabric.addresses.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_fabric_address');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Fabric Tokens -----------------------------------------------------
+
+describe('Fabric Tokens', () => {
+  it('create embeds token success', async () => {
+    const { last } = await callOk(() => client.fabric.tokens.createEmbedToken({}));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/embeds/tokens');
+    expect(last.matched_route).toBe('fabric.create_embeds_token');
+  });
+  it('create embeds token error 422', async () => {
+    const last = await callErr('fabric.create_embeds_token', 422, () =>
+      client.fabric.tokens.createEmbedToken({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_embeds_token');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('create guest token success', async () => {
+    const { last } = await callOk(() => client.fabric.tokens.createGuestToken({}));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/guests/tokens');
+    expect(last.matched_route).toBe('fabric.create_subscriber_guest_token');
+  });
+  it('create guest token error 422', async () => {
+    const last = await callErr('fabric.create_subscriber_guest_token', 422, () =>
+      client.fabric.tokens.createGuestToken({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_subscriber_guest_token');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('create invite token success', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.tokens.createInviteToken({ email: 'a@b.com' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/subscriber/invites');
+    expect(last.matched_route).toBe('fabric.create_subscriber_invite_token');
+  });
+  it('create invite token error 422', async () => {
+    const last = await callErr('fabric.create_subscriber_invite_token', 422, () =>
+      client.fabric.tokens.createInviteToken({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_subscriber_invite_token');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('create subscriber token success', async () => {
+    const { last } = await callOk(() => client.fabric.tokens.createSubscriberToken({}));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/subscribers/tokens');
+    expect(last.matched_route).toBe('fabric.create_subscriber_token');
+  });
+  it('create subscriber token error 422', async () => {
+    const last = await callErr('fabric.create_subscriber_token', 422, () =>
+      client.fabric.tokens.createSubscriberToken({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_subscriber_token');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('refresh subscriber token success', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.tokens.refreshSubscriberToken({ refresh_token: 'r-1' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/subscribers/tokens/refresh');
+    expect(last.matched_route).toBe('fabric.refresh_subscriber_token');
+  });
+  it('refresh subscriber token error 422', async () => {
+    const last = await callErr('fabric.refresh_subscriber_token', 422, () =>
+      client.fabric.tokens.refreshSubscriberToken({}),
+    );
+    expect(last.matched_route).toBe('fabric.refresh_subscriber_token');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- Generic Resources -------------------------------------------------
+
+describe('Generic Resources', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.resources.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources');
+    expect(last.matched_route).toBe('fabric.list_resources');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_resources', 500, () => client.fabric.resources.list());
+    expect(last.matched_route).toBe('fabric.list_resources');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.resources.get('res-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/res-1');
+    expect(last.matched_route).toBe('fabric.get_resource');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_resource', 404, () =>
+      client.fabric.resources.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_resource');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.resources.delete('res-2'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/res-2');
+    expect(last.matched_route).toBe('fabric.delete_resource');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_resource', 404, () =>
+      client.fabric.resources.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_resource');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() => client.fabric.resources.listAddresses('res-3'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/res-3/addresses');
+    expect(last.matched_route).toBe('fabric.list_resource_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_resource_addresses', 500, () =>
+      client.fabric.resources.listAddresses('res-3'),
+    );
+    expect(last.matched_route).toBe('fabric.list_resource_addresses');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('assign domain application success', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.resources.assignDomainApplication('res-4', { domain_application_id: 'da-7' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/res-4/domain_applications');
+    expect(last.matched_route).toBe('fabric.assign_resource_domain_application');
+  });
+  it('assign domain application error 422', async () => {
+    const last = await callErr('fabric.assign_resource_domain_application', 422, () =>
+      client.fabric.resources.assignDomainApplication('res-4', { domain_application_id: 'da-7' }),
+    );
+    expect(last.matched_route).toBe('fabric.assign_resource_domain_application');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('assign phone route success', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.resources.assignPhoneRoute('res-5', { phone_number_id: 'pn-1' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/res-5/phone_routes');
+    expect(last.matched_route).toBe('fabric.assign_resource_phone_route');
+  });
+  it('assign phone route error 422', async () => {
+    const last = await callErr('fabric.assign_resource_phone_route', 422, () =>
+      client.fabric.resources.assignPhoneRoute('res-5', { phone_number_id: 'pn-1' }),
+    );
+    expect(last.matched_route).toBe('fabric.assign_resource_phone_route');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- AI Agents ---------------------------------------------------------
+
+describe('AI Agents', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.aiAgents.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/ai_agents');
+    expect(last.matched_route).toBe('fabric.list_ai_agents');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_ai_agents', 500, () => client.fabric.aiAgents.list());
+    expect(last.matched_route).toBe('fabric.list_ai_agents');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.aiAgents.create({ name: 'a' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/ai_agents');
+    expect(last.matched_route).toBe('fabric.create_ai_agent');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_ai_agent', 422, () =>
+      client.fabric.aiAgents.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_ai_agent');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() => client.fabric.aiAgents.listAddresses('ag-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/ai_agents/ag-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_ai_agent_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_ai_agent_addresses', 500, () =>
+      client.fabric.aiAgents.listAddresses('ag-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_ai_agent_addresses');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.aiAgents.get('ag-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/ai_agents/ag-1');
+    expect(last.matched_route).toBe('fabric.get_ai_agent');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_ai_agent', 404, () =>
+      client.fabric.aiAgents.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_ai_agent');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PATCH)', async () => {
+    const { last } = await callOk(() => client.fabric.aiAgents.update('ag-1', { name: 'b' }));
+    expect(last.method).toBe('PATCH');
+    expect(last.path).toBe('/api/fabric/resources/ai_agents/ag-1');
+    expect(last.matched_route).toBe('fabric.update_ai_agent');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_ai_agent', 404, () =>
+      client.fabric.aiAgents.update('missing', { name: 'b' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_ai_agent');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.aiAgents.delete('ag-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/ai_agents/ag-1');
+    expect(last.matched_route).toBe('fabric.delete_ai_agent');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_ai_agent', 404, () =>
+      client.fabric.aiAgents.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_ai_agent');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Call Flows --------------------------------------------------------
+
+describe('Call Flows', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.callFlows.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/call_flows');
+    expect(last.matched_route).toBe('fabric.list_call_flows');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_call_flows', 500, () => client.fabric.callFlows.list());
+    expect(last.matched_route).toBe('fabric.list_call_flows');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.callFlows.create({ name: 'cf' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/call_flows');
+    expect(last.matched_route).toBe('fabric.create_call_flow');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_call_flow', 422, () =>
+      client.fabric.callFlows.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_call_flow');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.callFlows.get('cf-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/call_flows/cf-1');
+    expect(last.matched_route).toBe('fabric.get_call_flow');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_call_flow', 404, () =>
+      client.fabric.callFlows.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_call_flow');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.fabric.callFlows.update('cf-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/fabric/resources/call_flows/cf-1');
+    expect(last.matched_route).toBe('fabric.update_call_flow');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_call_flow', 404, () =>
+      client.fabric.callFlows.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_call_flow');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.callFlows.delete('cf-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/call_flows/cf-1');
+    expect(last.matched_route).toBe('fabric.delete_call_flow');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_call_flow', 404, () =>
+      client.fabric.callFlows.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_call_flow');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success (singular path)', async () => {
+    const { body, last } = await callOk(() => client.fabric.callFlows.listAddresses('cf-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/call_flow/cf-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_call_flow_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_call_flow_addresses', 500, () =>
+      client.fabric.callFlows.listAddresses('cf-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_call_flow_addresses');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('list versions success', async () => {
+    const { body, last } = await callOk(() => client.fabric.callFlows.listVersions('cf-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/call_flow/cf-1/versions');
+    expect(last.matched_route).toBe('fabric.list_call_flow_versions');
+  });
+  it('list versions error 500', async () => {
+    const last = await callErr('fabric.list_call_flow_versions', 500, () =>
+      client.fabric.callFlows.listVersions('cf-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_call_flow_versions');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('deploy version success', async () => {
+    const { last } = await callOk(() => client.fabric.callFlows.deployVersion('cf-1', {}));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/call_flow/cf-1/versions');
+    expect(last.matched_route).toBe('fabric.deploy_call_flow_version');
+  });
+  it('deploy version error 422', async () => {
+    const last = await callErr('fabric.deploy_call_flow_version', 422, () =>
+      client.fabric.callFlows.deployVersion('cf-1', {}),
+    );
+    expect(last.matched_route).toBe('fabric.deploy_call_flow_version');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- Conference Rooms --------------------------------------------------
+
+describe('Conference Rooms', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.conferenceRooms.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/conference_rooms');
+    expect(last.matched_route).toBe('fabric.list_conference_rooms');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_conference_rooms', 500, () =>
+      client.fabric.conferenceRooms.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_conference_rooms');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.conferenceRooms.create({ name: 'cr' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/conference_rooms');
+    expect(last.matched_route).toBe('fabric.create_conference_room');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_conference_room', 422, () =>
+      client.fabric.conferenceRooms.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_conference_room');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.conferenceRooms.get('cr-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/conference_rooms/cr-1');
+    expect(last.matched_route).toBe('fabric.get_conference_room');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_conference_room', 404, () =>
+      client.fabric.conferenceRooms.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_conference_room');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.conferenceRooms.update('cr-1', { name: 'x' }),
+    );
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/fabric/resources/conference_rooms/cr-1');
+    expect(last.matched_route).toBe('fabric.update_conference_room');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_conference_room', 404, () =>
+      client.fabric.conferenceRooms.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_conference_room');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.conferenceRooms.delete('cr-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/conference_rooms/cr-1');
+    expect(last.matched_route).toBe('fabric.delete_conference_room');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_conference_room', 404, () =>
+      client.fabric.conferenceRooms.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_conference_room');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success (singular path)', async () => {
+    const { body, last } = await callOk(() => client.fabric.conferenceRooms.listAddresses('cr-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/conference_room/cr-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_conference_room_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_conference_room_addresses', 500, () =>
+      client.fabric.conferenceRooms.listAddresses('cr-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_conference_room_addresses');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- cXML Applications (no create — overridden to throw) ----------------
+
+describe('cXML Applications', () => {
+  it('create throws (not a route)', async () => {
+    await expect(
+      // @ts-expect-error - create on this resource is overridden to throw
+      client.fabric.cxmlApplications.create({ name: 'never' }),
+    ).rejects.toThrow(/cXML applications cannot/);
+    const journal = await mock.journal();
+    expect(journal.length).toBe(0);
+  });
+
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.cxmlApplications.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/cxml_applications');
+    expect(last.matched_route).toBe('fabric.list_cxml_applications');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_cxml_applications', 500, () =>
+      client.fabric.cxmlApplications.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_cxml_applications');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.cxmlApplications.get('ca-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/cxml_applications/ca-1');
+    expect(last.matched_route).toBe('fabric.get_cxml_application');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_cxml_application', 404, () =>
+      client.fabric.cxmlApplications.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_cxml_application');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.cxmlApplications.update('ca-1', { name: 'x' }),
+    );
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/fabric/resources/cxml_applications/ca-1');
+    expect(last.matched_route).toBe('fabric.update_cxml_application');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_cxml_application', 404, () =>
+      client.fabric.cxmlApplications.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_cxml_application');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.cxmlApplications.delete('ca-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/cxml_applications/ca-1');
+    expect(last.matched_route).toBe('fabric.delete_cxml_application');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_cxml_application', 404, () =>
+      client.fabric.cxmlApplications.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_cxml_application');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() => client.fabric.cxmlApplications.listAddresses('ca-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/cxml_applications/ca-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_cxml_application_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_cxml_application_addresses', 500, () =>
+      client.fabric.cxmlApplications.listAddresses('ca-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_cxml_application_addresses');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- cXML Scripts ------------------------------------------------------
+
+describe('cXML Scripts', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.cxmlScripts.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/cxml_scripts');
+    expect(last.matched_route).toBe('fabric.list_cxml_scripts');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_cxml_scripts', 500, () =>
+      client.fabric.cxmlScripts.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_cxml_scripts');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.cxmlScripts.create({ name: 'cs' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/cxml_scripts');
+    expect(last.matched_route).toBe('fabric.create_cxml_script');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_cxml_script', 422, () =>
+      client.fabric.cxmlScripts.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_cxml_script');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.cxmlScripts.get('cs-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/cxml_scripts/cs-1');
+    expect(last.matched_route).toBe('fabric.get_cxml_script');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_cxml_script', 404, () =>
+      client.fabric.cxmlScripts.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_cxml_script');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.fabric.cxmlScripts.update('cs-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/fabric/resources/cxml_scripts/cs-1');
+    expect(last.matched_route).toBe('fabric.update_cxml_script');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_cxml_script', 404, () =>
+      client.fabric.cxmlScripts.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_cxml_script');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.cxmlScripts.delete('cs-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/cxml_scripts/cs-1');
+    expect(last.matched_route).toBe('fabric.delete_cxml_script');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_cxml_script', 404, () =>
+      client.fabric.cxmlScripts.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_cxml_script');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() => client.fabric.cxmlScripts.listAddresses('cs-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/cxml_scripts/cs-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_cxml_script_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_cxml_script_addresses', 500, () =>
+      client.fabric.cxmlScripts.listAddresses('cs-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_cxml_script_addresses');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- cXML Webhooks (create auto-materialized; emits warning) -----------
+
+describe('cXML Webhooks', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.cxmlWebhooks.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/cxml_webhooks');
+    expect(last.matched_route).toBe('fabric.list_cxml_webhooks');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_cxml_webhooks', 500, () =>
+      client.fabric.cxmlWebhooks.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_cxml_webhooks');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.cxmlWebhooks.create({ name: 'cw' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/cxml_webhooks');
+    expect(last.matched_route).toBe('fabric.create_cxml_webhook');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_cxml_webhook', 422, () =>
+      client.fabric.cxmlWebhooks.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_cxml_webhook');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.cxmlWebhooks.get('cw-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/cxml_webhooks/cw-1');
+    expect(last.matched_route).toBe('fabric.get_cxml_webhook');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_cxml_webhook', 404, () =>
+      client.fabric.cxmlWebhooks.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_cxml_webhook');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PATCH)', async () => {
+    const { last } = await callOk(() => client.fabric.cxmlWebhooks.update('cw-1', { name: 'x' }));
+    expect(last.method).toBe('PATCH');
+    expect(last.path).toBe('/api/fabric/resources/cxml_webhooks/cw-1');
+    expect(last.matched_route).toBe('fabric.update_cxml_webhook');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_cxml_webhook', 404, () =>
+      client.fabric.cxmlWebhooks.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_cxml_webhook');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.cxmlWebhooks.delete('cw-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/cxml_webhooks/cw-1');
+    expect(last.matched_route).toBe('fabric.delete_cxml_webhook');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_cxml_webhook', 404, () =>
+      client.fabric.cxmlWebhooks.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_cxml_webhook');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() => client.fabric.cxmlWebhooks.listAddresses('cw-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/cxml_webhooks/cw-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_cxml_webhook_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_cxml_webhook_addresses', 500, () =>
+      client.fabric.cxmlWebhooks.listAddresses('cw-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_cxml_webhook_addresses');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- FreeSWITCH Connectors ---------------------------------------------
+
+describe('FreeSWITCH Connectors', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.freeswitchConnectors.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/freeswitch_connectors');
+    expect(last.matched_route).toBe('fabric.list_freeswitch_connectors');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_freeswitch_connectors', 500, () =>
+      client.fabric.freeswitchConnectors.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_freeswitch_connectors');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.freeswitchConnectors.create({ name: 'fc' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/freeswitch_connectors');
+    expect(last.matched_route).toBe('fabric.create_freeswitch_connector');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_freeswitch_connector', 422, () =>
+      client.fabric.freeswitchConnectors.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_freeswitch_connector');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.freeswitchConnectors.get('fc-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/freeswitch_connectors/fc-1');
+    expect(last.matched_route).toBe('fabric.get_freeswitch_connector');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_freeswitch_connector', 404, () =>
+      client.fabric.freeswitchConnectors.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_freeswitch_connector');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.freeswitchConnectors.update('fc-1', { name: 'x' }),
+    );
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/fabric/resources/freeswitch_connectors/fc-1');
+    expect(last.matched_route).toBe('fabric.update_freeswitch_connector');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_freeswitch_connector', 404, () =>
+      client.fabric.freeswitchConnectors.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_freeswitch_connector');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.freeswitchConnectors.delete('fc-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/freeswitch_connectors/fc-1');
+    expect(last.matched_route).toBe('fabric.delete_freeswitch_connector');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_freeswitch_connector', 404, () =>
+      client.fabric.freeswitchConnectors.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_freeswitch_connector');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() =>
+      client.fabric.freeswitchConnectors.listAddresses('fc-1'),
+    );
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/freeswitch_connectors/fc-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_freeswitch_connector_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_freeswitch_connector_addresses', 500, () =>
+      client.fabric.freeswitchConnectors.listAddresses('fc-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_freeswitch_connector_addresses');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- Relay Applications ------------------------------------------------
+
+describe('Relay Applications', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.relayApplications.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/relay_applications');
+    expect(last.matched_route).toBe('fabric.list_relay_applications');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_relay_applications', 500, () =>
+      client.fabric.relayApplications.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_relay_applications');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.relayApplications.create({ name: 'ra' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/relay_applications');
+    expect(last.matched_route).toBe('fabric.create_relay_application');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_relay_application', 422, () =>
+      client.fabric.relayApplications.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_relay_application');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.relayApplications.get('ra-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/relay_applications/ra-1');
+    expect(last.matched_route).toBe('fabric.get_relay_application');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_relay_application', 404, () =>
+      client.fabric.relayApplications.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_relay_application');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.relayApplications.update('ra-1', { name: 'x' }),
+    );
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/fabric/resources/relay_applications/ra-1');
+    expect(last.matched_route).toBe('fabric.update_relay_application');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_relay_application', 404, () =>
+      client.fabric.relayApplications.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_relay_application');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.relayApplications.delete('ra-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/relay_applications/ra-1');
+    expect(last.matched_route).toBe('fabric.delete_relay_application');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_relay_application', 404, () =>
+      client.fabric.relayApplications.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_relay_application');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() =>
+      client.fabric.relayApplications.listAddresses('ra-1'),
+    );
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/relay_applications/ra-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_relay_application_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_relay_application_addresses', 500, () =>
+      client.fabric.relayApplications.listAddresses('ra-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_relay_application_addresses');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- SIP Endpoints (assign_resource_sip_endpoint is a doubled-path gap) -
+
+describe('SIP Endpoints', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.sipEndpoints.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/sip_endpoints');
+    expect(last.matched_route).toBe('fabric.list_sip_endpoints');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_sip_endpoints', 500, () =>
+      client.fabric.sipEndpoints.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_sip_endpoints');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.sipEndpoints.create({ username: 'se' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/sip_endpoints');
+    expect(last.matched_route).toBe('fabric.create_sip_endpoint');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_sip_endpoint', 422, () =>
+      client.fabric.sipEndpoints.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_sip_endpoint');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.sipEndpoints.get('se-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/sip_endpoints/se-1');
+    expect(last.matched_route).toBe('fabric.get_sip_endpoint');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_sip_endpoint', 404, () =>
+      client.fabric.sipEndpoints.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_sip_endpoint');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.sipEndpoints.update('se-1', { username: 'x' }),
+    );
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/fabric/resources/sip_endpoints/se-1');
+    expect(last.matched_route).toBe('fabric.update_sip_endpoint');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_sip_endpoint', 404, () =>
+      client.fabric.sipEndpoints.update('missing', { username: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_sip_endpoint');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.sipEndpoints.delete('se-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/sip_endpoints/se-1');
+    expect(last.matched_route).toBe('fabric.delete_sip_endpoint');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_sip_endpoint', 404, () =>
+      client.fabric.sipEndpoints.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_sip_endpoint');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() => client.fabric.sipEndpoints.listAddresses('se-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/sip_endpoints/se-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_sip_endpoint_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_sip_endpoint_addresses', 500, () =>
+      client.fabric.sipEndpoints.listAddresses('se-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_sip_endpoint_addresses');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- SIP Gateways (list_sip_gateway_addresses is a doubled-path gap) ----
+
+describe('SIP Gateways', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.sipGateways.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/sip_gateways');
+    expect(last.matched_route).toBe('fabric.list_sip_gateways');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_sip_gateways', 500, () =>
+      client.fabric.sipGateways.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_sip_gateways');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.sipGateways.create({ name: 'sg' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/sip_gateways');
+    expect(last.matched_route).toBe('fabric.create_sip_gateway');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_sip_gateway', 422, () =>
+      client.fabric.sipGateways.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_sip_gateway');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.sipGateways.get('sg-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/sip_gateways/sg-1');
+    expect(last.matched_route).toBe('fabric.get_sip_gateway');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_sip_gateway', 404, () =>
+      client.fabric.sipGateways.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_sip_gateway');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PATCH)', async () => {
+    const { last } = await callOk(() => client.fabric.sipGateways.update('sg-1', { name: 'x' }));
+    expect(last.method).toBe('PATCH');
+    expect(last.path).toBe('/api/fabric/resources/sip_gateways/sg-1');
+    expect(last.matched_route).toBe('fabric.update_sip_gateway');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_sip_gateway', 404, () =>
+      client.fabric.sipGateways.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_sip_gateway');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.sipGateways.delete('sg-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/sip_gateways/sg-1');
+    expect(last.matched_route).toBe('fabric.delete_sip_gateway');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_sip_gateway', 404, () =>
+      client.fabric.sipGateways.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_sip_gateway');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Subscribers (with nested SIP endpoints) ---------------------------
+
+describe('Subscribers', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.subscribers.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/subscribers');
+    expect(last.matched_route).toBe('fabric.list_subscribers');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_subscribers', 500, () =>
+      client.fabric.subscribers.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_subscribers');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.subscribers.create({ email: 'a@b.com' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/subscribers');
+    expect(last.matched_route).toBe('fabric.create_subscriber');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_subscriber', 422, () =>
+      client.fabric.subscribers.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_subscriber');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.subscribers.get('sub-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/subscribers/sub-1');
+    expect(last.matched_route).toBe('fabric.get_subscriber');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_subscriber', 404, () =>
+      client.fabric.subscribers.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_subscriber');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.subscribers.update('sub-1', { email: 'x@y.com' }),
+    );
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/fabric/resources/subscribers/sub-1');
+    expect(last.matched_route).toBe('fabric.update_subscriber');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_subscriber', 404, () =>
+      client.fabric.subscribers.update('missing', { email: 'x@y.com' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_subscriber');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.subscribers.delete('sub-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/subscribers/sub-1');
+    expect(last.matched_route).toBe('fabric.delete_subscriber');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_subscriber', 404, () =>
+      client.fabric.subscribers.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_subscriber');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() => client.fabric.subscribers.listAddresses('sub-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/subscribers/sub-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_subscriber_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_subscriber_addresses', 500, () =>
+      client.fabric.subscribers.listAddresses('sub-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_subscriber_addresses');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('list sip endpoints success', async () => {
+    const { body, last } = await callOk(() => client.fabric.subscribers.listSipEndpoints('sub-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/subscribers/sub-1/sip_endpoints');
+    expect(last.matched_route).toBe('fabric.list_subscriber_sip_endpoints');
+  });
+  it('list sip endpoints error 500', async () => {
+    const last = await callErr('fabric.list_subscriber_sip_endpoints', 500, () =>
+      client.fabric.subscribers.listSipEndpoints('sub-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_subscriber_sip_endpoints');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create sip endpoint success', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.subscribers.createSipEndpoint('sub-1', { username: 'u' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/subscribers/sub-1/sip_endpoints');
+    expect(last.matched_route).toBe('fabric.create_subscriber_sip_endpoint');
+  });
+  it('create sip endpoint error 422', async () => {
+    const last = await callErr('fabric.create_subscriber_sip_endpoint', 422, () =>
+      client.fabric.subscribers.createSipEndpoint('sub-1', { username: 'u' }),
+    );
+    expect(last.matched_route).toBe('fabric.create_subscriber_sip_endpoint');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get sip endpoint success', async () => {
+    const { last } = await callOk(() => client.fabric.subscribers.getSipEndpoint('sub-1', 'ep-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/subscribers/sub-1/sip_endpoints/ep-1');
+    expect(last.matched_route).toBe('fabric.get_subscriber_sip_endpoint');
+  });
+  it('get sip endpoint error 404', async () => {
+    const last = await callErr('fabric.get_subscriber_sip_endpoint', 404, () =>
+      client.fabric.subscribers.getSipEndpoint('sub-1', 'missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_subscriber_sip_endpoint');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update sip endpoint success (PATCH)', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.subscribers.updateSipEndpoint('sub-1', 'ep-1', { username: 'renamed' }),
+    );
+    expect(last.method).toBe('PATCH');
+    expect(last.path).toBe('/api/fabric/resources/subscribers/sub-1/sip_endpoints/ep-1');
+    expect(last.matched_route).toBe('fabric.update_subscriber_sip_endpoint');
+  });
+  it('update sip endpoint error 404', async () => {
+    const last = await callErr('fabric.update_subscriber_sip_endpoint', 404, () =>
+      client.fabric.subscribers.updateSipEndpoint('sub-1', 'missing', { username: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_subscriber_sip_endpoint');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete sip endpoint success', async () => {
+    const { last } = await callOk(() =>
+      client.fabric.subscribers.deleteSipEndpoint('sub-1', 'ep-1'),
+    );
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/subscribers/sub-1/sip_endpoints/ep-1');
+    expect(last.matched_route).toBe('fabric.delete_subscriber_sip_endpoint');
+  });
+  it('delete sip endpoint error 404', async () => {
+    const last = await callErr('fabric.delete_subscriber_sip_endpoint', 404, () =>
+      client.fabric.subscribers.deleteSipEndpoint('sub-1', 'missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_subscriber_sip_endpoint');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- SWML Scripts ------------------------------------------------------
+
+describe('SWML Scripts', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.swmlScripts.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/swml_scripts');
+    expect(last.matched_route).toBe('fabric.list_swml_scripts');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_swml_scripts', 500, () =>
+      client.fabric.swmlScripts.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_swml_scripts');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.swmlScripts.create({ name: 'ss' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/swml_scripts');
+    expect(last.matched_route).toBe('fabric.create_swml_script');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_swml_script', 422, () =>
+      client.fabric.swmlScripts.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_swml_script');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.swmlScripts.get('ss-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/swml_scripts/ss-1');
+    expect(last.matched_route).toBe('fabric.get_swml_script');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_swml_script', 404, () =>
+      client.fabric.swmlScripts.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_swml_script');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.fabric.swmlScripts.update('ss-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/fabric/resources/swml_scripts/ss-1');
+    expect(last.matched_route).toBe('fabric.update_swml_script');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_swml_script', 404, () =>
+      client.fabric.swmlScripts.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_swml_script');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.swmlScripts.delete('ss-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/swml_scripts/ss-1');
+    expect(last.matched_route).toBe('fabric.delete_swml_script');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_swml_script', 404, () =>
+      client.fabric.swmlScripts.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_swml_script');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() => client.fabric.swmlScripts.listAddresses('ss-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/swml_scripts/ss-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_swml_script_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_swml_script_addresses', 500, () =>
+      client.fabric.swmlScripts.listAddresses('ss-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_swml_script_addresses');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- SWML Webhooks (create auto-materialized; emits warning) -----------
+
+describe('SWML Webhooks', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.fabric.swmlWebhooks.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/swml_webhooks');
+    expect(last.matched_route).toBe('fabric.list_swml_webhooks');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fabric.list_swml_webhooks', 500, () =>
+      client.fabric.swmlWebhooks.list(),
+    );
+    expect(last.matched_route).toBe('fabric.list_swml_webhooks');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.fabric.swmlWebhooks.create({ name: 'sw' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/fabric/resources/swml_webhooks');
+    expect(last.matched_route).toBe('fabric.create_swml_webhook');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('fabric.create_swml_webhook', 422, () =>
+      client.fabric.swmlWebhooks.create({}),
+    );
+    expect(last.matched_route).toBe('fabric.create_swml_webhook');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.fabric.swmlWebhooks.get('sw-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/swml_webhooks/sw-1');
+    expect(last.matched_route).toBe('fabric.get_swml_webhook');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fabric.get_swml_webhook', 404, () =>
+      client.fabric.swmlWebhooks.get('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.get_swml_webhook');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PATCH)', async () => {
+    const { last } = await callOk(() => client.fabric.swmlWebhooks.update('sw-1', { name: 'x' }));
+    expect(last.method).toBe('PATCH');
+    expect(last.path).toBe('/api/fabric/resources/swml_webhooks/sw-1');
+    expect(last.matched_route).toBe('fabric.update_swml_webhook');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('fabric.update_swml_webhook', 404, () =>
+      client.fabric.swmlWebhooks.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('fabric.update_swml_webhook');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.fabric.swmlWebhooks.delete('sw-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/fabric/resources/swml_webhooks/sw-1');
+    expect(last.matched_route).toBe('fabric.delete_swml_webhook');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('fabric.delete_swml_webhook', 404, () =>
+      client.fabric.swmlWebhooks.delete('missing'),
+    );
+    expect(last.matched_route).toBe('fabric.delete_swml_webhook');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list addresses success', async () => {
+    const { body, last } = await callOk(() => client.fabric.swmlWebhooks.listAddresses('sw-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fabric/resources/swml_webhooks/sw-1/addresses');
+    expect(last.matched_route).toBe('fabric.list_swml_webhook_addresses');
+  });
+  it('list addresses error 500', async () => {
+    const last = await callErr('fabric.list_swml_webhook_addresses', 500, () =>
+      client.fabric.swmlWebhooks.listAddresses('sw-1'),
+    );
+    expect(last.matched_route).toBe('fabric.list_swml_webhook_addresses');
+    expect(last.response_status).toBe(500);
+  });
+});

--- a/tests/rest/relay_rest_coverage_mock.test.ts
+++ b/tests/rest/relay_rest_coverage_mock.test.ts
@@ -1,0 +1,952 @@
+/**
+ * Full REST success + error coverage for the `relay-rest` spec group.
+ *
+ * Mirrors the proven python/java suites and the committed coverage style in
+ * tests/rest/fabric_coverage_mock.test.ts: every coverable canonical
+ * relay-rest route (59 of 69) gets BOTH a success (2xx) test and an error
+ * (4xx/5xx) test, asserting method, path, matched_route, and (for errors)
+ * response_status against the mock journal.
+ *
+ * Accepted gaps (10, NOT faked — no relay-rest SDK surface in TS; same in
+ * python/java which lacked a relay-rest namespace for these paths):
+ *   - relay-rest SIP endpoints (5): list/create/retrieve/update/delete_sip_endpoint
+ *     at /api/relay/rest/endpoints/sip — TS only has Fabric sipEndpoints
+ *     (/api/fabric/...), not the relay-rest /endpoints/sip collection.
+ *   - relay-rest domain_applications (5): list/create/retrieve/update/delete_
+ *     domain_application at /api/relay/rest/domain_applications — TS only has a
+ *     Fabric assignDomainApplication, not this relay-rest collection.
+ *
+ * Unlike pre-fix java, TS DOES cover verified_caller_ids (7) and
+ * lookup_phone_number, so both are exercised here.
+ *
+ * Companion to tests/rest/phoneNumbers.test.ts and the small_namespaces /
+ * registry mock suites; self-contained.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { newMockClient } from './mocktest.js';
+import type { RestClient } from '../../src/rest/index.js';
+import type { JournalEntry, MockHarness } from './mocktest.js';
+import { RestError } from '../../src/rest/RestError.js';
+
+let client: RestClient;
+let mock: MockHarness;
+
+beforeEach(async () => {
+  ({ client, mock } = await newMockClient());
+});
+
+// ---- DRY helpers -------------------------------------------------------
+//
+// Each helper RETURNS the journal entry (or response) so the calling `it()`
+// body holds its own real assertions — the no-cheat auditor is intra-function.
+
+/**
+ * Await an SDK call, then return its response body alongside the last journal
+ * entry. The caller asserts on both.
+ */
+async function callOk<T>(fn: () => Promise<T>): Promise<{ body: T; last: JournalEntry }> {
+  const body = await fn();
+  const last = await mock.last();
+  return { body, last };
+}
+
+/**
+ * Arm a one-shot error scenario for `endpointId`, assert the SDK call rejects
+ * with RestError, and return the recorded journal entry for body assertions.
+ */
+async function callErr(
+  endpointId: string,
+  status: number,
+  fn: () => Promise<unknown>,
+): Promise<JournalEntry> {
+  await mock.pushScenario(endpointId, status, { error: 'x' });
+  await expect(fn()).rejects.toThrow(RestError);
+  return mock.last();
+}
+
+// ---- Phone Numbers -----------------------------------------------------
+
+describe('Phone Numbers', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.phoneNumbers.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/phone_numbers');
+    expect(last.matched_route).toBe('relay-rest.list_phone_numbers');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('relay-rest.list_phone_numbers', 500, () =>
+      client.phoneNumbers.list(),
+    );
+    expect(last.matched_route).toBe('relay-rest.list_phone_numbers');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('purchase (create) success', async () => {
+    const { last } = await callOk(() => client.phoneNumbers.create({ number: '+15551234567' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/phone_numbers');
+    expect(last.matched_route).toBe('relay-rest.purchase_phone_number');
+  });
+  it('purchase error 422', async () => {
+    const last = await callErr('relay-rest.purchase_phone_number', 422, () =>
+      client.phoneNumbers.create({}),
+    );
+    expect(last.matched_route).toBe('relay-rest.purchase_phone_number');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('search success', async () => {
+    const { body, last } = await callOk(() => client.phoneNumbers.search({ areaCode: '512' }));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/phone_numbers/search');
+    expect(last.matched_route).toBe('relay-rest.search_available_phone_numbers');
+  });
+  it('search error 500', async () => {
+    const last = await callErr('relay-rest.search_available_phone_numbers', 500, () =>
+      client.phoneNumbers.search({ areaCode: '512' }),
+    );
+    expect(last.matched_route).toBe('relay-rest.search_available_phone_numbers');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.phoneNumbers.get('pn-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/phone_numbers/pn-1');
+    expect(last.matched_route).toBe('relay-rest.retrieve_phone_number');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_phone_number', 404, () =>
+      client.phoneNumbers.get('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_phone_number');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.phoneNumbers.update('pn-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/relay/rest/phone_numbers/pn-1');
+    expect(last.matched_route).toBe('relay-rest.update_phone_number');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('relay-rest.update_phone_number', 404, () =>
+      client.phoneNumbers.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('relay-rest.update_phone_number');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('release (delete) success', async () => {
+    const { last } = await callOk(() => client.phoneNumbers.delete('pn-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/relay/rest/phone_numbers/pn-1');
+    expect(last.matched_route).toBe('relay-rest.release_phone_number');
+  });
+  it('release error 404', async () => {
+    const last = await callErr('relay-rest.release_phone_number', 404, () =>
+      client.phoneNumbers.delete('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.release_phone_number');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Addresses ---------------------------------------------------------
+
+describe('Addresses', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.addresses.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/addresses');
+    expect(last.matched_route).toBe('relay-rest.list_addresses');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('relay-rest.list_addresses', 500, () => client.addresses.list());
+    expect(last.matched_route).toBe('relay-rest.list_addresses');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.addresses.create({ display_name: 'a' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/addresses');
+    expect(last.matched_route).toBe('relay-rest.create_address');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('relay-rest.create_address', 422, () => client.addresses.create({}));
+    expect(last.matched_route).toBe('relay-rest.create_address');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.addresses.get('addr-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/addresses/addr-1');
+    expect(last.matched_route).toBe('relay-rest.get_address');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.get_address', 404, () =>
+      client.addresses.get('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.get_address');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.addresses.delete('addr-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/relay/rest/addresses/addr-1');
+    expect(last.matched_route).toBe('relay-rest.delete_address');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('relay-rest.delete_address', 404, () =>
+      client.addresses.delete('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.delete_address');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Verified Caller IDs -----------------------------------------------
+
+describe('Verified Caller IDs', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.verifiedCallers.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/verified_caller_ids');
+    expect(last.matched_route).toBe('relay-rest.list_verified_caller_ids');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('relay-rest.list_verified_caller_ids', 500, () =>
+      client.verifiedCallers.list(),
+    );
+    expect(last.matched_route).toBe('relay-rest.list_verified_caller_ids');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.verifiedCallers.create({ number: '+15551234567' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/verified_caller_ids');
+    expect(last.matched_route).toBe('relay-rest.create_verified_caller_id');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('relay-rest.create_verified_caller_id', 422, () =>
+      client.verifiedCallers.create({}),
+    );
+    expect(last.matched_route).toBe('relay-rest.create_verified_caller_id');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.verifiedCallers.get('vci-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/verified_caller_ids/vci-1');
+    expect(last.matched_route).toBe('relay-rest.retrieve_verified_caller_id');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_verified_caller_id', 404, () =>
+      client.verifiedCallers.get('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_verified_caller_id');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.verifiedCallers.update('vci-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/relay/rest/verified_caller_ids/vci-1');
+    expect(last.matched_route).toBe('relay-rest.update_verified_caller_id');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('relay-rest.update_verified_caller_id', 404, () =>
+      client.verifiedCallers.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('relay-rest.update_verified_caller_id');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.verifiedCallers.delete('vci-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/relay/rest/verified_caller_ids/vci-1');
+    expect(last.matched_route).toBe('relay-rest.delete_verified_caller_id');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('relay-rest.delete_verified_caller_id', 404, () =>
+      client.verifiedCallers.delete('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.delete_verified_caller_id');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('redial verification success (POST)', async () => {
+    const { last } = await callOk(() => client.verifiedCallers.redialVerification('vci-1'));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/verified_caller_ids/vci-1/verification');
+    expect(last.matched_route).toBe('relay-rest.redial_verification_call');
+  });
+  it('redial verification error 404', async () => {
+    const last = await callErr('relay-rest.redial_verification_call', 404, () =>
+      client.verifiedCallers.redialVerification('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.redial_verification_call');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('submit verification success (PUT)', async () => {
+    const { last } = await callOk(() =>
+      client.verifiedCallers.submitVerification('vci-1', { verification_code: '1234' }),
+    );
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/relay/rest/verified_caller_ids/vci-1/verification');
+    expect(last.matched_route).toBe('relay-rest.validate_verification_code');
+  });
+  it('submit verification error 422', async () => {
+    const last = await callErr('relay-rest.validate_verification_code', 422, () =>
+      client.verifiedCallers.submitVerification('vci-1', {}),
+    );
+    expect(last.matched_route).toBe('relay-rest.validate_verification_code');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- Queues + Members --------------------------------------------------
+
+describe('Queues', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.queues.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/queues');
+    expect(last.matched_route).toBe('relay-rest.list_queues');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('relay-rest.list_queues', 500, () => client.queues.list());
+    expect(last.matched_route).toBe('relay-rest.list_queues');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.queues.create({ name: 'q' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/queues');
+    expect(last.matched_route).toBe('relay-rest.create_queue');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('relay-rest.create_queue', 422, () => client.queues.create({}));
+    expect(last.matched_route).toBe('relay-rest.create_queue');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.queues.get('q-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/queues/q-1');
+    expect(last.matched_route).toBe('relay-rest.get_queue');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.get_queue', 404, () => client.queues.get('missing'));
+    expect(last.matched_route).toBe('relay-rest.get_queue');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.queues.update('q-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/relay/rest/queues/q-1');
+    expect(last.matched_route).toBe('relay-rest.update_queue');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('relay-rest.update_queue', 404, () =>
+      client.queues.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('relay-rest.update_queue');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.queues.delete('q-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/relay/rest/queues/q-1');
+    expect(last.matched_route).toBe('relay-rest.delete_queue');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('relay-rest.delete_queue', 404, () =>
+      client.queues.delete('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.delete_queue');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list members success', async () => {
+    const { body, last } = await callOk(() => client.queues.listMembers('q-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/queues/q-1/members');
+    expect(last.matched_route).toBe('relay-rest.list_queue_members');
+  });
+  it('list members error 500', async () => {
+    const last = await callErr('relay-rest.list_queue_members', 500, () =>
+      client.queues.listMembers('q-1'),
+    );
+    expect(last.matched_route).toBe('relay-rest.list_queue_members');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('next member success', async () => {
+    const { last } = await callOk(() => client.queues.getNextMember('q-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/queues/q-1/members/next');
+    expect(last.matched_route).toBe('relay-rest.retrieve_next_queue_member');
+  });
+  it('next member error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_next_queue_member', 404, () =>
+      client.queues.getNextMember('q-1'),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_next_queue_member');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('get member success', async () => {
+    const { last } = await callOk(() => client.queues.getMember('q-1', 'm-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/queues/q-1/members/m-1');
+    expect(last.matched_route).toBe('relay-rest.retrieve_queue_member');
+  });
+  it('get member error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_queue_member', 404, () =>
+      client.queues.getMember('q-1', 'missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_queue_member');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Recordings --------------------------------------------------------
+
+describe('Recordings', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.recordings.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/recordings');
+    expect(last.matched_route).toBe('relay-rest.list_recordings');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('relay-rest.list_recordings', 500, () => client.recordings.list());
+    expect(last.matched_route).toBe('relay-rest.list_recordings');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.recordings.get('rec-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/recordings/rec-1');
+    expect(last.matched_route).toBe('relay-rest.get_recording');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.get_recording', 404, () =>
+      client.recordings.get('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.get_recording');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.recordings.delete('rec-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/relay/rest/recordings/rec-1');
+    expect(last.matched_route).toBe('relay-rest.delete_recording');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('relay-rest.delete_recording', 404, () =>
+      client.recordings.delete('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.delete_recording');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Number Groups + Memberships ---------------------------------------
+
+describe('Number Groups', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.numberGroups.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/number_groups');
+    expect(last.matched_route).toBe('relay-rest.list_number_groups');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('relay-rest.list_number_groups', 500, () =>
+      client.numberGroups.list(),
+    );
+    expect(last.matched_route).toBe('relay-rest.list_number_groups');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.numberGroups.create({ name: 'ng' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/number_groups');
+    expect(last.matched_route).toBe('relay-rest.create_number_group');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('relay-rest.create_number_group', 422, () =>
+      client.numberGroups.create({}),
+    );
+    expect(last.matched_route).toBe('relay-rest.create_number_group');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.numberGroups.get('ng-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/number_groups/ng-1');
+    expect(last.matched_route).toBe('relay-rest.retrieve_number_group');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_number_group', 404, () =>
+      client.numberGroups.get('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_number_group');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.numberGroups.update('ng-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/relay/rest/number_groups/ng-1');
+    expect(last.matched_route).toBe('relay-rest.update_number_group');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('relay-rest.update_number_group', 404, () =>
+      client.numberGroups.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('relay-rest.update_number_group');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.numberGroups.delete('ng-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/relay/rest/number_groups/ng-1');
+    expect(last.matched_route).toBe('relay-rest.delete_number_group');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('relay-rest.delete_number_group', 404, () =>
+      client.numberGroups.delete('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.delete_number_group');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list memberships success', async () => {
+    const { body, last } = await callOk(() => client.numberGroups.listMemberships('ng-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/number_groups/ng-1/number_group_memberships');
+    expect(last.matched_route).toBe('relay-rest.list_number_group_memberships');
+  });
+  it('list memberships error 500', async () => {
+    const last = await callErr('relay-rest.list_number_group_memberships', 500, () =>
+      client.numberGroups.listMemberships('ng-1'),
+    );
+    expect(last.matched_route).toBe('relay-rest.list_number_group_memberships');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('add membership success', async () => {
+    const { last } = await callOk(() =>
+      client.numberGroups.addMembership('ng-1', { phone_number_id: 'pn-1' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/number_groups/ng-1/number_group_memberships');
+    expect(last.matched_route).toBe('relay-rest.create_number_group_membership');
+  });
+  it('add membership error 422', async () => {
+    const last = await callErr('relay-rest.create_number_group_membership', 422, () =>
+      client.numberGroups.addMembership('ng-1', {}),
+    );
+    expect(last.matched_route).toBe('relay-rest.create_number_group_membership');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get membership success', async () => {
+    const { last } = await callOk(() => client.numberGroups.getMembership('mem-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/number_group_memberships/mem-1');
+    expect(last.matched_route).toBe('relay-rest.retrieve_number_group_membership');
+  });
+  it('get membership error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_number_group_membership', 404, () =>
+      client.numberGroups.getMembership('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_number_group_membership');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete membership success', async () => {
+    const { last } = await callOk(() => client.numberGroups.deleteMembership('mem-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/relay/rest/number_group_memberships/mem-1');
+    expect(last.matched_route).toBe('relay-rest.delete_number_group_membership');
+  });
+  it('delete membership error 404', async () => {
+    const last = await callErr('relay-rest.delete_number_group_membership', 404, () =>
+      client.numberGroups.deleteMembership('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.delete_number_group_membership');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Short Codes -------------------------------------------------------
+
+describe('Short Codes', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.shortCodes.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/short_codes');
+    expect(last.matched_route).toBe('relay-rest.list_short_codes');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('relay-rest.list_short_codes', 500, () => client.shortCodes.list());
+    expect(last.matched_route).toBe('relay-rest.list_short_codes');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.shortCodes.get('sc-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/short_codes/sc-1');
+    expect(last.matched_route).toBe('relay-rest.retrieve_short_code');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_short_code', 404, () =>
+      client.shortCodes.get('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_short_code');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.shortCodes.update('sc-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/relay/rest/short_codes/sc-1');
+    expect(last.matched_route).toBe('relay-rest.update_short_code');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('relay-rest.update_short_code', 404, () =>
+      client.shortCodes.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('relay-rest.update_short_code');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Imported Phone Numbers --------------------------------------------
+
+describe('Imported Phone Numbers', () => {
+  it('create success', async () => {
+    const { last } = await callOk(() => client.importedNumbers.create({ number: '+15551234567' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/imported_phone_numbers');
+    expect(last.matched_route).toBe('relay-rest.create_imported_phone_number');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('relay-rest.create_imported_phone_number', 422, () =>
+      client.importedNumbers.create({}),
+    );
+    expect(last.matched_route).toBe('relay-rest.create_imported_phone_number');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- MFA ---------------------------------------------------------------
+
+describe('MFA', () => {
+  it('request sms success', async () => {
+    const { last } = await callOk(() => client.mfa.sms({ to: '+15551234567' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/mfa/sms');
+    expect(last.matched_route).toBe('relay-rest.request_mfa_sms');
+  });
+  it('request sms error 422', async () => {
+    const last = await callErr('relay-rest.request_mfa_sms', 422, () => client.mfa.sms({}));
+    expect(last.matched_route).toBe('relay-rest.request_mfa_sms');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('request call success', async () => {
+    const { last } = await callOk(() => client.mfa.call({ to: '+15551234567' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/mfa/call');
+    expect(last.matched_route).toBe('relay-rest.request_mfa_call');
+  });
+  it('request call error 422', async () => {
+    const last = await callErr('relay-rest.request_mfa_call', 422, () => client.mfa.call({}));
+    expect(last.matched_route).toBe('relay-rest.request_mfa_call');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('verify success', async () => {
+    const { last } = await callOk(() => client.mfa.verify('mfa-1', { token: '123456' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/mfa/mfa-1/verify');
+    expect(last.matched_route).toBe('relay-rest.verify_mfa_token');
+  });
+  it('verify error 422', async () => {
+    const last = await callErr('relay-rest.verify_mfa_token', 422, () =>
+      client.mfa.verify('mfa-1', {}),
+    );
+    expect(last.matched_route).toBe('relay-rest.verify_mfa_token');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- SIP Profile (singleton) -------------------------------------------
+
+describe('SIP Profile', () => {
+  it('get success', async () => {
+    const { last } = await callOk(() => client.sipProfile.get());
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/sip_profile');
+    expect(last.matched_route).toBe('relay-rest.retrieve_sip_profile');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_sip_profile', 404, () =>
+      client.sipProfile.get(),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_sip_profile');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.sipProfile.update({ domain: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/relay/rest/sip_profile');
+    expect(last.matched_route).toBe('relay-rest.update_sip_profile');
+  });
+  it('update error 422', async () => {
+    const last = await callErr('relay-rest.update_sip_profile', 422, () =>
+      client.sipProfile.update({}),
+    );
+    expect(last.matched_route).toBe('relay-rest.update_sip_profile');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- Lookup ------------------------------------------------------------
+
+describe('Lookup', () => {
+  it('phone number success', async () => {
+    const { last } = await callOk(() => client.lookup.phoneNumber('+15551234567'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/lookup/phone_number/+15551234567');
+    expect(last.matched_route).toBe('relay-rest.lookup_phone_number');
+  });
+  it('phone number error 404', async () => {
+    const last = await callErr('relay-rest.lookup_phone_number', 404, () =>
+      client.lookup.phoneNumber('+15550000000'),
+    );
+    expect(last.matched_route).toBe('relay-rest.lookup_phone_number');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- 10DLC Registry: Brands --------------------------------------------
+
+describe('Registry Brands', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.registry.brands.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/brands');
+    expect(last.matched_route).toBe('relay-rest.list_brands');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('relay-rest.list_brands', 500, () => client.registry.brands.list());
+    expect(last.matched_route).toBe('relay-rest.list_brands');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.registry.brands.create({ name: 'b' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/brands');
+    expect(last.matched_route).toBe('relay-rest.create_brand');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('relay-rest.create_brand', 422, () =>
+      client.registry.brands.create({}),
+    );
+    expect(last.matched_route).toBe('relay-rest.create_brand');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.registry.brands.get('brand-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/brands/brand-1');
+    expect(last.matched_route).toBe('relay-rest.retrieve_brand');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_brand', 404, () =>
+      client.registry.brands.get('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_brand');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list campaigns success', async () => {
+    const { body, last } = await callOk(() => client.registry.brands.listCampaigns('brand-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/brands/brand-1/campaigns');
+    expect(last.matched_route).toBe('relay-rest.list_campaigns');
+  });
+  it('list campaigns error 500', async () => {
+    const last = await callErr('relay-rest.list_campaigns', 500, () =>
+      client.registry.brands.listCampaigns('brand-1'),
+    );
+    expect(last.matched_route).toBe('relay-rest.list_campaigns');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create campaign success', async () => {
+    const { last } = await callOk(() =>
+      client.registry.brands.createCampaign('brand-1', { name: 'c' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/brands/brand-1/campaigns');
+    expect(last.matched_route).toBe('relay-rest.create_campaign');
+  });
+  it('create campaign error 422', async () => {
+    const last = await callErr('relay-rest.create_campaign', 422, () =>
+      client.registry.brands.createCampaign('brand-1', {}),
+    );
+    expect(last.matched_route).toBe('relay-rest.create_campaign');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- 10DLC Registry: Campaigns -----------------------------------------
+
+describe('Registry Campaigns', () => {
+  it('get success', async () => {
+    const { last } = await callOk(() => client.registry.campaigns.get('camp-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/campaigns/camp-1');
+    expect(last.matched_route).toBe('relay-rest.retrieve_campaign');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_campaign', 404, () =>
+      client.registry.campaigns.get('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_campaign');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.registry.campaigns.update('camp-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/campaigns/camp-1');
+    expect(last.matched_route).toBe('relay-rest.update_campaign');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('relay-rest.update_campaign', 404, () =>
+      client.registry.campaigns.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('relay-rest.update_campaign');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list numbers success', async () => {
+    const { body, last } = await callOk(() => client.registry.campaigns.listNumbers('camp-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/campaigns/camp-1/numbers');
+    expect(last.matched_route).toBe('relay-rest.list_number_assignments');
+  });
+  it('list numbers error 500', async () => {
+    const last = await callErr('relay-rest.list_number_assignments', 500, () =>
+      client.registry.campaigns.listNumbers('camp-1'),
+    );
+    expect(last.matched_route).toBe('relay-rest.list_number_assignments');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('list orders success', async () => {
+    const { body, last } = await callOk(() => client.registry.campaigns.listOrders('camp-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/campaigns/camp-1/orders');
+    expect(last.matched_route).toBe('relay-rest.list_orders');
+  });
+  it('list orders error 500', async () => {
+    const last = await callErr('relay-rest.list_orders', 500, () =>
+      client.registry.campaigns.listOrders('camp-1'),
+    );
+    expect(last.matched_route).toBe('relay-rest.list_orders');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create order success', async () => {
+    const { last } = await callOk(() => client.registry.campaigns.createOrder('camp-1', {}));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/campaigns/camp-1/orders');
+    expect(last.matched_route).toBe('relay-rest.create_order');
+  });
+  it('create order error 422', async () => {
+    const last = await callErr('relay-rest.create_order', 422, () =>
+      client.registry.campaigns.createOrder('camp-1', {}),
+    );
+    expect(last.matched_route).toBe('relay-rest.create_order');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- 10DLC Registry: Orders --------------------------------------------
+
+describe('Registry Orders', () => {
+  it('get success', async () => {
+    const { last } = await callOk(() => client.registry.orders.get('order-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/orders/order-1');
+    expect(last.matched_route).toBe('relay-rest.retrieve_order');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('relay-rest.retrieve_order', 404, () =>
+      client.registry.orders.get('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.retrieve_order');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- 10DLC Registry: Number Assignments --------------------------------
+
+describe('Registry Number Assignments', () => {
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.registry.numbers.delete('num-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/relay/rest/registry/beta/numbers/num-1');
+    expect(last.matched_route).toBe('relay-rest.delete_number_assignment');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('relay-rest.delete_number_assignment', 404, () =>
+      client.registry.numbers.delete('missing'),
+    );
+    expect(last.matched_route).toBe('relay-rest.delete_number_assignment');
+    expect(last.response_status).toBe(404);
+  });
+});

--- a/tests/rest/small_specs_coverage_mock.test.ts
+++ b/tests/rest/small_specs_coverage_mock.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Full REST success + error coverage for the SMALL spec groups:
+ * project, voice, fax, message, calling, chat, pubsub, logs.
+ *
+ * Mirrors the proven python/java suites and the canonical
+ * tests/rest/fabric_coverage_mock.test.ts style: every coverable canonical
+ * route in these groups (14 of 14 — ZERO gaps, matching python/java) gets
+ * BOTH a success (2xx) test and an error (4xx/5xx) test, asserting method,
+ * path, matched_route, and (for errors) response_status against the mock
+ * journal.
+ *
+ * Routes covered (14):
+ *   project.create_token         POST   /api/project/tokens
+ *   project.update_token         PATCH  /api/project/tokens/{token_id}
+ *   project.delete_token         DELETE /api/project/tokens/{token_id}
+ *   voice.list_voice_logs        GET    /api/voice/logs
+ *   voice.get_voice_log          GET    /api/voice/logs/{id}
+ *   voice.list_voice_log_events  GET    /api/voice/logs/{id}/events
+ *   fax.list_fax_logs            GET    /api/fax/logs
+ *   fax.get_fax_log              GET    /api/fax/logs/{id}
+ *   message.list_message_logs    GET    /api/messaging/logs
+ *   message.get_message_log      GET    /api/messaging/logs/{id}
+ *   logs.list_conferences        GET    /api/logs/conferences
+ *   calling.call-commands        POST   /api/calling/calls (dial command)
+ *   chat.create_chat_token       POST   /api/chat/tokens
+ *   pubsub.create_token          POST   /api/pubsub/tokens
+ *
+ * Companion to tests/rest/logs_mock.test.ts and calling_mock.test.ts (idiom);
+ * self-contained.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { newMockClient } from './mocktest.js';
+import type { RestClient } from '../../src/rest/index.js';
+import type { JournalEntry, MockHarness } from './mocktest.js';
+import { RestError } from '../../src/rest/RestError.js';
+
+let client: RestClient;
+let mock: MockHarness;
+
+beforeEach(async () => {
+  ({ client, mock } = await newMockClient());
+});
+
+// ---- DRY helpers -------------------------------------------------------
+//
+// Each helper RETURNS the journal entry (or response) so the calling `it()`
+// body holds its own real assertions — the no-cheat auditor is intra-function.
+
+async function callOk<T>(fn: () => Promise<T>): Promise<{ body: T; last: JournalEntry }> {
+  const body = await fn();
+  const last = await mock.last();
+  return { body, last };
+}
+
+async function callErr(
+  endpointId: string,
+  status: number,
+  fn: () => Promise<unknown>,
+): Promise<JournalEntry> {
+  await mock.pushScenario(endpointId, status, { error: 'x' });
+  await expect(fn()).rejects.toThrow(RestError);
+  return mock.last();
+}
+
+// ---- Project Tokens — /api/project/tokens ------------------------------
+
+describe('Project Tokens', () => {
+  it('create success', async () => {
+    const { last } = await callOk(() =>
+      client.project.tokens.create({ name: 'tok', permissions: ['messaging'] }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/project/tokens');
+    expect(last.matched_route).toBe('project.create_token');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('project.create_token', 422, () =>
+      client.project.tokens.create({ name: 'tok', permissions: ['messaging'] }),
+    );
+    expect(last.matched_route).toBe('project.create_token');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('update success (PATCH)', async () => {
+    const { last } = await callOk(() => client.project.tokens.update('tok-1', { name: 'renamed' }));
+    expect(last.method).toBe('PATCH');
+    expect(last.path).toBe('/api/project/tokens/tok-1');
+    expect(last.matched_route).toBe('project.update_token');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('project.update_token', 404, () =>
+      client.project.tokens.update('missing', { name: 'renamed' }),
+    );
+    expect(last.matched_route).toBe('project.update_token');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.project.tokens.delete('tok-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/project/tokens/tok-1');
+    expect(last.matched_route).toBe('project.delete_token');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('project.delete_token', 404, () =>
+      client.project.tokens.delete('missing'),
+    );
+    expect(last.matched_route).toBe('project.delete_token');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Voice Logs — /api/voice/logs --------------------------------------
+
+describe('Voice Logs', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.logs.voice.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/voice/logs');
+    expect(last.matched_route).toBe('voice.list_voice_logs');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('voice.list_voice_logs', 500, () => client.logs.voice.list());
+    expect(last.matched_route).toBe('voice.list_voice_logs');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.logs.voice.get('vl-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/voice/logs/vl-1');
+    expect(last.matched_route).toBe('voice.get_voice_log');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('voice.get_voice_log', 404, () => client.logs.voice.get('missing'));
+    expect(last.matched_route).toBe('voice.get_voice_log');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list events success', async () => {
+    const { body, last } = await callOk(() => client.logs.voice.listEvents('vl-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/voice/logs/vl-1/events');
+    expect(last.matched_route).toBe('voice.list_voice_log_events');
+  });
+  it('list events error 500', async () => {
+    const last = await callErr('voice.list_voice_log_events', 500, () =>
+      client.logs.voice.listEvents('vl-1'),
+    );
+    expect(last.matched_route).toBe('voice.list_voice_log_events');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- Fax Logs — /api/fax/logs ------------------------------------------
+
+describe('Fax Logs', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.logs.fax.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fax/logs');
+    expect(last.matched_route).toBe('fax.list_fax_logs');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('fax.list_fax_logs', 500, () => client.logs.fax.list());
+    expect(last.matched_route).toBe('fax.list_fax_logs');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.logs.fax.get('fl-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/fax/logs/fl-1');
+    expect(last.matched_route).toBe('fax.get_fax_log');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('fax.get_fax_log', 404, () => client.logs.fax.get('missing'));
+    expect(last.matched_route).toBe('fax.get_fax_log');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Message Logs — /api/messaging/logs --------------------------------
+
+describe('Message Logs', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.logs.messages.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/messaging/logs');
+    expect(last.matched_route).toBe('message.list_message_logs');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('message.list_message_logs', 500, () => client.logs.messages.list());
+    expect(last.matched_route).toBe('message.list_message_logs');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.logs.messages.get('ml-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/messaging/logs/ml-1');
+    expect(last.matched_route).toBe('message.get_message_log');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('message.get_message_log', 404, () =>
+      client.logs.messages.get('missing'),
+    );
+    expect(last.matched_route).toBe('message.get_message_log');
+    expect(last.response_status).toBe(404);
+  });
+});
+
+// ---- Conference Logs — /api/logs/conferences ---------------------------
+
+describe('Conference Logs', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.logs.conferences.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/logs/conferences');
+    expect(last.matched_route).toBe('logs.list_conferences');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('logs.list_conferences', 500, () => client.logs.conferences.list());
+    expect(last.matched_route).toBe('logs.list_conferences');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- Calling dial — POST /api/calling/calls ----------------------------
+
+describe('Calling dial', () => {
+  it('dial success', async () => {
+    const { body, last } = await callOk(() =>
+      client.calling.dial({ from: '+15551112222', to: '+15553334444' }),
+    );
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/calling/calls');
+    expect(last.matched_route).toBe('calling.call-commands');
+    const sent = last.body as Record<string, unknown>;
+    expect(sent.command).toBe('dial');
+    expect('id' in sent).toBe(false);
+  });
+  it('dial error 422', async () => {
+    const last = await callErr('calling.call-commands', 422, () =>
+      client.calling.dial({ from: '+15551112222', to: '+15553334444' }),
+    );
+    expect(last.matched_route).toBe('calling.call-commands');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- Chat token — POST /api/chat/tokens --------------------------------
+
+describe('Chat Token', () => {
+  it('create token success', async () => {
+    const { body, last } = await callOk(() =>
+      client.chat.createToken({ ttl: 60, channels: { room1: { read: true } } }),
+    );
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/chat/tokens');
+    expect(last.matched_route).toBe('chat.create_chat_token');
+  });
+  it('create token error 422', async () => {
+    const last = await callErr('chat.create_chat_token', 422, () =>
+      client.chat.createToken({ ttl: 60, channels: { room1: { read: true } } }),
+    );
+    expect(last.matched_route).toBe('chat.create_chat_token');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- PubSub token — POST /api/pubsub/tokens ----------------------------
+
+describe('PubSub Token', () => {
+  it('create token success', async () => {
+    const { body, last } = await callOk(() =>
+      client.pubsub.createToken({ ttl: 60, channels: { ch1: { read: true } } }),
+    );
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/pubsub/tokens');
+    expect(last.matched_route).toBe('pubsub.create_token');
+  });
+  it('create token error 422', async () => {
+    const last = await callErr('pubsub.create_token', 422, () =>
+      client.pubsub.createToken({ ttl: 60, channels: { ch1: { read: true } } }),
+    );
+    expect(last.matched_route).toBe('pubsub.create_token');
+    expect(last.response_status).toBe(422);
+  });
+});

--- a/tests/rest/video_coverage_mock.test.ts
+++ b/tests/rest/video_coverage_mock.test.ts
@@ -1,0 +1,526 @@
+/**
+ * Full REST success + error coverage for the `video` spec group.
+ *
+ * Mirrors the proven python/java suites: every coverable canonical video
+ * route (30 of 33) gets BOTH a success (2xx) test and an error (4xx/5xx)
+ * test, asserting method, path, matched_route, and (for errors)
+ * response_status against the mock journal.
+ *
+ * Gaps (3, same as python/java — NOT faked):
+ *   - video.list_logs / video.get_log (2) — no video logs accessor on the
+ *     TS SDK surface (client.video has no `logs`).
+ *   - video.get_room (1) — routing collision: GET /api/video/rooms/{id}
+ *     is wire-identical to GET /api/video/rooms/{name}, and the mock always
+ *     resolves GET /rooms/X to video.get_room_by_name, so video.get_room is
+ *     unhittable. get_room_by_name IS covered (via rooms.get()).
+ *
+ * Companion to tests/rest/video_mock.test.ts (idiom); self-contained.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { newMockClient } from './mocktest.js';
+import type { RestClient } from '../../src/rest/index.js';
+import type { JournalEntry, MockHarness } from './mocktest.js';
+import { RestError } from '../../src/rest/RestError.js';
+
+let client: RestClient;
+let mock: MockHarness;
+
+beforeEach(async () => {
+  ({ client, mock } = await newMockClient());
+});
+
+// ---- DRY helpers -------------------------------------------------------
+//
+// Each helper RETURNS the journal entry (or response) so the calling `it()`
+// body holds its own real assertions — the no-cheat auditor is intra-function.
+
+/**
+ * Await an SDK call, then return its response body alongside the last journal
+ * entry. The caller asserts on both.
+ */
+async function callOk<T>(fn: () => Promise<T>): Promise<{ body: T; last: JournalEntry }> {
+  const body = await fn();
+  const last = await mock.last();
+  return { body, last };
+}
+
+/**
+ * Arm a one-shot error scenario for `endpointId`, assert the SDK call rejects
+ * with RestError, and return the recorded journal entry for body assertions.
+ */
+async function callErr(
+  endpointId: string,
+  status: number,
+  fn: () => Promise<unknown>,
+): Promise<JournalEntry> {
+  await mock.pushScenario(endpointId, status, { error: 'x' });
+  await expect(fn()).rejects.toThrow(RestError);
+  return mock.last();
+}
+
+// ---- Rooms -------------------------------------------------------------
+
+describe('Video Rooms', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.video.rooms.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/rooms');
+    expect(last.matched_route).toBe('video.list_rooms');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('video.list_rooms', 500, () => client.video.rooms.list());
+    expect(last.matched_route).toBe('video.list_rooms');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.video.rooms.create({ name: 'standup' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/video/rooms');
+    expect(last.matched_route).toBe('video.create_room');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('video.create_room', 422, () => client.video.rooms.create({}));
+    expect(last.matched_route).toBe('video.create_room');
+    expect(last.response_status).toBe(422);
+  });
+
+  // GET /api/video/rooms/{id} collides with GET /api/video/rooms/{name};
+  // the mock resolves it to video.get_room_by_name (video.get_room is an
+  // unhittable routing-collision gap — see file header).
+  it('get success (resolves to get_room_by_name)', async () => {
+    const { last } = await callOk(() => client.video.rooms.get('room-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/rooms/room-1');
+    expect(last.matched_route).toBe('video.get_room_by_name');
+  });
+  it('get error 404 (get_room_by_name)', async () => {
+    const last = await callErr('video.get_room_by_name', 404, () =>
+      client.video.rooms.get('missing'),
+    );
+    expect(last.matched_route).toBe('video.get_room_by_name');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.video.rooms.update('room-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/video/rooms/room-1');
+    expect(last.matched_route).toBe('video.update_room');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('video.update_room', 404, () =>
+      client.video.rooms.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('video.update_room');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.video.rooms.delete('room-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/video/rooms/room-1');
+    expect(last.matched_route).toBe('video.delete_room');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('video.delete_room', 404, () =>
+      client.video.rooms.delete('missing'),
+    );
+    expect(last.matched_route).toBe('video.delete_room');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list streams success', async () => {
+    const { body, last } = await callOk(() => client.video.rooms.listStreams('room-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/rooms/room-1/streams');
+    expect(last.matched_route).toBe('video.list_room_streams');
+  });
+  it('list streams error 500', async () => {
+    const last = await callErr('video.list_room_streams', 500, () =>
+      client.video.rooms.listStreams('room-1'),
+    );
+    expect(last.matched_route).toBe('video.list_room_streams');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create stream success', async () => {
+    const { last } = await callOk(() =>
+      client.video.rooms.createStream('room-1', { url: 'rtmp://example.com/live' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/video/rooms/room-1/streams');
+    expect(last.matched_route).toBe('video.create_room_stream');
+  });
+  it('create stream error 422', async () => {
+    const last = await callErr('video.create_room_stream', 422, () =>
+      client.video.rooms.createStream('room-1', { url: 'rtmp://example.com/live' }),
+    );
+    expect(last.matched_route).toBe('video.create_room_stream');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- Room Tokens -------------------------------------------------------
+
+describe('Video Room Tokens', () => {
+  it('create success', async () => {
+    const { last } = await callOk(() =>
+      client.video.roomTokens.create({ room_name: 'standup', user_name: 'Alice' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/video/room_tokens');
+    expect(last.matched_route).toBe('video.create_room_token');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('video.create_room_token', 422, () =>
+      client.video.roomTokens.create({ room_name: 'standup' }),
+    );
+    expect(last.matched_route).toBe('video.create_room_token');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- Room Sessions -----------------------------------------------------
+
+describe('Video Room Sessions', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.video.roomSessions.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/room_sessions');
+    expect(last.matched_route).toBe('video.list_room_sessions');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('video.list_room_sessions', 500, () =>
+      client.video.roomSessions.list(),
+    );
+    expect(last.matched_route).toBe('video.list_room_sessions');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.video.roomSessions.get('sess-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/room_sessions/sess-1');
+    expect(last.matched_route).toBe('video.get_room_session');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('video.get_room_session', 404, () =>
+      client.video.roomSessions.get('missing'),
+    );
+    expect(last.matched_route).toBe('video.get_room_session');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list events success', async () => {
+    const { body, last } = await callOk(() => client.video.roomSessions.listEvents('sess-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/room_sessions/sess-1/events');
+    expect(last.matched_route).toBe('video.list_room_session_events');
+  });
+  it('list events error 500', async () => {
+    const last = await callErr('video.list_room_session_events', 500, () =>
+      client.video.roomSessions.listEvents('sess-1'),
+    );
+    expect(last.matched_route).toBe('video.list_room_session_events');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('list members success', async () => {
+    const { body, last } = await callOk(() => client.video.roomSessions.listMembers('sess-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/room_sessions/sess-1/members');
+    expect(last.matched_route).toBe('video.list_room_session_members');
+  });
+  it('list members error 500', async () => {
+    const last = await callErr('video.list_room_session_members', 500, () =>
+      client.video.roomSessions.listMembers('sess-1'),
+    );
+    expect(last.matched_route).toBe('video.list_room_session_members');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('list recordings success', async () => {
+    const { body, last } = await callOk(() => client.video.roomSessions.listRecordings('sess-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/room_sessions/sess-1/recordings');
+    expect(last.matched_route).toBe('video.list_room_session_recordings');
+  });
+  it('list recordings error 500', async () => {
+    const last = await callErr('video.list_room_session_recordings', 500, () =>
+      client.video.roomSessions.listRecordings('sess-1'),
+    );
+    expect(last.matched_route).toBe('video.list_room_session_recordings');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- Room Recordings (top-level) ---------------------------------------
+
+describe('Video Room Recordings', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.video.roomRecordings.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/room_recordings');
+    expect(last.matched_route).toBe('video.list_room_recordings');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('video.list_room_recordings', 500, () =>
+      client.video.roomRecordings.list(),
+    );
+    expect(last.matched_route).toBe('video.list_room_recordings');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.video.roomRecordings.get('rec-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/room_recordings/rec-1');
+    expect(last.matched_route).toBe('video.get_room_recording');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('video.get_room_recording', 404, () =>
+      client.video.roomRecordings.get('missing'),
+    );
+    expect(last.matched_route).toBe('video.get_room_recording');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.video.roomRecordings.delete('rec-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/video/room_recordings/rec-1');
+    expect(last.matched_route).toBe('video.delete_room_recording');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('video.delete_room_recording', 404, () =>
+      client.video.roomRecordings.delete('missing'),
+    );
+    expect(last.matched_route).toBe('video.delete_room_recording');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list events success', async () => {
+    const { body, last } = await callOk(() => client.video.roomRecordings.listEvents('rec-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/room_recordings/rec-1/events');
+    expect(last.matched_route).toBe('video.list_room_recording_events');
+  });
+  it('list events error 500', async () => {
+    const last = await callErr('video.list_room_recording_events', 500, () =>
+      client.video.roomRecordings.listEvents('rec-1'),
+    );
+    expect(last.matched_route).toBe('video.list_room_recording_events');
+    expect(last.response_status).toBe(500);
+  });
+});
+
+// ---- Conferences -------------------------------------------------------
+
+describe('Video Conferences', () => {
+  it('list success', async () => {
+    const { body, last } = await callOk(() => client.video.conferences.list());
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/conferences');
+    expect(last.matched_route).toBe('video.list_video_conferences');
+  });
+  it('list error 500', async () => {
+    const last = await callErr('video.list_video_conferences', 500, () =>
+      client.video.conferences.list(),
+    );
+    expect(last.matched_route).toBe('video.list_video_conferences');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create success', async () => {
+    const { last } = await callOk(() => client.video.conferences.create({ name: 'conf' }));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/video/conferences');
+    expect(last.matched_route).toBe('video.create_video_conference');
+  });
+  it('create error 422', async () => {
+    const last = await callErr('video.create_video_conference', 422, () =>
+      client.video.conferences.create({}),
+    );
+    expect(last.matched_route).toBe('video.create_video_conference');
+    expect(last.response_status).toBe(422);
+  });
+
+  it('get success', async () => {
+    const { last } = await callOk(() => client.video.conferences.get('conf-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/conferences/conf-1');
+    expect(last.matched_route).toBe('video.get_video_conference');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('video.get_video_conference', 404, () =>
+      client.video.conferences.get('missing'),
+    );
+    expect(last.matched_route).toBe('video.get_video_conference');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() => client.video.conferences.update('conf-1', { name: 'x' }));
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/video/conferences/conf-1');
+    expect(last.matched_route).toBe('video.update_video_conference');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('video.update_video_conference', 404, () =>
+      client.video.conferences.update('missing', { name: 'x' }),
+    );
+    expect(last.matched_route).toBe('video.update_video_conference');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.video.conferences.delete('conf-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/video/conferences/conf-1');
+    expect(last.matched_route).toBe('video.delete_video_conference');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('video.delete_video_conference', 404, () =>
+      client.video.conferences.delete('missing'),
+    );
+    expect(last.matched_route).toBe('video.delete_video_conference');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('list conference tokens success', async () => {
+    const { body, last } = await callOk(() =>
+      client.video.conferences.listConferenceTokens('conf-1'),
+    );
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/conferences/conf-1/conference_tokens');
+    expect(last.matched_route).toBe('video.list_conference_tokens');
+  });
+  it('list conference tokens error 500', async () => {
+    const last = await callErr('video.list_conference_tokens', 500, () =>
+      client.video.conferences.listConferenceTokens('conf-1'),
+    );
+    expect(last.matched_route).toBe('video.list_conference_tokens');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('list streams success', async () => {
+    const { body, last } = await callOk(() => client.video.conferences.listStreams('conf-1'));
+    expect(typeof body === 'object' && body !== null).toBe(true);
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/conferences/conf-1/streams');
+    expect(last.matched_route).toBe('video.list_conference_streams');
+  });
+  it('list streams error 500', async () => {
+    const last = await callErr('video.list_conference_streams', 500, () =>
+      client.video.conferences.listStreams('conf-1'),
+    );
+    expect(last.matched_route).toBe('video.list_conference_streams');
+    expect(last.response_status).toBe(500);
+  });
+
+  it('create stream success', async () => {
+    const { last } = await callOk(() =>
+      client.video.conferences.createStream('conf-1', { url: 'rtmp://example.com/live' }),
+    );
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/video/conferences/conf-1/streams');
+    expect(last.matched_route).toBe('video.create_conference_stream');
+  });
+  it('create stream error 422', async () => {
+    const last = await callErr('video.create_conference_stream', 422, () =>
+      client.video.conferences.createStream('conf-1', { url: 'rtmp://example.com/live' }),
+    );
+    expect(last.matched_route).toBe('video.create_conference_stream');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- Conference Tokens (top-level) -------------------------------------
+
+describe('Video Conference Tokens', () => {
+  it('get success', async () => {
+    const { last } = await callOk(() => client.video.conferenceTokens.get('tok-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/conference_tokens/tok-1');
+    expect(last.matched_route).toBe('video.get_conference_token');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('video.get_conference_token', 404, () =>
+      client.video.conferenceTokens.get('missing'),
+    );
+    expect(last.matched_route).toBe('video.get_conference_token');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('reset success', async () => {
+    const { last } = await callOk(() => client.video.conferenceTokens.reset('tok-1'));
+    expect(last.method).toBe('POST');
+    expect(last.path).toBe('/api/video/conference_tokens/tok-1/reset');
+    expect(last.matched_route).toBe('video.reset_conference_token');
+  });
+  it('reset error 422', async () => {
+    const last = await callErr('video.reset_conference_token', 422, () =>
+      client.video.conferenceTokens.reset('tok-1'),
+    );
+    expect(last.matched_route).toBe('video.reset_conference_token');
+    expect(last.response_status).toBe(422);
+  });
+});
+
+// ---- Streams (top-level) -----------------------------------------------
+
+describe('Video Streams', () => {
+  it('get success', async () => {
+    const { last } = await callOk(() => client.video.streams.get('stream-1'));
+    expect(last.method).toBe('GET');
+    expect(last.path).toBe('/api/video/streams/stream-1');
+    expect(last.matched_route).toBe('video.get_stream');
+  });
+  it('get error 404', async () => {
+    const last = await callErr('video.get_stream', 404, () => client.video.streams.get('missing'));
+    expect(last.matched_route).toBe('video.get_stream');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('update success (PUT)', async () => {
+    const { last } = await callOk(() =>
+      client.video.streams.update('stream-1', { url: 'rtmp://example.com/new' }),
+    );
+    expect(last.method).toBe('PUT');
+    expect(last.path).toBe('/api/video/streams/stream-1');
+    expect(last.matched_route).toBe('video.update_stream');
+  });
+  it('update error 404', async () => {
+    const last = await callErr('video.update_stream', 404, () =>
+      client.video.streams.update('missing', { url: 'rtmp://example.com/new' }),
+    );
+    expect(last.matched_route).toBe('video.update_stream');
+    expect(last.response_status).toBe(404);
+  });
+
+  it('delete success', async () => {
+    const { last } = await callOk(() => client.video.streams.delete('stream-1'));
+    expect(last.method).toBe('DELETE');
+    expect(last.path).toBe('/api/video/streams/stream-1');
+    expect(last.matched_route).toBe('video.delete_stream');
+  });
+  it('delete error 404', async () => {
+    const last = await callErr('video.delete_stream', 404, () =>
+      client.video.streams.delete('missing'),
+    );
+    expect(last.matched_route).toBe('video.delete_stream');
+    expect(last.response_status).toBe(404);
+  });
+});


### PR DESCRIPTION
## What

Replicates the python/java REST full-coverage suite to TypeScript: every implemented canonical REST route is now exercised with **both** a success (2xx) **and** an error (4xx/5xx) response, on the correct on-the-wire path. TS goes **0/307 → 286/307** fully covered — the same coverable set as python and java — with a hard `REST-COVERAGE` gate wired into `run-ci.sh`.

**No SDK source changes needed** — unlike java (which was missing FabricResource addresses, verifiedCallers, lookup, etc.), TypeScript's REST surface was already at python parity. This PR is pure test coverage + the gate.

## Tests

5 new `tests/rest/*_coverage_mock.test.ts` files — fabric (96 routes), compat/LaML (78), relay-rest (59), video (30), datasphere (9) + small specs (14). ~570 new `it()` blocks. Each mirrors the existing `fabric_mock.test.ts` idiom: success = `await client.<ns>.<method>()` → assert response + `await mock.last()` method/path/matched_route; error = `await mock.pushScenario(endpointId, 4xx/5xx, …)` → `await expect(...).rejects.toThrow(RestError)` → assert journal `response_status`. DRY `callOk`/`callErr` helpers return the journal entry so every `it()` holds a real in-body assertion (no-cheat clean).

## The gate

`REST-COVERAGE` added to `run-ci.sh` (after NO-CHEAT) — self-contained (spins its own mock, runs the rest suite serially, checks the journal via porting-sdk's `rest_coverage`). Passes at **286/307** with **21 accepted gaps** allowlisted: the shared `porting-sdk/REST_COVERAGE_BASELINE.md` (2 doubled-path artifacts + the `video.get_room`/`get_room_by_name` routing collision) + this port's `REST_COVERAGE_GAPS.md` (18 sdk-gaps: dialogflow_agents, relay-rest SIP-endpoints/domain-applications, video logs, compat per-country). These 21 are **identical** to python's and java's accepted gaps.

## Verification

`bash scripts/run-ci.sh` → **CI PASS**, all 13 gates green (TEST, SIGNATURES, DRIFT, SURFACE-FRESH, GEN-FRESH, NO-CHEAT, **REST-COVERAGE**, EMISSION, SKILL-CONTRACT, FMT, LINT, DOC-AUDIT, SURFACE-DIFF). `rest_coverage` reports `286/307 fully covered, parity clean, 21 accepted gaps`. 1020 rest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau