### PR TITLE
docs+test: wire-truth W1 burn — areacode + params-wrapped tts (REST surface)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ const client = new RestClient({
 });
 
 await client.fabric.aiAgents.create({ name: 'Support Bot', prompt: { text: 'You are helpful.' } });
-await client.calling.play(callId, [{ type: 'tts', text: 'Hello!' }]);
+await client.calling.play(callId, [{ type: 'tts', params: { text: 'Hello!' } }]);
 await client.phoneNumbers.search({ area_code: '512' });
 await client.datasphere.documents.search('billing policy');
 ```

--- a/examples/quickstart-rest.ts
+++ b/examples/quickstart-rest.ts
@@ -19,7 +19,7 @@ const client = new RestClient({
 });
 
 await client.fabric.aiAgents.create({ name: 'Support Bot', prompt: { text: 'You are helpful.' } });
-await client.calling.play(callId, [{ type: 'tts', text: 'Hello!' }]);
+await client.calling.play(callId, [{ type: 'tts', params: { text: 'Hello!' } }]);
 await client.phoneNumbers.search({ area_code: '512' });
 await client.datasphere.documents.search('billing policy');
 // endregion: construct

--- a/rest/README.md
+++ b/rest/README.md
@@ -20,7 +20,7 @@ const agent = await client.fabric.aiAgents.create({
 });
 
 // Search for a phone number
-const results = await client.phoneNumbers.search({ areaCode: '512' });
+const results = await client.phoneNumbers.search({ areacode: '512' });
 
 // Place a call via REST — from and to are positional
 await client.calling.dial('+15559876543', '+15551234567', {

--- a/rest/docs/calling.md
+++ b/rest/docs/calling.md
@@ -76,7 +76,7 @@ await client.calling.disconnect(callId);
 Play audio, TTS, silence, or ringtone. The `play` array is positional.
 
 ```typescript
-await client.calling.play(callId, [{ type: 'tts', text: 'Hello!' }], {
+await client.calling.play(callId, [{ type: 'tts', params: { text: 'Hello!' } }], {
   volume: 5.0,
 });
 ```

--- a/rest/docs/guide.md
+++ b/rest/docs/guide.md
@@ -21,7 +21,7 @@ declare const httpClient: import('@signalwire/sdk').HttpClient;
 const agents = await client.fabric.aiAgents.list();
 
 // Search phone numbers
-const numbers = await client.phoneNumbers.search({ areaCode: '512' });
+const numbers = await client.phoneNumbers.search({ areacode: '512' });
 
 // Play audio into a call (the `play` array is positional)
 await client.calling.play('call-id', [{ type: 'audio', url: 'https://example.com/audio.mp3' }]);

--- a/rest/docs/namespaces.md
+++ b/rest/docs/namespaces.md
@@ -18,7 +18,7 @@ let numbers = await client.phoneNumbers.list();
 numbers = await client.phoneNumbers.list({ name: 'Main' });
 
 // Search available numbers to purchase
-const available = await client.phoneNumbers.search({ areaCode: '512', numberType: 'local' });
+const available = await client.phoneNumbers.search({ areacode: '512', numberType: 'local' });
 
 // Purchase a number
 const number = await client.phoneNumbers.create({ number: '+15551234567' });
@@ -29,7 +29,7 @@ await client.phoneNumbers.update('pn-uuid', { name: 'Support Line' });
 await client.phoneNumbers.delete('pn-uuid');
 ```
 
-> Search filters are camelCase: use `areaCode`, not `area_code`.
+> Search filters use the WIRE parameter names verbatim: `areacode` (all lowercase, as in the REST spec) — `areaCode` and `area_code` are silently ignored by the server.
 
 ## Addresses
 

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -32,7 +32,7 @@ const logger = getLogger('rest_client');
  * // Use namespaced resources
  * await client.fabric.aiAgents.list();
  * await client.calling.play(callId, { play: [...] });
- * await client.phoneNumbers.search({ areaCode: '512' });
+ * await client.phoneNumbers.search({ areacode: '512' });
  * await client.video.rooms.create({ name: 'standup' });
  * ```
  */

--- a/tests/rest/relay-rest.test.ts
+++ b/tests/rest/relay-rest.test.ts
@@ -27,9 +27,9 @@ describe('PhoneNumbersResource', () => {
   it('searches available numbers', async () => {
     const { http, getRequests } = makeHttp();
     const res = new PhoneNumbersResource(http);
-    await res.search({ areaCode: '512' });
+    await res.search({ areacode: '512' });
     expect(getRequests()[0]!.url).toContain('/api/relay/rest/phone_numbers/search');
-    expect(getRequests()[0]!.url).toContain('areaCode=512');
+    expect(getRequests()[0]!.url).toContain('areacode=512');
   });
 
   it('updates with PUT', async () => {


### PR DESCRIPTION
**Wave-1 wire-truth burn** (GATE_ENFORCEMENT_PLAN §A1, ts sites).

1. **`areaCode` → `areacode`** (5 doc sites + the enshrined test). `search()` forwards params verbatim as query params; the spec name is `areacode` — `areaCode` is silently ignored (unfiltered search that looks filtered). `tests/rest/relay-rest.test.ts` was asserting the wrong wire (`areaCode=512` in the URL) — now asserts the spec name. Also rewrote the `namespaces.md` guidance line that taught the inverted rule ('filters are camelCase').
2. **Flat `{type:'tts', text}` → `{type:'tts', params:{text}}`** (3 REST-surface sites). REST `calling.play()` passes the play array verbatim; spec CallPlayRequest nests text under `params` — flat items silently no-op. RELAY-surface docs are deliberately unchanged: the relay `PlayItem` type + `normalizePlayItems` accept the flat form and build the wire shape (that's SDK-normalized, not a bug).

**Verified:** relay-rest test file 35/35 · README-INCLUDE PASS · NO-LAUNDER clean (banned: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DbkphxGZfj9bx9uyYDMFp