### PR TITLE
fix(swaig-test): validate --simulate-serverless platform; error on no action

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -358,6 +358,23 @@ run_gate "SURFACE-DIFF" "diff_port_surface vs python_surface.json" \
         --omissions "$PORT_ROOT/PORT_OMISSIONS.md" \
         --additions "$PORT_ROOT/PORT_ADDITIONS.md"
 
+# Gate 11: SWAIG-CLI — the lightweight shared swaig-test mini-contract (NOT
+# python parity; python's in-process simulator surface is reference-only). Black-
+# box: invokes this port's swaig-test --help + a couple golden invocations and
+# asserts (1) the shared verbs are documented, (2) an unknown --simulate-serverless
+# platform errors instead of silently falling back, (3) no-action errors instead
+# of a silent default. TS accepts --simulate-serverless (lambda/gcf/azure/cgi), so
+# the unknown-platform clause applies.
+run_gate "SWAIG-CLI" "swaig-test shared mini-contract (verbs/serverless-reject/default-action)" \
+    python3 "$PORTING_SDK_DIR/scripts/audit_swaig_cli_contract.py" \
+        --port typescript \
+        --cmd "npx tsx $PORT_ROOT/src/cli/swaig-test.ts" \
+        --default-action-argv 'AGENT_FILE_PLACEHOLDER' \
+        --has-serverless \
+        --serverless-argv 'AGENT_FILE_PLACEHOLDER|--simulate-serverless|bogus-platform-xyz' \
+        --agent-file-suffix '.ts' \
+        --agent-file-content "import { AgentBase } from '$PORT_ROOT/src/AgentBase.ts'; const a = new AgentBase({ name: 'probe', route: '/' }); a.setPromptText('hi'); export default a;"
+
 if [ -z "$FAILED_GATES" ]; then
     echo "==> CI PASS"
     exit 0

--- a/src/cli/swaig-test.ts
+++ b/src/cli/swaig-test.ts
@@ -40,9 +40,58 @@ import { suppressAllLogs, setGlobalLogLevel } from '../Logger.js';
 import { ServerlessAdapter } from '../ServerlessAdapter.js';
 import type { ServerlessPlatform } from '../ServerlessAdapter.js';
 
+/**
+ * Concrete serverless platforms the {@link ServerlessAdapter} actually implements
+ * end-to-end (normalize event → route through Hono → normalize response, plus a
+ * platform-specific handler factory and URL generator). `'auto'` is intentionally
+ * NOT here: it is environment-based detection for production wiring and is
+ * meaningless as an explicit `--simulate-serverless` target.
+ *
+ * This is the canonical "supported set" the CLI validates `--simulate-serverless`
+ * against — mirroring the Go port's `supportedSimulatePlatforms` in
+ * `cmd/swaig-test/simulate.go`. Adding an entry here without a real adapter path
+ * would be a lie that silently passes a bogus `--simulate-serverless <x>`.
+ */
+const SUPPORTED_SIMULATE_PLATFORMS: readonly Exclude<ServerlessPlatform, 'auto'>[] = [
+  'lambda',
+  'gcf',
+  'azure',
+  'cgi',
+];
+
+/**
+ * Validate a user-supplied `--simulate-serverless` platform against what this
+ * port actually implements. Returns the narrowed platform on success; throws a
+ * descriptive Error (naming the supported set) otherwise — never a silent
+ * fallback. Matches the Go port's `validateSimulatePlatform` error shape so the
+ * cross-port SWAIG-CLI contract gate sees a consistent reject-don't-fallback.
+ */
+function validateSimulatePlatform(platform: string): ServerlessPlatform {
+  if (!platform) {
+    throw new Error('--simulate-serverless requires a platform name (e.g. "lambda")');
+  }
+  if ((SUPPORTED_SIMULATE_PLATFORMS as readonly string[]).includes(platform)) {
+    return platform as ServerlessPlatform;
+  }
+  throw new Error(
+    `--simulate-serverless ${platform}: unknown platform. ` +
+      `This TypeScript port supports: ${SUPPORTED_SIMULATE_PLATFORMS.join(', ')}. ` +
+      `(No silent fallback to the server path.)`,
+  );
+}
+
 interface CliOptions {
   agentPath: string;
   action: 'list-tools' | 'list-agents' | 'dump-swml' | 'exec';
+  /**
+   * Whether an explicit action flag (--list-tools / --list-agents / --dump-swml
+   * / --exec) was passed. When false AND not in --simulate-serverless mode the
+   * CLI errors instead of silently defaulting — matching the cross-port
+   * majority (go/java/ruby/php/perl/rust/cpp all error on no action) and the
+   * SWAIG-CLI mini-contract gate. `action` still carries a default value so the
+   * downstream switch stays exhaustive.
+   */
+  actionExplicit: boolean;
   execName?: string;
   raw: boolean;
   verbose: boolean;
@@ -106,6 +155,7 @@ function parseArgs(argv: string[]): CliOptions {
   const opts: CliOptions = {
     agentPath: '',
     action: 'dump-swml',
+    actionExplicit: false,
     raw: false,
     verbose: false,
     formatJson: false,
@@ -131,15 +181,19 @@ function parseArgs(argv: string[]): CliOptions {
     switch (arg) {
       case '--list-tools':
         opts.action = 'list-tools';
+        opts.actionExplicit = true;
         break;
       case '--list-agents':
         opts.action = 'list-agents';
+        opts.actionExplicit = true;
         break;
       case '--dump-swml':
         opts.action = 'dump-swml';
+        opts.actionExplicit = true;
         break;
       case '--exec':
         opts.action = 'exec';
+        opts.actionExplicit = true;
         opts.execName = args[++i];
         if (!opts.execName) {
           console.error('Error: --exec requires a function name');
@@ -331,9 +385,18 @@ async function main(): Promise<void> {
     agent.route = opts.route;
   }
 
+  // Consistent default action: when a target is given but no action flag, error
+  // rather than silently dumping SWML. --simulate-serverless without a sub-action
+  // is still allowed (it runs the simulation render, mirroring the Go/Ruby
+  // "render and exit" default). Matches the cross-port SWAIG-CLI mini-contract.
+  if (!opts.actionExplicit && !opts.simulateServerless) {
+    console.error('Error: one of --dump-swml, --list-tools, or --exec is required');
+    process.exit(1);
+  }
+
   // Handle --simulate-serverless
   if (opts.simulateServerless) {
-    const platform = opts.simulateServerless as ServerlessPlatform;
+    const platform = validateSimulatePlatform(opts.simulateServerless);
     const adapter = new ServerlessAdapter(platform);
     const app = agent.getApp();
     const postData = generateFakePostData({

--- a/tests/cli/swaig-test.test.ts
+++ b/tests/cli/swaig-test.test.ts
@@ -1,6 +1,94 @@
 import { describe, it, expect } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { AgentBase } from '../../src/AgentBase.js';
 import { FunctionResult } from '../../src/FunctionResult.js';
+
+const CLI = fileURLToPath(new URL('../../src/cli/swaig-test.ts', import.meta.url));
+
+/** Run the swaig-test CLI via tsx as a subprocess; resolves with code+output. */
+function runCli(args: string[]): Promise<{ code: number; out: string }> {
+  return new Promise((resolve) => {
+    execFile(
+      'npx',
+      ['tsx', CLI, ...args],
+      { timeout: 60_000, env: { ...process.env, SIGNALWIRE_LOG_MODE: 'off' } },
+      (err, stdout, stderr) => {
+        const code =
+          err && typeof (err as NodeJS.ErrnoException & { code?: number }).code === 'number'
+            ? ((err as unknown as { code: number }).code ?? 1)
+            : err
+              ? 1
+              : 0;
+        resolve({ code, out: `${stdout}\n${stderr}` });
+      },
+    );
+  });
+}
+
+/** Write a throwaway agent .ts file exporting a default AgentBase. */
+function writeAgentFile(): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'swaig-cli-'));
+  const path = join(dir, 'agent.ts');
+  writeFileSync(
+    path,
+    [
+      "import { AgentBase } from '" +
+        fileURLToPath(new URL('../../src/AgentBase.ts', import.meta.url)) +
+        "';",
+      "const agent = new AgentBase({ name: 'probe', route: '/' });",
+      "agent.setPromptText('hi');",
+      'export default agent;',
+    ].join('\n'),
+  );
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe('swaig-test CLI contract (subprocess)', () => {
+  it('rejects an unknown --simulate-serverless platform with a descriptive error', async () => {
+    const { path, cleanup } = writeAgentFile();
+    try {
+      const { code, out } = await runCli([path, '--simulate-serverless', 'bogus-platform-xyz']);
+      expect(code).not.toBe(0);
+      expect(out).toContain('bogus-platform-xyz');
+      expect(out.toLowerCase()).toContain('unknown platform');
+      // Must NOT silently fall through to a serverless simulation render.
+      expect(out).not.toContain('Serverless Simulation');
+    } finally {
+      cleanup();
+    }
+  }, 70_000);
+
+  it('accepts a real platform (gcf) — proves the validator is not over-strict', async () => {
+    const { path, cleanup } = writeAgentFile();
+    try {
+      const { code, out } = await runCli([path, '--simulate-serverless', 'gcf', '--raw']);
+      // gcf is implemented; it must NOT be rejected as unknown.
+      expect(out).not.toContain('unknown platform');
+      expect(code).toBe(0);
+    } finally {
+      cleanup();
+    }
+  }, 70_000);
+
+  it('errors when a target is given but no action flag (no silent dump-swml)', async () => {
+    const { path, cleanup } = writeAgentFile();
+    try {
+      const { code, out } = await runCli([path]);
+      expect(code).not.toBe(0);
+      expect(out).toContain('--dump-swml');
+      expect(out).toContain('--list-tools');
+      expect(out).toContain('--exec');
+      // The old behavior dumped a SWML document; ensure it no longer does.
+      expect(out).not.toContain('SWML Document');
+    } finally {
+      cleanup();
+    }
+  }, 70_000);
+});
 
 describe('agent introspection', () => {
   function createAgent() {


### PR DESCRIPTION
## FIX 1 (highest value) — `--simulate-serverless` platform validation / fail-loud

`src/cli/swaig-test.ts` replaced the bare cast `opts.simulateServerless as ServerlessPlatform` — which **silently accepted any typo or unimplemented platform and fell through** to the adapter — with `validateSimulatePlatform()`, mirroring the Go port's `validateSimulatePlatform` in `cmd/swaig-test/simulate.go`.

The TS `ServerlessAdapter` genuinely implements **lambda / gcf / azure / cgi** (event normalize → Hono → response, plus per-platform handler factories and `generateUrl`), so those four are the supported set. `'auto'` is intentionally excluded (it's env-detection, not a sim target). Anything else now exits non-zero with a descriptive error naming the supported platforms — **never a silent fallback**.

## FIX 3 — consistent default action

A target with no action flag used to silently default to `--dump-swml`. Seven of the nine HTTP-model ports (go/java/ruby/php/perl/rust/cpp) independently chose the same deliberate behavior — error `one of --dump-swml, --list-tools, or --exec is required`. TS now matches that cross-port majority. `--simulate-serverless` without a sub-action still renders (unchanged).

## Tests

3 subprocess regression tests (vitest): unknown platform errors and names the platform; a real platform (`gcf`) is still accepted (validator isn't over-strict); no-action errors instead of dumping SWML.

## Gate

Wires the shared **SWAIG-CLI** mini-contract gate (porting-sdk `audit_swaig_cli_contract.py`, PR signalwire/porting-sdk#50) into `scripts/run-ci.sh`. Full `run-ci.sh` is green including the new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)