### PR TITLE
ci(rest): add SPEC-PARITY gate + route registry

### DIFF
--- a/scripts/route-registry.ts
+++ b/scripts/route-registry.ts
@@ -1,0 +1,198 @@
+/**
+ * route-registry.ts — enumerate the REST routes the TypeScript SDK IMPLEMENTS.
+ *
+ * This is "Set B" for the cross-port SPEC-PARITY gate: the routes the live
+ * RestClient actually dispatches, captured from the REAL code path — not parsed
+ * from source (an AST scraper would have to re-implement the CrudResource /
+ * base-path machinery and would drift) and not read from the test journal
+ * (which only sees routes that happen to be tested, the exact blind spot the
+ * gate closes).
+ *
+ * How: construct RestClient with a recording `fetchImpl` that captures
+ * `(method, path)` from each request and returns a stub 200 Response instead of
+ * doing network I/O. Every route — CRUD-base, custom createToken, etc. — funnels
+ * through HttpClient._request → fetch. We then walk every namespace on the
+ * client, every public method on every sub-resource, and invoke each with
+ * sentinel arguments. The path param sentinel is normalized back to `{id}` so
+ * the captured template matches the spec's path_template.
+ *
+ * A method that cannot be invoked is NOT silently skipped — a dropped method is
+ * a route missing from Set B, which would turn a real divergence into a false
+ * pass. Methods that don't map to a single route go in REGISTRY_SKIP with a
+ * reason; anything else that throws on invocation is a hard error (non-zero exit
+ * + recorded in `errors`), mirroring python_route_registry.py.
+ *
+ * Output: JSON `{routes:[{method,path_template,via}], skipped:[...], errors:[...]}`
+ * on stdout. Exit 1 if any uninvokable, un-skip-listed method (Set B incomplete).
+ *
+ * Run: `npx tsx scripts/route-registry.ts`
+ */
+
+import { RestClient } from '../src/rest/index.js';
+
+// Sentinel for any path parameter — one segment, no slash; normalized to {id}.
+const SENTINEL = '__ID__';
+
+// Methods that do NOT map to a single canonical REST route, keyed by
+// "<namespace>.<resource>.<method>" or a "<namespace>.<resource>.*" wildcard.
+// Every entry needs a reason; a method that merely throws is an ERROR, not an
+// implicit skip — add it here (justified) or fix the harness so it invokes.
+const REGISTRY_SKIP: Record<string, string> = {
+  // cXML applications expose the CRUD surface but create is unsupported
+  // (mirrors python: no POST /cxml_applications canonical route).
+  'fabric.cxmlApplications.create': 'no create route — unsupported by design',
+};
+
+interface RouteRec {
+  method: string;
+  path_template: string;
+  via: string[];
+}
+
+const captured: Array<{ method: string; path: string }> = [];
+
+/** A recording fetch: capture (method, pathname) and return a stub 200. */
+const recordingFetch: typeof globalThis.fetch = async (input, init) => {
+  const url = typeof input === 'string' ? input : input.toString();
+  const method = (init?.method ?? 'GET').toUpperCase();
+  let path: string;
+  try {
+    path = new URL(url).pathname;
+  } catch {
+    path = url;
+  }
+  captured.push({ method, path });
+  // Minimal Response the SDK's _request can consume (.ok, .status, .json/.text).
+  return new Response('{}', {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+};
+
+function isResourceLike(v: unknown): v is object {
+  // A namespace or resource instance: a non-null object that is not a plain
+  // data value. We treat any class instance hanging off the client as walkable.
+  return typeof v === 'object' && v !== null && v.constructor !== Object;
+}
+
+/** Public method names on an instance (walk its prototype chain, skip ctor). */
+function publicMethods(obj: object): string[] {
+  const names = new Set<string>();
+  let proto = Object.getPrototypeOf(obj);
+  while (proto && proto !== Object.prototype) {
+    for (const name of Object.getOwnPropertyNames(proto)) {
+      if (name === 'constructor' || name.startsWith('_')) continue;
+      const desc = Object.getOwnPropertyDescriptor(proto, name);
+      if (desc && typeof desc.value === 'function') names.add(name);
+    }
+    proto = Object.getPrototypeOf(proto);
+  }
+  return [...names].sort();
+}
+
+/** Own enumerable resource-instance properties of a namespace. */
+function subResources(ns: object): Array<[string, object]> {
+  const out: Array<[string, object]> = [];
+  for (const [name, val] of Object.entries(ns)) {
+    if (name.startsWith('_')) continue;
+    if (isResourceLike(val)) out.push([name, val]);
+  }
+  return out;
+}
+
+function skipReason(key: string): string | undefined {
+  if (key in REGISTRY_SKIP) return REGISTRY_SKIP[key];
+  const wildcard = key.slice(0, key.lastIndexOf('.')) + '.*';
+  return REGISTRY_SKIP[wildcard];
+}
+
+async function invokeAndCapture(fn: (...a: unknown[]) => unknown): Promise<void> {
+  // Pass enough sentinel positional args to satisfy the common shapes:
+  // (resourceId), (resourceId, body), (body). Extra args are harmless — JS
+  // ignores params beyond the signature. The path captures the sentinel in
+  // resource-id position; body args don't affect the URL.
+  const args = [SENTINEL, {}, SENTINEL];
+  await fn(...args);
+}
+
+async function build(): Promise<{
+  routes: RouteRec[];
+  skipped: Array<{ key: string; reason: string }>;
+  errors: Array<{ key: string; error: string }>;
+}> {
+  const client = new RestClient({
+    project: 'p',
+    token: 't',
+    host: 'example.signalwire.com',
+    fetchImpl: recordingFetch,
+  });
+
+  const routes: RouteRec[] = [];
+  const skipped: Array<{ key: string; reason: string }> = [];
+  const errors: Array<{ key: string; error: string }> = [];
+
+  async function handleResource(nsName: string, resName: string, res: object) {
+    for (const m of publicMethods(res)) {
+      const key = `${nsName}.${resName}.${m}`;
+      const reason = skipReason(key);
+      if (reason !== undefined) {
+        skipped.push({ key, reason });
+        continue;
+      }
+      const fn = (res as Record<string, unknown>)[m];
+      if (typeof fn !== 'function') continue;
+      captured.length = 0;
+      try {
+        await invokeAndCapture((fn as (...a: unknown[]) => unknown).bind(res));
+      } catch (e) {
+        errors.push({ key, error: `${(e as Error).name}: ${(e as Error).message}` });
+        continue;
+      }
+      if (captured.length === 0) {
+        errors.push({
+          key,
+          error: 'invoked but issued no HTTP request (client-side helper? add to REGISTRY_SKIP)',
+        });
+        continue;
+      }
+      for (const c of captured) {
+        const path = c.path.split(SENTINEL).join('{id}');
+        routes.push({ method: c.method, path_template: path, via: [key] });
+      }
+    }
+  }
+
+  for (const [nsName, ns] of Object.entries(client)) {
+    if (nsName.startsWith('_')) continue;
+    if (!isResourceLike(ns)) continue;
+    // The namespace may itself be a flat resource (has its own routes)…
+    if (publicMethods(ns).length > 0) await handleResource(nsName, nsName, ns);
+    // …and/or a container of sub-resources.
+    for (const [resName, res] of subResources(ns)) {
+      await handleResource(nsName, resName, res);
+    }
+  }
+
+  // De-dupe identical (method, path); collect the `via` accessors.
+  const byRoute = new Map<string, RouteRec>();
+  for (const r of routes) {
+    const k = `${r.method} ${r.path_template}`;
+    const existing = byRoute.get(k);
+    if (existing) existing.via.push(...r.via);
+    else byRoute.set(k, { ...r });
+  }
+  const deduped = [...byRoute.values()].sort((a, b) =>
+    (a.path_template + a.method).localeCompare(b.path_template + b.method),
+  );
+  return { routes: deduped, skipped, errors };
+}
+
+build()
+  .then((out) => {
+    process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+    process.exit(out.errors.length ? 1 : 0);
+  })
+  .catch((e) => {
+    process.stderr.write(`route-registry failed: ${e?.stack ?? e}\n`);
+    process.exit(2);
+  });

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -206,6 +206,34 @@ rest_coverage_gate() {
 run_gate "REST-COVERAGE" "every implemented REST route covered success+error (parity + allowlist)" \
     rest_coverage_gate
 
+# Gate 5c: SPEC-PARITY — the routes the SDK actually IMPLEMENTS must equal the
+# canonical spec route set, modulo porting-sdk/SPEC_IMPLEMENTATION_GAPS.md. This
+# is the spec-first guard REST-COVERAGE can't give: REST-COVERAGE only proves
+# *tested* routes match the spec, so a route the SDK implements that the spec
+# doesn't define (or vice versa) would slip past it. Set B is built by
+# scripts/route-registry.ts — it drives the live RestClient through a recording
+# fetchImpl and captures every dispatched (method, path), so it sees every
+# implemented route whether or not it's tested (not an AST scrape, not the
+# journal). The shared porting-sdk diff consumes that JSON via --registry-json.
+spec_parity_gate() {
+    local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
+    export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
+    local registry
+    registry="$(mktemp)"
+    # SIGNALWIRE_LOG_MODE=off so the SDK logger doesn't pollute stdout JSON.
+    SIGNALWIRE_LOG_MODE=off npx tsx "$PORT_ROOT/scripts/route-registry.ts" >"$registry" 2>/dev/null || {
+        rm -f "$registry"; return 1
+    }
+    python3 "$PORTING_SDK_DIR/scripts/diff_spec_implementation.py" \
+        --registry-json "$registry" \
+        --gaps "$PORTING_SDK_DIR/SPEC_IMPLEMENTATION_GAPS.md"
+    local rc=$?
+    rm -f "$registry"
+    return $rc
+}
+run_gate "SPEC-PARITY" "implemented routes == canonical spec (modulo SPEC_IMPLEMENTATION_GAPS.md)" \
+    spec_parity_gate
+
 # Gate 6: emission — byte-compare FunctionResult serialisation vs the Python
 # to_dict() oracle over the shared corpus (scripts/emit-corpus.ts builds the
 # native dump). Pure serialisation: no mock servers, no network — just


### PR DESCRIPTION
Adds the **SPEC-PARITY** gate to TypeScript — the first port after the python reference to get the spec↔implementation check. This is the template for rolling SPEC-PARITY to the remaining ports.

## What
- **`scripts/route-registry.ts`** — builds "Set B" (the routes the SDK implements) by constructing the live `RestClient` with a recording `fetchImpl`, walking every namespace → sub-resource → public method, invoking each with sentinel args, and capturing the dispatched `(method, path)` at the fetch chokepoint. Emits `{routes,skipped,errors}` JSON. Not an AST scrape (would re-implement the CRUD/base-path machinery and drift) and not the test journal (sees only tested routes — the blind spot). Uninvokable methods fail loud unless in the reviewed `REGISTRY_SKIP` (1 entry: `cxmlApplications.create`, unsupported by design).
- **`scripts/run-ci.sh`** — new `SPEC-PARITY` gate (after REST-COVERAGE): runs the registry (with `SIGNALWIRE_LOG_MODE=off` so the SDK logger doesn't pollute the JSON) and feeds it to porting-sdk's shared `diff_spec_implementation.py --registry-json`. Fails on B−A (implemented route absent from spec) and A−B (canonical route unimplemented, unless in `SPEC_IMPLEMENTATION_GAPS.md`).

## Result
**286/307** implemented, 21 accepted gaps, 1 allowed divergence — matching the python reference exactly. Full `run-ci.sh` green (all 14 gates → CI PASS).

## Depends on
porting-sdk#45 (the `--registry-json` support). Merge that first; until it lands on porting-sdk@main, this PR's SPEC-PARITY gate will error in CI (`diff_spec_implementation.py: unrecognized arguments: --registry-json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau