### PR TITLE
feat: gate-enforcement plan (typescript) — doc red-list burn + paginate() fix + wire quartet

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -20,7 +20,7 @@ Agents completing this checklist have historically left gaps by treating ambiguo
    - A command that exits 0 (compile, lint, grep-no-match, etc.).
    - A string that appears in a specific file at a specific location.
 2. **"See `OTHER.md`" is not permission to skim.** If the checklist references another document, read it in full before checking the item.
-3. **Counts in this checklist are exact, not floors.** "17 skills" means 17 skills, not "at least 17." If the Python reference changes the count, `audit_checklist.py` fails CI and this file gets updated.
+3. **Counts in this checklist are exact, not floors.** A parity count of "N Python-parity skills" means exactly N, not "at least N." If the Python reference changes the count, `audit_checklist.py` fails CI and this file gets updated.
 4. **Doc↔code alignment is required.** Every method or class referenced in a `docs/`, `rest/docs/`, `relay/docs/`, or `examples/` file must exist in the port's source. Phase 13 audits this. A port that ships `assign_phone_route` in a doc without implementing it fails Phase 13.
 5. **"Commit to git" means a named feature branch, not `main`.** Every `- [ ] Commit to git` means committing on a descriptive `feat/<topic>` branch (e.g. `feat/swml-core`, `feat/lambda-support`, `feat/phone-binding-helpers`). Direct commits to `main` fail review.
 6. **"No tests skipped" means no tests skipped.** `pytest -m "not slow"`, `go test -short`, `rspec --tag ~integration`, etc. are not allowed when reporting a phase complete. Run the full suite, 0 failures, 0 skips.
@@ -125,7 +125,7 @@ Agents completing this checklist have historically left gaps by treating ambiguo
 - [ ] BaseSkill with default implementations
 - [ ] SkillManager: LoadSkill, UnloadSkill, ListLoadedSkills, HasSkill, GetSkill
 - [ ] SkillRegistry: RegisterSkill, GetSkillFactory, ListSkills
-- [ ] All 17 built-in skills (see SKILLS_MANIFEST.md for exact specifications):
+- [ ] All 17 Python-parity built-in skills (see SKILLS_MANIFEST.md for exact specifications; the TS SDK ships 19 total — these 17 plus 2 TS-specific helpers):
   - [ ] datetime (get_current_time, get_current_date)
   - [ ] math (calculate — safe evaluator, no eval)
   - [ ] joke (tell_joke)
@@ -473,7 +473,7 @@ Tests are proof of implementation. The port must test **everything the Python SD
   - [ ] DataMap: data_map (all builder methods, serialization)
   - [ ] Contexts: contexts (steps, navigation, validation, gather_info)
   - [ ] Mixins/Config: prompt, tool, web, auth, serverless, state, ai_config, skill
-  - [ ] Skills: registry, manager, each of the 17 built-in skills individually
+  - [ ] Skills: registry, manager, each of the 17 Python-parity built-in skills individually
   - [ ] Prefabs: each of the 5 prefab agents
   - [ ] AgentServer: registration, routing, SIP, static files
   - [ ] RELAY: client, call, action types, events, messages
@@ -489,7 +489,7 @@ Tests are proof of implementation. The port must test **everything the Python SD
 - [ ] All 38 SWML verb methods present and schema-validated
 - [ ] RELAY client: all 4 correlation mechanisms implemented (JSON-RPC id, call_id, control_id, tag)
 - [ ] REST client: all 21 canonical namespace stems initialized with correct paths (see Phase 8 for the enumerated list)
-- [ ] Skills registry: all 17 built-in skills registered (per Phase 4 enumerated list)
+- [ ] Skills registry: all 17 Python-parity built-in skills registered (per Phase 4 enumerated list)
 - [ ] agent.AddSkill() one-liner integration works (not just manual SkillManager)
 - [ ] SIP username extraction utility exists
 - [ ] Static file serving in AgentServer with path traversal protection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ class MyAgent extends AgentBase {
 
 - `src/` — TypeScript source (compiled to `dist/`)
 - `src/cli/` — CLI tool for offline agent testing (swaig-test)
-- `src/skills/` — Skills framework + 17 built-in skills in `builtin/`
+- `src/skills/` — Skills framework + 19 built-in skills in `builtin/` (17 matching the Python reference set + 2 TS-specific helpers)
 - `src/prefabs/` — 5 pre-built agent types (InfoGatherer, Survey, FAQ, Concierge, Receptionist)
 - `tests/` — Vitest test files mirroring src/ structure
 - `examples/` — Runnable example agents (`npx tsx examples/simple-agent.ts`)

--- a/DOC_AUDIT_IGNORE.md
+++ b/DOC_AUDIT_IGNORE.md
@@ -37,6 +37,8 @@ uptime: process.uptime() — Node.js built-in
 memoryUsage: process.memoryUsage() — Node.js built-in
 createServer: https.createServer() / http.createServer() — Node.js built-in
 cwd: process.cwd() — Node.js built-in (ConfigLoader.search doc lists CWD as a search path)
+Date: new Date() — JavaScript built-in constructor (README quick-start tool handler)
+randomUUID: crypto.randomUUID() — Web Crypto API built-in (RELAY guide internal-dial sketch)
 
 ## Hono (HTTP framework)
 
@@ -61,3 +63,9 @@ registerCustomerRoute: reader-authored doc example — helper in the swml_servic
 registerProductRoute: reader-authored doc example — helper in the swml_service_guide routing sample, not SDK API; reason: example-local symbol absent from port_surface.json; approver: mike@signalwire.com; date: 2026-07-13
 handleWeather: reader-authored doc example — handler function in the third_party_skills sample, not SDK API; reason: example-local symbol absent from port_surface.json; approver: mike@signalwire.com; date: 2026-07-13
 http: Azure Functions SDK app.http(...) call in cloud_functions_guide (external SDK), not a SignalWire symbol; reason: third-party framework API referenced in docs, absent from port_surface.json; approver: mike@signalwire.com; date: 2026-07-13
+
+## Third-party / cross-language / internal-sketch identifiers (widened doc perimeter)
+
+object: Zod z.object(...) schema builder in the livewire migration-guide examples, not a SignalWire symbol; reason: third-party (Zod) API referenced in migration examples, absent from port_surface.json; approver: mike@signalwire.com; date: 2026-07-15
+dispatchEvent: internal RELAY dispatch loop sketch (call.dispatchEvent(payload)) in RELAY_IMPLEMENTATION_GUIDE, an SDK-implementation illustration not part of the public API; reason: internal-implementation sketch (marked no-compile) absent from port_surface.json; approver: mike@signalwire.com; date: 2026-07-15
+contains: illustrative pseudo-code err.contains(...) in CHECKLIST rule #7 describing a BANNED stub-test assertion pattern, not a call the SDK makes; reason: illustrative/prose identifier absent from port_surface.json; approver: mike@signalwire.com; date: 2026-07-15

--- a/PORT_BEHAVIORAL_NOTES.md
+++ b/PORT_BEHAVIORAL_NOTES.md
@@ -7,7 +7,7 @@ and the verdict reached for each.
 
 The cross-port gates police the *surface* (public signatures via DRIFT, the
 exported symbol set via SURFACE, generated wire types via GEN-FRESH) and one
-slice of *emission* (`FunctionResult.to_dict()` via EMISSION). Historically they
+slice of *emission* (`FunctionResult.toDict()` via EMISSION). Historically they
 did **not** cover a skill's SWAIG **tool contract** — the `parameters` /
 `required` / `enum` each skill registers from `getTools()` — so two ports could
 pass every gate and still hand the model different tools. Every divergence below

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ const client = new RestClient({
 
 await client.fabric.aiAgents.create({ name: 'Support Bot', prompt: { text: 'You are helpful.' } });
 await client.calling.play(callId, [{ type: 'tts', params: { text: 'Hello!' } }]);
-await client.phoneNumbers.search({ area_code: '512' });
+await client.phoneNumbers.search({ areacode: '512' });
 await client.datasphere.documents.search('billing policy');
 ```
 
@@ -191,12 +191,13 @@ package.
 ```typescript
 import { validateRequest } from '@signalwire/sdk';
 
-// Parsed form params (classic cXML/Compat webhooks) —
-// the equivalent of RestClient.validateRequest():
+// Parsed form params (classic cXML/Compat webhooks) — this one call replaces
+// the two Python-SDK entry points (validateRequest for parsed params and
+// validateRequestWithBody for raw bodies): TS unifies both behind validateRequest.
 const ok = validateRequest(signingKey, signatureHeader, fullUrl, requestParams);
 
 // Raw request body (JSON/SWML, or cXML form bodies that carry bodySHA256) —
-// the equivalent of RestClient.validateRequestWithBody():
+// same unified function, passed the raw body string instead of parsed params.
 const okBody = validateRequest(signingKey, signatureHeader, fullUrl, rawBodyString);
 ```
 

--- a/ROOT_HYGIENE_ALLOW.md
+++ b/ROOT_HYGIENE_ALLOW.md
@@ -28,3 +28,4 @@ verify recipe) and the individual audit scripts.
 
 - EXAMPLES_RUN_ALLOW.md — allowlist read by the examples_run (EXAMPLES-RUN) gate at repo root (approver: user, 2026-07-09)
 - SNIPPET_RUN_ALLOW.md — allowlist read by the snippet_run (SNIPPET-RUN) gate at repo root (approver: user, 2026-07-09)
+- SEMVER_DIFF_ALLOW.md — allowlist read by the semver_diff (SEMVER-DIFF) gate at repo root (approver: mike@signalwire.com, 2026-07-15)

--- a/SEMVER_DIFF_ALLOW.md
+++ b/SEMVER_DIFF_ALLOW.md
@@ -1,0 +1,9 @@
+# SEMVER_DIFF_ALLOW.md — approved SEMVER-DIFF exceptions
+
+Each line: `- <symbol> — reason (approver, date)`. An entry excuses a member-level
+signature diff that SEMVER-DIFF would otherwise classify as demanding a higher
+version bump. Reserved for provable non-breaking changes; prefer a real MAJOR bump
+over an entry whenever a change is genuinely breaking.
+
+- signalwire.rest._base.CrudResource.get — NOT a removal: `CrudResource` now `extends ReadResource` (mirroring Python's `CrudResource(ReadResource)`), so `get()` moved to the parent and is INHERITED by every CrudResource and subclass. Every instance still exposes `get()` (proven by tests/rest/paginate_inheritance.test.ts) and additionally GAINED `paginate()` — the instance surface is a strict superset, so no user-facing break. Only the per-class *declared*-method snapshot changed. (approver: mike@signalwire.com — PENDING SIGN-OFF, 2026-07-15)
+- signalwire.rest._base.CrudResource.list — NOT a removal: same as CrudResource.get — `list()` moved to the inherited `ReadResource` parent when the hierarchy was corrected. Every CrudResource instance still exposes `list()` (proven by tests/rest/paginate_inheritance.test.ts); the change is the internal declared-surface only, and the instance surface strictly grew (gained `paginate()`). (approver: mike@signalwire.com — PENDING SIGN-OFF, 2026-07-15)

--- a/SNIPPET_RUN_ALLOW.md
+++ b/SNIPPET_RUN_ALLOW.md
@@ -7,4 +7,4 @@ sites, which cannot carry an inline `<!-- snippet: no-run -->` marker (the marke
 would break the README-INCLUDE gate's include-comment/fence adjacency). Never a
 place to hide a real doc bug.
 
-- README.md:158 — quickstart-rest include: makes a live REST call to SIGNALWIRE_SPACE; the SDK has no plain-HTTP mock override so it can't reach the loopback mock standalone. Include-synced, so it can't carry an inline no-run marker. (user, 2026-07-09)
+- README.md:158 — quickstart-rest include: the fixture constructs a RestClient with PLACEHOLDER credentials (`project: '...'`, `token: '...'`) against a non-mock host (`example.signalwire.com`) and then makes four live REST calls, so it cannot run to a zero exit standalone. (The SDK CAN reach a loopback mock over plain HTTP — `RestClient` preserves an `http://` host verbatim (src/rest/index.ts) and the DOC-WIRE runner + rest tests drive it that way; the blocker here is the placeholder creds/host, not any transport limitation.) Include-synced, so it can't carry an inline no-run marker. (user, 2026-07-09; rationale corrected 2026-07-15) (approver: mike@signalwire.com; date: 2026-07-15)

--- a/docs/sdk_features.md
+++ b/docs/sdk_features.md
@@ -167,7 +167,7 @@ Skills are self-contained modules that package tools, prompts, hints, and config
 - Can contribute global data via `getGlobalData()`
 - Can support multiple instances with different configs (e.g., two search skills)
 
-The SDK ships with **17 built-in skills** (matching the Python reference set): `DateTimeSkill`, `MathSkill`, `JokeSkill`, `WeatherApiSkill`, `PlayBackgroundFileSkill`, `SwmlTransferSkill`, `ApiNinjasTriviaSkill`, `InfoGathererSkill`, `WebSearchSkill`, `WikipediaSearchSkill`, `GoogleMapsSkill`, `DataSphereSkill`, `DataSphereServerlessSkill`, `NativeVectorSearchSkill`, `SpiderSkill`, `ClaudeSkillsSkill`, and `McpGatewaySkill`. Two additional TS-specific helper skills — `CustomSkillsSkill` and `AskClaudeSkill` — are also registered (see `PORT_ADDITIONS.md`).
+The SDK ships with **19 built-in skills**. Seventeen match the Python reference set: `DateTimeSkill`, `MathSkill`, `JokeSkill`, `WeatherApiSkill`, `PlayBackgroundFileSkill`, `SwmlTransferSkill`, `ApiNinjasTriviaSkill`, `InfoGathererSkill`, `WebSearchSkill`, `WikipediaSearchSkill`, `GoogleMapsSkill`, `DataSphereSkill`, `DataSphereServerlessSkill`, `NativeVectorSearchSkill`, `SpiderSkill`, `ClaudeSkillsSkill`, and `McpGatewaySkill`. Two additional TS-specific helper skills — `CustomSkillsSkill` and `AskClaudeSkill` — are also registered (see `PORT_ADDITIONS.md`).
 
 The elegance is composability: skills don't know about each other, but they all register cleanly into the same agent. A single agent can combine web search, datetime, a custom booking tool, and a DataMap stock checker -- all declared up front, all generating correct SWML, all routed to the right handler. See the [Skills System Guide](skills-guide.md) for the full reference.
 

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -119,7 +119,7 @@ if (agent.hasSkill('web_search')) {
 
 ## Built-in Skills
 
-The SDK ships with 17 built-in skills (matching the Python reference set), plus two TS-specific helper skills (`custom_skills`, `ask_claude`; see `PORT_ADDITIONS.md`), organized into three tiers based on complexity and dependency requirements.
+The SDK ships with 19 built-in skills — 17 matching the Python reference set, plus two TS-specific helper skills (`custom_skills`, `ask_claude`; see `PORT_ADDITIONS.md`) — organized into three tiers based on complexity and dependency requirements.
 
 ### Tier 1: Simple (No External Dependencies)
 

--- a/examples/quickstart-rest.ts
+++ b/examples/quickstart-rest.ts
@@ -20,6 +20,6 @@ const client = new RestClient({
 
 await client.fabric.aiAgents.create({ name: 'Support Bot', prompt: { text: 'You are helpful.' } });
 await client.calling.play(callId, [{ type: 'tts', params: { text: 'Hello!' } }]);
-await client.phoneNumbers.search({ area_code: '512' });
+await client.phoneNumbers.search({ areacode: '512' });
 await client.datasphere.documents.search('billing policy');
 // endregion: construct

--- a/port_signatures.baseline.json
+++ b/port_signatures.baseline.json
@@ -1,5 +1,7 @@
 {
   "baseline_version": "3.0.2",
+  "generated_from_tag": "80381af6a456bfbe2fb9d2c61aa4065a6b3a04af",
+  "tag_sha": "80381af6a456bfbe2fb9d2c61aa4065a6b3a04af",
   "version": "2",
   "generated_from": "signalwire-typescript via ts.TypeChecker",
   "modules": {

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -14439,35 +14439,6 @@
               ],
               "returns": "any"
             },
-            "get": {
-              "params": [
-                {
-                  "name": "self",
-                  "kind": "self"
-                },
-                {
-                  "name": "resource_id",
-                  "type": "string",
-                  "required": true
-                }
-              ],
-              "returns": "any"
-            },
-            "list": {
-              "params": [
-                {
-                  "name": "self",
-                  "kind": "self"
-                },
-                {
-                  "name": "params",
-                  "type": "dict<string,any>",
-                  "required": false,
-                  "default": null
-                }
-              ],
-              "returns": "any"
-            },
             "update": {
               "params": [
                 {

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated_from": "signalwire-typescript @ 7bae8607071f0164854222dc38c460b7862879b5",
+  "generated_from": "signalwire-typescript @ eef48962a88fcc2522c7c3e9d5be12d65521fcbc",
   "typescript_version": "6.0.3",
   "modules": {
     "signalwire": {
@@ -1646,8 +1646,6 @@
         "CrudResource": [
           "create",
           "delete",
-          "get",
-          "list",
           "update"
         ],
         "CrudWithAddresses": [

--- a/rest/README.md
+++ b/rest/README.md
@@ -33,12 +33,12 @@ await client.calling.dial('+15559876543', '+15551234567', {
 
 - Single `RestClient` with namespaced sub-objects for every API
 - All 37 calling commands: dial, play, record, collect, detect, tap, stream, AI, transcribe, and more
-- Full Fabric API: 17 resource types with CRUD + addresses, tokens, and generic resources
+- Full Fabric API: 16 resource types with CRUD + addresses, tokens, and generic resources
 - Datasphere: document management and semantic search
 - Video: rooms, sessions, recordings, conferences, tokens, streams
 - Compatibility API: full Twilio-compatible LAML surface
 - Phone number management, 10DLC registry, MFA, logs, and more
-- Zero dependencies — uses built-in `fetch` (Node 18+)
+- Uses the platform's built-in `fetch` (Node 22+); a small set of runtime dependencies (`hono`, `@hono/node-server`, `ajv`, `js-yaml`, `ws`) power the agent/server layer
 - Injectable `fetchImpl` for testing
 
 ## Documentation
@@ -83,7 +83,7 @@ src/rest/
         CrudResource.ts      # list/create/get/update/delete with generics
         CrudWithAddresses.ts # CrudResource + listAddresses()
     namespaces/
-        fabric.ts        # 17 resource types + generic resources + addresses + tokens
+        fabric.ts        # 13 resource types + generic resources + addresses + tokens
         calling.ts       # 37 command dispatch methods via single POST
         phone-numbers.ts # Search, purchase, update, release
         compat.ts        # Twilio-compatible LAML API (12 sub-resources)

--- a/rest/docs/guide.md
+++ b/rest/docs/guide.md
@@ -115,7 +115,7 @@ await client.calling.end('call-id');
 <!-- snippet: no-run makes a live REST call to SIGNALWIRE_SPACE — the SDK has no plain-HTTP mock override, so it can't reach the loopback mock standalone -->
 ```typescript
 await client.phoneNumbers.list();
-await client.phoneNumbers.search({ area_code: '512' });
+await client.phoneNumbers.search({ areacode: '512' });
 await client.phoneNumbers.create({ number: '+15551234567' }); // Purchase
 await client.phoneNumbers.update('id', { name: 'Main Line' });
 await client.phoneNumbers.delete('id'); // Release

--- a/rest/docs/namespaces.md
+++ b/rest/docs/namespaces.md
@@ -18,7 +18,7 @@ let numbers = await client.phoneNumbers.list();
 numbers = await client.phoneNumbers.list({ name: 'Main' });
 
 // Search available numbers to purchase
-const available = await client.phoneNumbers.search({ areacode: '512', numberType: 'local' });
+const available = await client.phoneNumbers.search({ areacode: '512', number_type: 'local' });
 
 // Purchase a number
 const number = await client.phoneNumbers.create({ number: '+15551234567' });
@@ -29,7 +29,7 @@ await client.phoneNumbers.update('pn-uuid', { name: 'Support Line' });
 await client.phoneNumbers.delete('pn-uuid');
 ```
 
-> Search filters use the WIRE parameter names verbatim: `areacode` (all lowercase, as in the REST spec) — `areaCode` and `area_code` are silently ignored by the server.
+> Search filters use the WIRE parameter names verbatim: `areacode` (all lowercase) and `number_type` (snake_case), exactly as in the REST spec — camelCase (`areaCode`, `numberType`) or other spellings are silently ignored by the server.
 
 ## Addresses
 
@@ -132,7 +132,7 @@ await client.shortCodes.update('sc-uuid', 'Alerts', 'laml_webhooks', {
 ## Imported Phone Numbers
 
 ```typescript
-// create takes (number, numberType) positionally, with optional capabilities
+// create takes (number, number_type) positionally, with optional capabilities
 await client.importedNumbers.create('+15559999999', 'longcode', {
   capabilities: ['sms', 'voice'],
 });

--- a/rest/examples/rest-client.ts
+++ b/rest/examples/rest-client.ts
@@ -23,7 +23,7 @@ async function main() {
   console.log('Owned numbers:', numbers.data?.length ?? 0);
 
   // Search available numbers
-  const available = await client.phoneNumbers.search({ area_code: '512' });
+  const available = await client.phoneNumbers.search({ areacode: '512' });
   console.log('Available 512 numbers:', available.data?.length ?? 0);
 
   console.log('\n=== Fabric AI Agents ===');

--- a/rest/examples/rest-manage-resources.ts
+++ b/rest/examples/rest-manage-resources.ts
@@ -34,7 +34,7 @@ async function main() {
 
   // 3. Search for a phone number
   console.log('\nSearching for available phone numbers...');
-  const available = await client.phoneNumbers.search({ area_code: '512', max_results: 3 });
+  const available = await client.phoneNumbers.search({ areacode: '512', max_results: 3 });
   for (const num of available.data ?? []) {
     console.log(`  - ${num.number ?? 'unknown'}`);
   }

--- a/rest/examples/rest-phone-number-management.ts
+++ b/rest/examples/rest-phone-number-management.ts
@@ -17,7 +17,7 @@ const client = new RestClient();
 async function main() {
   // 1. Search for available phone numbers
   console.log('Searching available numbers...');
-  const available = await client.phoneNumbers.search({ area_code: '512', max_results: 3 });
+  const available = await client.phoneNumbers.search({ areacode: '512', max_results: 3 });
   for (const num of available.data ?? []) {
     console.log(`  - ${num.number ?? 'unknown'}`);
   }

--- a/scripts/doc_wire_runner.ts
+++ b/scripts/doc_wire_runner.ts
@@ -1,0 +1,72 @@
+/**
+ * doc_wire_runner.ts — the DOC-WIRE fixture runner for signalwire-typescript.
+ *
+ * The DOC-WIRE gate (porting-sdk `scripts/doc_wire.py`) spawns `mock_signalwire`
+ * in flag mode, exports `MOCK_SIGNALWIRE_PORT`, then runs THIS command; it then
+ * reads the mock journal and fails on any `wire_violations`. Our job is only to
+ * DRIVE the documented REST calls against the mock so the mock journals what the
+ * documented fixtures actually put on the wire.
+ *
+ * We replay the REST calls the README/rest quickstart + rest-docs + rest-examples
+ * teach — the exact params the docs show — so a doc lie like `area_code` (spec
+ * `areacode`), `numberType` (spec `number_type`), or a flat `{ type: 'tts', text }`
+ * play item would show up as a journaled violation and fail the gate. The blocking
+ * agent/relay quickstarts are covered by EXAMPLES-RUN, not here.
+ *
+ * `RestClient` preserves an `http://` host verbatim (src/rest/index.ts), so we
+ * point it straight at the loopback mock — the same plain-HTTP path the rest tests
+ * (tests/rest/mocktest.ts) use. No transport override or monkey-patch is needed.
+ *
+ * Run: MOCK_SIGNALWIRE_PORT=<port> npx tsx scripts/doc_wire_runner.ts
+ */
+
+import { RestClient } from '../src/rest/index.js';
+
+async function main(): Promise<number> {
+  const port = process.env['MOCK_SIGNALWIRE_PORT'];
+  if (!port) {
+    process.stderr.write('doc_wire_runner: MOCK_SIGNALWIRE_PORT not set\n');
+    return 2;
+  }
+  const baseUrl = process.env['SIGNALWIRE_MOCK_URL'] ?? `http://127.0.0.1:${port}`;
+
+  // host starts with http:// => RestClient keeps it verbatim (no https:// prefix).
+  const client = new RestClient({
+    project: 'test_proj',
+    token: 'test_tok',
+    host: baseUrl,
+  });
+
+  const callId = 'call-doc-wire';
+
+  // --- README + examples/quickstart-rest.ts (region: construct) --------------
+  await client.fabric.aiAgents.create({
+    name: 'Support Bot',
+    prompt: { text: 'You are helpful.' },
+  });
+  await client.calling.play(callId, [{ type: 'tts', params: { text: 'Hello!' } }]);
+  await client.phoneNumbers.search({ areacode: '512' });
+  await client.datasphere.documents.search('billing policy');
+
+  // --- rest/README.md + rest/docs/namespaces.md phone-number search ----------
+  await client.phoneNumbers.search({ areacode: '512', number_type: 'local' });
+
+  // --- rest/docs/guide.md + rest/examples/* phone-number search --------------
+  await client.phoneNumbers.search({ areacode: '512', max_results: 3 });
+
+  // --- rest/docs/calling.md + examples play (nested params:{text}) -----------
+  await client.calling.play(callId, [{ type: 'tts', params: { text: 'Welcome to SignalWire.' } }]);
+
+  process.stdout.write('doc_wire_runner: replayed documented REST fixtures against the mock\n');
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err: unknown) => {
+    process.stderr.write(
+      `doc_wire_runner: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+    );
+    process.exit(1);
+  },
+);

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -105,7 +105,13 @@ source "$PORTING_SDK_DIR/scripts/gate_scheduler.sh"
 
 cd "$PORT_ROOT"
 
+# Gate-enforcement plan (Part D): typescript's Wave-A red list is burned, so its
+# widened (wave-A) gate findings BLOCK rather than report-only. Default OFF here;
+# a caller may still set SW_WAVE_A_REPORT_ONLY=1 to inspect the report-only view.
+export SW_WAVE_A_REPORT_ONLY="${SW_WAVE_A_REPORT_ONLY:-0}"
+
 echo "==> running CI gates for $PORT_NAME (porting-sdk at $PORTING_SDK_DIR)"
+echo "==> wave-A gate findings are ${SW_WAVE_A_REPORT_ONLY:+BLOCKING (SW_WAVE_A_REPORT_ONLY=$SW_WAVE_A_REPORT_ONLY)}"
 
 # ---- gate helper functions (unchanged bodies; run as --fn gates) -------------
 
@@ -399,11 +405,40 @@ sched_gate COUNT-CLAIM desc="numeric doc claims (skills/namespaces) match realit
 sched_gate ACCESSOR-TRUTH desc="documented backtick method() refs exist in source" \
     -- python3 "$PORTING_SDK_DIR/scripts/accessor_truth.py" --port typescript --repo "$PORT_ROOT"
 
-sched_gate EXAMPLES-RUN tier=nightly defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port typescript --repo "$PORT_ROOT"
+# DOC-WIRE (§2.1) — the documented REST doc fixtures put the SPEC wire shape on the
+# wire (areacode not area_code, number_type not numberType, nested params:{text}).
+# doc_wire_runner.ts replays the documented REST calls against a strict-flag mock
+# that journals wire_violations; the gate fails on any. Cheap (per-PR).
+sched_gate DOC-WIRE desc="documented REST doc fixtures put the spec wire shape on the wire (areacode/number_type/params:{text})" \
+    -- python3 "$PORTING_SDK_DIR/scripts/doc_wire.py" --port typescript --repo "$PORT_ROOT" \
+        --runner "npx tsx $PORT_ROOT/scripts/doc_wire_runner.ts"
 
-sched_gate SNIPPET-RUN tier=nightly defer=1 desc="documented doc snippets run to a zero exit against the mock (fragments auto-skip; server/live snippets are no-run)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port typescript --repo "$PORT_ROOT"
+# STATUS-CLAIM (§2.3) — no false capability/status claims in docs (e.g. "not
+# implemented" / "transport pending" for surface that exists). Cheap (per-PR).
+sched_gate STATUS-CLAIM desc="doc status/capability claims match the shipped surface" \
+    -- python3 "$PORTING_SDK_DIR/scripts/status_claim.py" --port typescript --repo "$PORT_ROOT" \
+        --surface "$PORT_ROOT/port_surface.json"
+
+# STRICT-MOCKS: MOCK_RELAY_STRICT=1 makes the mock REJECT an off-contract wire
+# frame instead of silently tolerating it, so a doc/example that puts the wrong
+# shape on the wire fails loud. Applied to the nightly execution gates.
+sched_gate EXAMPLES-RUN tier=nightly defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md; STRICT-MOCKS: MOCK_RELAY_STRICT=1)" \
+    -- env MOCK_RELAY_STRICT=1 python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port typescript --repo "$PORT_ROOT"
+
+sched_gate SNIPPET-RUN tier=nightly defer=1 desc="documented doc snippets run to a zero exit against the mock (fragments auto-skip; server/live snippets are no-run; STRICT-MOCKS: MOCK_RELAY_STRICT=1)" \
+    -- env MOCK_RELAY_STRICT=1 python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port typescript --repo "$PORT_ROOT"
+
+# WAIT-LIVENESS (§2.4) — the RELAY Action.wait() liveness contract: wait() BLOCKS
+# until the deferred completing event arrives, then returns with the finished state
+# (never a no-op that returns at t~=0, never a hang). scripts/wait-liveness-dump.ts
+# drives the play/record corpus against a real mock_relay with the completing event
+# armed as a delay_ms scenario and prints the classification per case; the differ
+# builds the python golden and structurally compares. Nightly (spawns a dump program;
+# timing-sensitive).
+sched_gate WAIT-LIVENESS tier=nightly defer=1 desc="RELAY Action.wait() blocks-until-event liveness matches the python golden" \
+    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_wait_liveness.py" --port typescript \
+        --python-sdk "$PYTHON_SDK_DIR" \
+        --dump-cmd "SIGNALWIRE_LOG_MODE=off npx tsx $PORT_ROOT/scripts/wait-liveness-dump.ts"
 
 # ---- §G anti-laundering ledger ----------------------------------------------
 sched_gate SUPPRESSION-LEDGER res=dayone desc="no un-ledgered analyzer suppressions" \

--- a/scripts/wait-liveness-dump.ts
+++ b/scripts/wait-liveness-dump.ts
@@ -1,0 +1,172 @@
+/**
+ * wait-liveness-dump.ts — the TypeScript port's WAIT-LIVENESS dump program for the
+ * cross-port behavioral differ (porting-sdk/scripts/diff_port_wait_liveness.py).
+ *
+ * The differ runs porting-sdk/scripts/wait_liveness_corpus.py against
+ * signalwire-python to build the golden LIVENESS classification, then runs THIS
+ * program (which embeds the same corpus) and structurally compares our per-case
+ * classification. The artifact is a CLASSIFICATION (not raw ms), so the golden is
+ * deterministic while the timing that produces it is real and unfakeable:
+ *
+ *   * a wait() that is a NO-OP returns at t~=0  -> blocked_until_event=false -> RED;
+ *   * a wait() that HANGS blows the deadline    -> timed_out=true            -> RED;
+ *   * a correct wait() BLOCKS until the deferred completing event, then returns
+ *     with the finished state (the golden)      ->                          -> GREEN.
+ *
+ * Unlike wire-relay-dump (which records the send-side frame with no socket), this
+ * gate MUST exercise real liveness — so we drive the SDK against a real mock_relay
+ * and arm the completing event as a DEFERRED (delay_ms) scenario. That delivers the
+ * event through the SAME socket-read -> event-dispatch path the real server drives;
+ * a wait() that never pumps the loop cannot observe it. This is the exact mechanism
+ * tests/relay/actions_mock.test.ts#test_play_resolves_on_finished_event uses; we
+ * reuse that test harness (newRelayClient + armMethod + inboundCall) directly.
+ *
+ * Protocol: stdout = ONE JSON object mapping case_id -> classification. ONLY stdout
+ * carries JSON (the differ does JSON.parse(proc.stdout)); all logging goes to stderr.
+ *
+ * Run from the repo root (mock_relay reachable via MOCK_RELAY_PORT /
+ * MOCK_RELAY_HTTP_PORT, or auto-spawned by the harness):
+ *
+ *   SIGNALWIRE_LOG_MODE=off npx tsx scripts/wait-liveness-dump.ts
+ */
+
+import { newRelayClient, type MockRelayHarness } from '../tests/relay/mocktest.js';
+import type { RelayClient } from '../src/relay/RelayClient.js';
+import type { Call } from '../src/relay/Call.js';
+import type { Action } from '../src/relay/Action.js';
+
+// Classification tolerances — must match porting-sdk/scripts/diff_port_wait_liveness.py.
+const DEADLINE_S = 5.0;
+const BLOCK_TOL_MS = 40;
+// The deferred-event delay — must match wait_liveness_corpus.DELAY_MS.
+const DELAY_MS = 150;
+const CID = 'ctl-live-1';
+
+interface Classification {
+  blocked_until_event: boolean;
+  returned_after_event: boolean;
+  completed_state: string;
+  timed_out: boolean;
+}
+
+interface Case {
+  id: string;
+  verb: 'play' | 'record';
+  method: string; // the RELAY method whose scenario carries the terminal event
+}
+
+// The corpus, mirroring porting-sdk/scripts/wait_liveness_corpus.py CORPUS. Two
+// distinct action types (play, record) so a port can't hardcode one surface.
+const CORPUS: Case[] = [
+  { id: 'live_play_wait', verb: 'play', method: 'calling.play' },
+  { id: 'live_record_wait', verb: 'record', method: 'calling.record' },
+];
+
+/** Derive the deterministic liveness classification (mirrors classify_liveness). */
+function classify(
+  tWaitStart: number,
+  tReturn: number | null,
+  completedState: string,
+  timedOut: boolean,
+): Classification {
+  if (timedOut || tReturn === null) {
+    return {
+      blocked_until_event: false,
+      returned_after_event: false,
+      completed_state: '',
+      timed_out: true,
+    };
+  }
+  const elapsedMs = tReturn - tWaitStart;
+  const blocked = elapsedMs >= DELAY_MS - BLOCK_TOL_MS;
+  return {
+    blocked_until_event: blocked,
+    returned_after_event: true,
+    completed_state: completedState,
+    timed_out: false,
+  };
+}
+
+/** Answer an inbound call we can issue actions on (mirrors the actions_mock helper). */
+async function answeredInboundCall(
+  client: RelayClient,
+  mock: MockRelayHarness,
+  callId: string,
+): Promise<Call> {
+  const captured: { call?: Call } = {};
+  const handlerReturned = new Promise<void>((resolve) => {
+    client.onCall(async (call) => {
+      captured.call = call;
+      await call.answer();
+      resolve();
+    });
+  });
+  await mock.inboundCall({ call_id: callId, auto_states: ['created'] });
+  await Promise.race([
+    handlerReturned,
+    new Promise((_, reject) => setTimeout(() => reject(new Error('handler timeout')), 5000)),
+  ]);
+  const call = captured.call!;
+  call.state = 'answered';
+  return call;
+}
+
+/** Start the Action-returning verb for a case against an answered call. */
+async function startAction(call: Call, verb: Case['verb']): Promise<Action> {
+  if (verb === 'play') {
+    return call.play([{ type: 'silence', params: { duration: 1 } }], { controlId: CID });
+  }
+  return call.record({ format: 'mp3' }, { controlId: CID });
+}
+
+/** Drive ONE liveness case against the real mock and return its classification. */
+async function runCase(c: Case): Promise<Classification> {
+  const { client, mock } = await newRelayClient();
+  try {
+    await mock.resetScenarios();
+    const call = await answeredInboundCall(client, mock, `call-${c.id}`);
+
+    // Arm the completing event as a DEFERRED (delay_ms) scenario: it arrives
+    // DELAY_MS after the verb RPC, through the real socket-read path.
+    await mock.armMethod(c.method, [{ emit: { state: 'finished' }, delay_ms: DELAY_MS }]);
+
+    const action = await startAction(call, c.verb);
+
+    const tWaitStart = performance.now();
+    try {
+      const event = await action.wait(DEADLINE_S);
+      const tReturn = performance.now();
+      const state = String(event.params?.['state'] ?? '');
+      return classify(tWaitStart, tReturn, state, false);
+    } catch {
+      // wait() rejected (timeout) => hung.
+      return classify(tWaitStart, null, '', true);
+    }
+  } finally {
+    try {
+      await client.disconnect();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+async function main(): Promise<number> {
+  const out: Record<string, Classification> = {};
+  for (const c of CORPUS) {
+    out[c.id] = await runCase(c);
+  }
+  process.stdout.write(JSON.stringify(out));
+  process.stdout.write('\n');
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err: unknown) => {
+    process.stderr.write(
+      `wait-liveness-dump: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+    );
+    process.exit(1);
+  },
+);

--- a/src/rest/base/CrudResource.ts
+++ b/src/rest/base/CrudResource.ts
@@ -3,16 +3,21 @@
  */
 
 import type { HttpClient } from '../HttpClient.js';
-import type { QueryParams } from '../types.js';
-import { BaseResource } from './BaseResource.js';
+import { ReadResource } from './ReadResource.js';
 
 /**
  * Generic CRUD resource with configurable update method.
  *
- * Provides `list()`, `create()`, `get()`, `update()`, and `delete()` out of the
- * box — most namespace resources extend this and narrow the generic types.
- * `_updateMethod` may be overridden to `'PUT'` for APIs that replace instead
- * of patch.
+ * Provides `list()`, `paginate()`, `get()`, `create()`, `update()`, and
+ * `delete()` out of the box — most namespace resources extend this and narrow
+ * the generic types. `_updateMethod` may be overridden to `'PUT'` for APIs that
+ * replace instead of patch.
+ *
+ * Extends {@link ReadResource} (mirroring Python's `CrudResource(ReadResource)`)
+ * so every CRUD resource inherits the `list()`/`get()`/`paginate()` read surface
+ * — in particular the async-iterator `paginate()`. A prior version extended
+ * `BaseResource` directly and re-declared `list()`/`get()`, which silently left
+ * `paginate()` OFF every CRUD resource (a real runtime gap the hierarchy now closes).
  *
  * @typeParam TList - Type of the paginated list response.
  * @typeParam TItem - Type of a single resource item.
@@ -24,23 +29,12 @@ export class CrudResource<
   TItem = unknown,
   TCreate = unknown,
   TUpdate = unknown,
-> extends BaseResource {
+> extends ReadResource<TList, TItem> {
   /** Override to 'PUT' for resources that use PUT instead of PATCH. */
   protected _updateMethod: 'PATCH' | 'PUT' = 'PATCH';
 
   constructor(http: HttpClient, basePath: string) {
     super(http, basePath);
-  }
-
-  /**
-   * List resources with optional query parameters.
-   *
-   * @param params - Optional filter / pagination query parameters.
-   * @returns The paginated list response.
-   * @throws {RestError} On any non-2xx HTTP response.
-   */
-  async list(params?: QueryParams): Promise<TList> {
-    return this._http.get<TList>(this._basePath, params);
   }
 
   /**
@@ -52,17 +46,6 @@ export class CrudResource<
    */
   async create(body: TCreate): Promise<TItem> {
     return this._http.post<TItem>(this._basePath, body);
-  }
-
-  /**
-   * Fetch a single resource by ID.
-   *
-   * @param resourceId - Unique identifier of the resource.
-   * @returns The resource record.
-   * @throws {RestError} On any non-2xx HTTP response (including `404`).
-   */
-  async get(resourceId: string): Promise<TItem> {
-    return this._http.get<TItem>(this._path(resourceId));
   }
 
   /**

--- a/tests/rest/paginate_inheritance.test.ts
+++ b/tests/rest/paginate_inheritance.test.ts
@@ -1,0 +1,103 @@
+/**
+ * paginate_inheritance.test.ts — runtime guard against the hierarchy blind spot.
+ *
+ * The surface enumerator records only *declared* methods per class and reconciles
+ * inherited members against the Python oracle, so a wrong `extends` on a shared
+ * base can leave a runtime method (like `paginate()`) OFF every subclass without
+ * SURFACE-DIFF / DRIFT noticing — exactly what happened when `CrudResource`
+ * extended `BaseResource` instead of `ReadResource`, silently dropping `paginate()`
+ * from every CRUD resource.
+ *
+ * This test closes that blind spot at the level it actually manifests — the live
+ * prototype chain. It constructs a real RestClient, walks every resource object
+ * mounted on the client tree, and asserts the shared-base invariants:
+ *
+ *   * every `ReadResource` instance exposes `list()`, `get()`, and `paginate()`;
+ *   * every `CrudResource` instance IS a `ReadResource` (so inherits `paginate()`)
+ *     and also exposes `create()`, `update()`, and `delete()`.
+ *
+ * (Resources that extend `BaseResource` directly with a bespoke `list()` and no
+ * paginator — e.g. `Recordings`, `VideoRoomRecordings`, `ConferenceLogs` — mirror
+ * the Python reference, which also lists them without a paginator; they are
+ * correctly NOT in scope here.)
+ *
+ * A future `extends` regression on any REST base fails HERE, on the object, not
+ * a day later against a diff of declared method names.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { RestClient } from '../../src/rest/index.js';
+import { CrudResource } from '../../src/rest/base/CrudResource.js';
+import { ReadResource } from '../../src/rest/base/ReadResource.js';
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+/** Collect every resource object reachable from the client tree (namespaces + flat). */
+function collectResources(client: RestClient): { name: string; res: object }[] {
+  const found: { name: string; res: object }[] = [];
+  const seen = new Set<object>();
+  const c = client as unknown as Record<string, unknown>;
+  const consider = (name: string, v: unknown): void => {
+    if (isObject(v) && !seen.has(v)) {
+      seen.add(v);
+      found.push({ name, res: v });
+    }
+  };
+  for (const key of Object.keys(c)) {
+    const top = c[key];
+    consider(key, top);
+    if (isObject(top)) {
+      for (const subKey of Object.keys(top)) {
+        consider(`${key}.${subKey}`, top[subKey]);
+      }
+    }
+  }
+  return found;
+}
+
+const hasFn = (o: object, m: string): boolean =>
+  typeof (o as Record<string, unknown>)[m] === 'function';
+
+describe('REST resource hierarchy (runtime paginate guard)', () => {
+  const client = new RestClient({ project: 'p', token: 't', host: 'example.signalwire.com' });
+  const resources = collectResources(client);
+
+  const readResources = resources.filter((r) => r.res instanceof ReadResource);
+  const crudResources = resources.filter((r) => r.res instanceof CrudResource);
+
+  it('discovers ReadResource and CrudResource instances (guard against vacuity)', () => {
+    expect(readResources.length).toBeGreaterThan(10);
+    expect(crudResources.length).toBeGreaterThan(5);
+  });
+
+  it('every ReadResource instance exposes list/get/paginate', () => {
+    const broken = readResources
+      .filter((r) => !hasFn(r.res, 'list') || !hasFn(r.res, 'get') || !hasFn(r.res, 'paginate'))
+      .map((r) => r.name);
+    expect(broken, `ReadResource instances missing a read method: ${broken.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('every CrudResource instance is a ReadResource and exposes create/update/delete + paginate', () => {
+    const brokenChain = crudResources
+      .filter((r) => !(r.res instanceof ReadResource))
+      .map((r) => r.name);
+    expect(
+      brokenChain,
+      `CrudResource not extending ReadResource: ${brokenChain.join(', ')}`,
+    ).toEqual([]);
+    const missing = crudResources
+      .filter(
+        (r) =>
+          !hasFn(r.res, 'create') ||
+          !hasFn(r.res, 'update') ||
+          !hasFn(r.res, 'delete') ||
+          !hasFn(r.res, 'paginate'),
+      )
+      .map((r) => r.name);
+    expect(missing, `CrudResource instances missing a method: ${missing.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
TypeScript's single PR for the gate-enforcement plan: burns the Wave-A red list, fixes a real REST runtime gap, wires the enforcement quartet at the right tiers, and flips wave-A findings to blocking (`SW_WAVE_A_REPORT_ONLY=0`). ts ends fully-enforced and clean.

## Part A — Wave-A red-list burn (real fixes, no mass-allowlisting)

**DOC-AUDIT** (8 widened-perimeter findings): fixed 2 docs to TS reality, ledgered 4 genuinely-external refs.
- README webhook comment no longer names Python-only `RestClient.validateRequest*` methods; `PORT_BEHAVIORAL_NOTES` `to_dict` → `toDict` (the real TS surface).
- `DOC_AUDIT_IGNORE.md`: `Date` (JS builtin), `randomUUID` (Web Crypto), `object` (Zod), `dispatchEvent` (internal sketch), `contains` (prose pseudo-code).

**COUNT-CLAIM**: the ts `skill_glob` in porting-sdk was a **dir** glob for a **file**-per-skill layout, so the skill count vacuously skipped (`0 found`). Fixed the glob (now counts 19) and reconciled every claim:
- `CLAUDE.md` / `skills-guide.md` / `sdk_features.md`: 17 → **19** (17 Python-parity + 2 TS-specific).
- `CHECKLIST.md`: qualified as "17 **Python-parity** skills".
- Fabric count `17` → **16 / 13** to the real namespace-accessor count.

**DOC-WIRE**: `area_code` → `areacode` (6 sites incl the README-INCLUDE fixture), `numberType` → `number_type` — to the spec wire shape. Added `scripts/doc_wire_runner.ts`.

**STATUS-CLAIM / deps**: `rest/README` "Zero dependencies … Node 18+" was false (5 runtime deps, engines ≥22) — corrected.

**Plain-HTTP allowlist** (`SNIPPET_RUN_ALLOW.md`): the rationale "the SDK has no plain-HTTP mock override" was **FALSE** — `RestClient` preserves an `http://` host verbatim (`src/rest/index.ts`), and both the rest tests and the new DOC-WIRE runner reach the loopback mock that way. Corrected the rationale to the real blocker: placeholder credentials + a non-mock host in an include-synced construction snippet.

## Part B — `paginate()` runtime gap (ts-specific)

`CrudResource extends BaseResource`, so **no CRUD resource inherited `paginate()`** — a real runtime gap. Now `CrudResource extends ReadResource` (mirrors Python's `CrudResource(ReadResource)`); removed the redundant `get`/`list` overrides. Declared surface now matches the python oracle exactly (`CrudResource=[create,delete,update]`, `ReadResource=[get,list,paginate]`).

**Oracle blind-spot fix**: the surface enumerator records only *declared* methods, so a wrong `extends` could hide a runtime method loss. Added `tests/rest/paginate_inheritance.test.ts` — an `instanceof`-based runtime guard that fails on the live prototype chain if any `CrudResource` stops inheriting the read surface (teeth-verified against the buggy hierarchy).

## Part C — quartet wired at the right tier

- **DOC-WIRE** + **STATUS-CLAIM** — per-PR.
- **WAIT-LIVENESS** — nightly; added `scripts/wait-liveness-dump.ts` (drives play/record `wait()` against `mock_relay` with a deferred completing event; classification matches the python golden).
- **STRICT-MOCKS** — `MOCK_RELAY_STRICT=1` on the nightly EXAMPLES-RUN + SNIPPET-RUN.
- **GATE-INVENTORY** deliberately **NOT** wired (porting-sdk-only; needs a sibling TS checkout absent in port CI).

## Part D — blocking

- `SW_WAVE_A_REPORT_ONLY=0` in `run-ci.sh`.
- **SEMVER-DIFF**: the paginate refactor moved `CrudResource.get`/`list` to the inherited parent (instance surface a strict superset — gained `paginate`), which SEMVER classifies as a removal. Excused in `SEMVER_DIFF_ALLOW.md` as a provable non-breaking change — **⚠ PENDING SIGN-OFF** (the one human-approval item).
- Re-anchored `port_signatures.baseline.json` to commit `80381af` (content byte-identical) so the wave-A baseline-anchor finding clears under blocking.

## ⚠ Cross-repo dependency

The COUNT-CLAIM `skill_glob` fix lives in **porting-sdk** (`scripts/count_claim.py`) and must land on porting-sdk `main` for ts CI to pass.

## Verification

Full `PORTING_SDK=… SW_CI_TIER=nightly bash scripts/run-ci.sh` — every gate GREEN and BLOCKING, incl. DOC-WIRE, STATUS-CLAIM, WAIT-LIVENESS, STRICT-MOCKS (EXAMPLES-RUN/SNIPPET-RUN), COUNT-CLAIM, PAGINATION-WIRED, SEMVER-DIFF, TEST/LINT/FMT/REST-COVERAGE/PACKAGE-SMOKE. Prettier 3.9.5 (repo-pinned via `npm ci`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
