### PR TITLE
docs(readme): document built-in webhook verification (validateRequest) [#95]

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,39 @@ See the **[REST documentation](rest/README.md)** for the full guide, API referen
 
 ---
 
+## Webhook Verification
+
+Verify that an inbound webhook (status callback, messaging callback, SWML/SWAIG
+request) genuinely came from SignalWire using your Signing Key. This is the
+spiritual successor to the Compatibility API's `RestClient.validateRequest()` /
+`validateRequestWithBody()` — and it ships **built into `@signalwire/sdk`** as a
+top-level export, so you do not need the separate `@signalwire/compatibility-api`
+package.
+
+```typescript
+import { validateRequest } from '@signalwire/sdk';
+
+// Parsed form params (classic cXML/Compat webhooks) —
+// the equivalent of RestClient.validateRequest():
+const ok = validateRequest(signingKey, signatureHeader, fullUrl, requestParams);
+
+// Raw request body (JSON/SWML, or cXML form bodies that carry bodySHA256) —
+// the equivalent of RestClient.validateRequestWithBody():
+const ok = validateRequest(signingKey, signatureHeader, fullUrl, rawBodyString);
+```
+
+`validateRequest` folds both Compatibility API methods into one call: pass a
+**parsed params object / `Map` / array of tuples** for form-encoded webhooks, or
+the **raw body string** to additionally verify the `bodySHA256` the platform
+includes for JSON/SWML payloads. It returns `true` on a match, `false`
+otherwise, and throws if the Signing Key is missing.
+
+If you want the lower-level primitive (compute/compare a single signature over a
+raw body), `validateWebhookSignature(signingKey, signature, url, rawBody)` is
+also exported.
+
+---
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## What

Adds a **Webhook Verification** section to the README documenting the built-in `validateRequest` / `validateWebhookSignature` exports.

## Why (#95)

A customer (@f3ndot) migrating Twilio → SignalWire on `@signalwire/sdk` couldn't find webhook-payload verification and ended up installing the separate `@signalwire/compatibility-api` package to get `RestClient.validateRequest()` / `validateRequestWithBody()`.

But `@signalwire/sdk` **already ships** that capability as top-level exports (`src/index.ts:169`): `validateRequest` folds both Compat API methods into one call — parsed params for cXML/form webhooks, or a raw body string for the `bodySHA256` (JSON/SWML) case. The only gap was discoverability: it wasn't in the README.

This is the docs half of #95. No code change — no misplaced `RestClient.validateRequest` method is added (that would invent surface to mimic a legacy shape); the existing unified export is the spiritual successor.

## Verification

- DOC-AUDIT gate passes locally (both referenced symbols resolve to real exports).
- No surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)