### PR TITLE
test+ci: dynamic free ports + fail-loud for mock servers

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -179,8 +179,15 @@ run_gate "NO-CHEAT" "audit_no_cheat_tests" \
 # fails the gate. Self-contained: spins its own mock, runs the rest suite serially
 # against it (MOCK_SIGNALWIRE_PORT so all traffic lands in one journal), then
 # checks that journal. Same shape as python's/java's gate.
+# Pick a free TCP port on 127.0.0.1 (bind :0, read the OS-assigned port,
+# release). Never reuse a hardcoded port — a leftover or concurrent mock
+# squatting a fixed port otherwise makes the gate hang on its health poll.
+pick_free_port() {
+    python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
+}
 rest_coverage_gate() {
-    local port=8769
+    local port
+    port="$(pick_free_port)" || { echo "could not allocate a free port" >&2; return 1; }
     local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
     export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
     python3 -m mock_signalwire --host 127.0.0.1 --port "$port" --log-level error \
@@ -188,13 +195,24 @@ rest_coverage_gate() {
     local mock_pid=$!
     # shellcheck disable=SC2064
     trap "kill $mock_pid 2>/dev/null" RETURN
-    local i
+    # Fail LOUD if the mock dies mid-startup or never becomes healthy — never hang.
+    local i ready=0
     for i in $(seq 1 60); do
+        if ! kill -0 "$mock_pid" 2>/dev/null; then
+            echo "mock_signalwire died on port $port — log:" >&2
+            cat "/tmp/rest_cov_mock.$$.log" >&2
+            return 1
+        fi
         if python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:$port/__mock__/health',timeout=1)" 2>/dev/null; then
+            ready=1
             break
         fi
         sleep 0.5
     done
+    if [ "$ready" -ne 1 ]; then
+        echo "mock_signalwire on port $port not healthy within 30s" >&2
+        return 1
+    fi
     python3 -c "import urllib.request; urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:$port/__mock__/journal/reset',method='POST'),timeout=5).read()"
     MOCK_SIGNALWIRE_PORT="$port" npx vitest run tests/rest --no-file-parallelism || return 1
     python3 -m mock_signalwire.rest_coverage \

--- a/tests/relay/mocktest.ts
+++ b/tests/relay/mocktest.ts
@@ -324,7 +324,6 @@ export class MockRelayHarness {
 // Server lifecycle (singleton across the test process)
 // ---------------------------------------------------------------------------
 
-const DEFAULT_WS_PORT = 8776;
 const STARTUP_TIMEOUT_MS = 30_000;
 const PROBE_TIMEOUT_MS = 2_000;
 
@@ -342,23 +341,40 @@ const state: ServerState = {
   starting: null,
 };
 
-function resolveWsPort(): number {
+// Ask the OS for a free loopback TCP port (listen on :0, read it, close).
+async function pickFreePort(): Promise<number> {
+  const { createServer } = await import('node:net');
+  return new Promise<number>((resolve, reject) => {
+    const srv = createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = addr && typeof addr === 'object' ? addr.port : 0;
+      srv.close(() => (port > 0 ? resolve(port) : reject(new Error('failed to pick a free port'))));
+    });
+  });
+}
+
+// Env override wins; otherwise pick a FREE port rather than a hardcoded default
+// that would collide with a stale/concurrent mock and hang the suite.
+async function resolveWsPort(): Promise<number> {
   const raw = process.env['MOCK_RELAY_WS_PORT'];
   if (raw) {
     const p = parseInt(raw, 10);
     if (!isNaN(p) && p > 0) return p;
   }
-  return DEFAULT_WS_PORT;
+  return pickFreePort();
 }
 
-function resolveHttpPort(wsPort: number): number {
+// HTTP control plane: an independent free port (env override wins). Picked
+// separately rather than ws+1000 so a dynamic WS port never derives a busy one.
+async function resolveHttpPort(): Promise<number> {
   const raw = process.env['MOCK_RELAY_HTTP_PORT'];
   if (raw) {
     const p = parseInt(raw, 10);
     if (!isNaN(p) && p > 0) return p;
   }
-  // Default behavior of mock-relay: HTTP = WS + 1000.
-  return wsPort + 1000;
+  return pickFreePort();
 }
 
 async function probeHealth(httpUrl: string): Promise<boolean> {
@@ -385,8 +401,8 @@ async function ensureServer(): Promise<MockRelayHarness> {
   }
 
   state.starting = (async () => {
-    const wsPort = resolveWsPort();
-    const httpPort = resolveHttpPort(wsPort);
+    const wsPort = await resolveWsPort();
+    const httpPort = await resolveHttpPort();
     const httpUrl = `http://127.0.0.1:${httpPort}`;
     const wsUrl = `ws://127.0.0.1:${wsPort}`;
     const relayHost = `127.0.0.1:${wsPort}`;

--- a/tests/rest/mocktest.ts
+++ b/tests/rest/mocktest.ts
@@ -179,7 +179,6 @@ export class MockHarness {
 // Server lifecycle (singleton across the test process)
 // ---------------------------------------------------------------------------
 
-const DEFAULT_PORT = 8766;
 const STARTUP_TIMEOUT_MS = 30_000;
 const PROBE_TIMEOUT_MS = 2_000;
 
@@ -197,13 +196,30 @@ const state: ServerState = {
   starting: null,
 };
 
-function resolvePort(): number {
+// Ask the OS for a free loopback TCP port (listen on :0, read it, close).
+async function pickFreePort(): Promise<number> {
+  const { createServer } = await import('node:net');
+  return new Promise<number>((resolve, reject) => {
+    const srv = createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = addr && typeof addr === 'object' ? addr.port : 0;
+      srv.close(() => (port > 0 ? resolve(port) : reject(new Error('failed to pick a free port'))));
+    });
+  });
+}
+
+// MOCK_SIGNALWIRE_PORT (set by the CI gate, which pre-spawns the mock) wins;
+// otherwise pick a FREE port rather than a hardcoded default that would collide
+// with a stale/concurrent mock and hang the suite.
+async function resolvePort(): Promise<number> {
   const raw = process.env['MOCK_SIGNALWIRE_PORT'];
   if (raw) {
     const p = parseInt(raw, 10);
     if (!isNaN(p) && p > 0) return p;
   }
-  return DEFAULT_PORT;
+  return pickFreePort();
 }
 
 async function probeHealth(baseUrl: string): Promise<boolean> {
@@ -230,7 +246,7 @@ async function ensureServer(): Promise<MockHarness> {
   }
 
   state.starting = (async () => {
-    const port = resolvePort();
+    const port = await resolvePort();
     const url = `http://127.0.0.1:${port}`;
 
     // Probe — if a server is already running we reuse it.

--- a/tests/tls/support.ts
+++ b/tests/tls/support.ts
@@ -33,12 +33,30 @@ import { fileURLToPath } from 'node:url';
 const STARTUP_TIMEOUT_MS = 40_000; // mock_signalwire cold-loads 13 specs (~15s)
 const PROBE_TIMEOUT_MS = 2_000;
 
-// Dedicated ports for the --tls mocks, distinct from the plain-HTTP shared
-// mocks (mock_relay ws=8776/http=9776, mock_signalwire 8766) so both can run
-// in the same suite without colliding.
-const TLS_RELAY_WS_PORT = 8778;
-const TLS_RELAY_HTTP_PORT = 9778;
-const TLS_SIGNALWIRE_PORT = 8768;
+// The --tls mocks pick FREE ports (bind :0) rather than hardcoded ones, so a
+// stale/concurrent listener never collides. Each start function picks its own
+// (relay: WS + HTTP independently); env overrides win when set.
+async function pickFreePort(): Promise<number> {
+  const { createServer } = await import('node:net');
+  return new Promise<number>((resolve, reject) => {
+    const srv = createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = addr && typeof addr === 'object' ? addr.port : 0;
+      srv.close(() => (port > 0 ? resolve(port) : reject(new Error('failed to pick a free port'))));
+    });
+  });
+}
+
+async function resolveTlsPort(envVar: string): Promise<number> {
+  const raw = process.env[envVar];
+  if (raw) {
+    const p = parseInt(raw, 10);
+    if (!isNaN(p) && p > 0) return p;
+  }
+  return pickFreePort();
+}
 
 /**
  * Resolve the porting-sdk root: $PORTING_SDK / $PSDK (the env vars run-ci.sh
@@ -168,8 +186,10 @@ export async function startTlsMockRelay(): Promise<TlsMockRelay | null> {
   // null pkgDir is fine — the mock also resolves from the system Python.
   const pkgDir = discoverPortingSdkPackage('mock_relay');
 
-  const httpUrl = `http://127.0.0.1:${TLS_RELAY_HTTP_PORT}`;
-  const relayHost = `127.0.0.1:${TLS_RELAY_WS_PORT}`;
+  const tlsWsPort = await resolveTlsPort('MOCK_RELAY_TLS_WS_PORT');
+  const tlsHttpPort = await resolveTlsPort('MOCK_RELAY_TLS_HTTP_PORT');
+  const httpUrl = `http://127.0.0.1:${tlsHttpPort}`;
+  const relayHost = `127.0.0.1:${tlsWsPort}`;
 
   // Reuse an already-running --tls instance if one answers (probe-then-spawn).
   if (await probeHealth(httpUrl, 'schemas_loaded')) {
@@ -184,9 +204,9 @@ export async function startTlsMockRelay(): Promise<TlsMockRelay | null> {
       '--host',
       '127.0.0.1',
       '--ws-port',
-      String(TLS_RELAY_WS_PORT),
+      String(tlsWsPort),
       '--http-port',
-      String(TLS_RELAY_HTTP_PORT),
+      String(tlsHttpPort),
       '--tls',
       '--log-level',
       'error',
@@ -261,7 +281,8 @@ export async function startTlsMockSignalwire(): Promise<TlsMockSignalwire | null
   // null pkgDir is fine — the mock also resolves from the system Python.
   const pkgDir = discoverPortingSdkPackage('mock_signalwire');
 
-  const baseUrl = `https://127.0.0.1:${TLS_SIGNALWIRE_PORT}`;
+  const tlsPort = await resolveTlsPort('MOCK_SIGNALWIRE_TLS_PORT');
+  const baseUrl = `https://127.0.0.1:${tlsPort}`;
 
   if (await probeHealth(baseUrl, 'specs_loaded')) {
     return new TlsMockSignalwire(spawn('true'), baseUrl);
@@ -275,7 +296,7 @@ export async function startTlsMockSignalwire(): Promise<TlsMockSignalwire | null
       '--host',
       '127.0.0.1',
       '--port',
-      String(TLS_SIGNALWIRE_PORT),
+      String(tlsPort),
       '--tls',
       '--log-level',
       'error',


### PR DESCRIPTION
Replace hardcoded mock ports in the REST-COVERAGE gate and the REST/RELAY/TLS test harnesses with OS-assigned free ports (node `net` listen :0; python socket :0 in the gate), and add a fail-loud guard so a dead/never-healthy mock fails the gate instead of hanging. Fixes the ts↔ruby 8769 collision. Env-var overrides preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau