### PR TITLE
Fix RELAY device/collect/dial wire types to match the protocol schema (#19535)

### DIFF
--- a/scripts/wire-relay-dump.ts
+++ b/scripts/wire-relay-dump.ts
@@ -249,7 +249,8 @@ async function main(): Promise<void> {
     const dialPromise = client
       .dial([[{ type: 'phone', params: { to_number: '+15551112222' } }]] as any, {
         tag: 'dial-1',
-        maxDuration: 600,
+        region: 'us',
+        maxPricePerMinute: 0.05,
         dialTimeout: 2,
       })
       .catch(() => undefined);

--- a/src/relay/Call.ts
+++ b/src/relay/Call.ts
@@ -39,6 +39,7 @@ import type {
   DeviceInput,
   EventHandler,
   PlayItem,
+  ReferDevice,
 } from './types.js';
 // Canonical RELAY wire param shapes (generated from porting-sdk/relay-protocol/
 // *.params.json — the switchblade source). Method params index into these so
@@ -53,6 +54,7 @@ import type {
   CallingAnswerResult,
   CallingBindDigitResult,
   CallingClearDigitBindingsResult,
+  CallingCollectParams,
   CallingConnectParams,
   CallingConnectResult,
   CallingDenoiseResult,
@@ -82,7 +84,6 @@ import type {
 // same wire command, fully specified. (connect's params are relay-only — see
 // CallingConnectParams above for ringback.)
 import type {
-  CallCollectRequest,
   CallDetectRequest,
   CallRecordRequest,
   CallTapRequest,
@@ -824,8 +825,8 @@ export class Call {
    */
   async collect(
     options: {
-      digits?: CallCollectRequest['params']['digits'];
-      speech?: CallCollectRequest['params']['speech'];
+      digits?: CallingCollectParams['digits'];
+      speech?: CallingCollectParams['speech'];
       initialTimeout?: number;
       partialResults?: boolean;
       continuous?: boolean;
@@ -1056,17 +1057,22 @@ export class Call {
   /**
    * Transfer a SIP call via REFER.
    *
-   * @param device - Platform-shaped SIP target device descriptor.
+   * @param device - SIP target device descriptor. `to` is required by the wire
+   *   (`CallingReferParams.device.params.to`); `headers` is a name→value map.
    * @param options - Optional REFER behaviour.
    * @param options.statusUrl - Webhook URL for REFER status events.
    * @returns The platform's refer response.
    * @throws {RelayError} When the refer command is rejected.
    */
   async refer(
-    device: DeviceInput,
+    device: ReferDevice,
     options: { statusUrl?: string } = {},
   ): Promise<CallingReferResult> {
-    const params: Record<string, unknown> = { device: normalizeDevice(device) };
+    // ReferDevice is a closed shape (no index signature), so widen it to the
+    // normalizer's open record type at this boundary.
+    const params: Record<string, unknown> = {
+      device: normalizeDevice(device as unknown as Record<string, unknown>),
+    };
     if (options.statusUrl != null) params.status_url = options.statusUrl;
     return this._execute<CallingReferResult>('refer', params);
   }

--- a/src/relay/RelayClient.ts
+++ b/src/relay/RelayClient.ts
@@ -47,11 +47,11 @@ import { RelayError } from './RelayError.js';
 import type { CallState, MessageState } from './closedSets.js';
 import type {
   CallHandler,
-  CompletedCallback,
   Device,
   JsonRpcError,
   MessageHandler,
   RelayClientOptions,
+  SendMessageOptions,
 } from './types.js';
 
 /** Raw RELAY wire payload — an open JSON-RPC frame or `signalwire.event` dict. */
@@ -584,7 +584,10 @@ export class RelayClient {
    * @param options - Optional dial behaviour overrides.
    * @param options.tag - Client-provided tag for event correlation.
    *   Auto-generated (UUID) when omitted.
-   * @param options.maxDuration - Maximum call duration in minutes.
+   * @param options.region - Origination region override
+   *   (`CallingDialParams.region`).
+   * @param options.maxPricePerMinute - Price cap per minute
+   *   (`CallingDialParams.max_price_per_minute`).
    * @param options.dialTimeout - Seconds to wait for the dial to complete.
    *   Defaults to `120`.
    * @returns A {@link Call} representing the answered leg.
@@ -595,7 +598,8 @@ export class RelayClient {
     devices: Record<string, unknown>[][],
     options: {
       tag?: string;
-      maxDuration?: number;
+      region?: string;
+      maxPricePerMinute?: number;
       /** Dial timeout in seconds (default 120). */
       dialTimeout?: number;
     } = {},
@@ -605,7 +609,10 @@ export class RelayClient {
       tag: dialTag,
       devices: normalizeDevicePlan(devices),
     };
-    if (options.maxDuration != null) params.max_duration = options.maxDuration;
+    // `calling.dial` has no max_duration on the wire (unlike `connect`); the real
+    // optional knobs are region + max_price_per_minute (CallingDialParams).
+    if (options.region != null) params.region = options.region;
+    if (options.maxPricePerMinute != null) params.max_price_per_minute = options.maxPricePerMinute;
 
     // Register a deferred that _handleEvent will resolve
     const dialDeferred = createDeferred<Call>();
@@ -666,16 +673,7 @@ export class RelayClient {
    * @returns A {@link Message} tracking the outbound send.
    * @throws {RelayError} When the server rejects the send request.
    */
-  async sendMessage(options: {
-    toNumber: string;
-    fromNumber: string;
-    context?: string;
-    body?: string;
-    media?: string[];
-    tags?: string[];
-    region?: string;
-    onCompleted?: CompletedCallback;
-  }): Promise<Message> {
+  async sendMessage(options: SendMessageOptions): Promise<Message> {
     if (!options.body && (!options.media || options.media.length === 0)) {
       throw new Error('At least one of body or media is required');
     }

--- a/src/relay/types.ts
+++ b/src/relay/types.ts
@@ -76,7 +76,11 @@ export interface PhoneDevice {
   timeout?: number;
   max_duration?: number;
   codecs?: string[];
-  headers?: Record<string, string>[];
+  /**
+   * SIP headers as a name→value map. The RELAY wire models device headers as a
+   * map object (`CallingReferParams.device.params.headers`), not an array.
+   */
+  headers?: Record<string, string>;
 }
 
 /** SIP device specification for dial/connect. */
@@ -87,7 +91,11 @@ export interface SipDevice {
   timeout?: number;
   max_duration?: number;
   codecs?: string[];
-  headers?: Record<string, string>[];
+  /**
+   * SIP headers as a name→value map. The RELAY wire models device headers as a
+   * map object (`CallingReferParams.device.params.headers`), not an array.
+   */
+  headers?: Record<string, string>;
 }
 
 /** Any device specification. */
@@ -117,6 +125,10 @@ export interface SendMessageOptions {
   context?: string;
   /** Tags for the message. */
   tags?: string[];
+  /** Origination region override (`MessagingSendParams.region`). */
+  region?: string;
+  /** Callback fired when the message reaches a terminal state. */
+  onCompleted?: CompletedCallback;
 }
 
 /**
@@ -150,6 +162,21 @@ export type CollectConfig = Omit<CallingCollectParams, 'node_id' | 'call_id' | '
  * accepted-input type is an object with a `type` plus arbitrary other fields.
  */
 export type DeviceInput = { type: string } & Record<string, unknown>;
+
+/**
+ * The typed device descriptor accepted by `refer()`. Unlike the open
+ * {@link DeviceInput}, the RELAY REFER wire (`CallingReferParams.device.params`)
+ * REQUIRES `to`; `headers` is a name→value map. {@link normalizeDevice} folds
+ * this flat shape into `{ type, params: { to, headers } }` before sending.
+ */
+export interface ReferDevice {
+  /** Device type (typically `'sip'`). */
+  type: string;
+  /** Transfer target — required by the wire (`device.params.to`). */
+  to: string;
+  /** Optional SIP headers as a name→value map. */
+  headers?: Record<string, string>;
+}
 
 /** Queued request waiting for reconnection. */
 export interface QueuedRequest {

--- a/tests/relay/outbound_call_mock.test.ts
+++ b/tests/relay/outbound_call_mock.test.ts
@@ -86,7 +86,7 @@ describe('Dial — happy path', () => {
     expect(p!.devices![0]![0]!.type).toBe('phone');
   });
 
-  it('test_dial_with_max_duration_in_frame', async () => {
+  it('test_dial_with_region_and_max_price_in_frame', async () => {
     await mock.armDial({
       tag: 't-md',
       winner_call_id: 'winner-md',
@@ -94,9 +94,18 @@ describe('Dial — happy path', () => {
       node_id: 'node-mock-1',
       device: phoneDevice(),
     });
-    await client.dial([[phoneDevice()]], { tag: 't-md', maxDuration: 300, dialTimeout: 5.0 });
+    // calling.dial has no max_duration on the wire (CallingDialParams); the real
+    // optional knobs are region + max_price_per_minute.
+    await client.dial([[phoneDevice()]], {
+      tag: 't-md',
+      region: 'us',
+      maxPricePerMinute: 0.05,
+      dialTimeout: 5.0,
+    });
     const [entry] = await mock.journalRecv('calling.dial');
-    expect(entry!.frame.params!.max_duration).toBe(300);
+    expect(entry!.frame.params!.region).toBe('us');
+    expect(entry!.frame.params!.max_price_per_minute).toBe(0.05);
+    expect(entry!.frame.params!.max_duration).toBeUndefined();
   });
 
   it('test_dial_auto_generates_uuid_tag_when_omitted', async () => {


### PR DESCRIPTION
## Description
Several hand-written RELAY wire-facing types and method params diverged from the generated protocol types (`Calling*Params` in `protocol.types.generated.ts`, the source of truth for the JSON-RPC wire), so type-checking code could put an invalid payload on the wire. Each fix sources the hand-written type from the corresponding `Calling*Params` shape.

**Fixes:**
- `PhoneDevice`/`SipDevice.headers`: `Record<string, string>[]` → `Record<string, string>` — the only protocol type modelling device headers (`CallingReferParams.device.params.headers`) is a **map**, not an array of single-key objects. `normalizeDevice` passes `headers` through verbatim, so the array shape put a JSON array on the wire where SIP headers must be a map.
- `refer(device)`: `DeviceInput` → typed `ReferDevice` (`{ type; to; headers? }`) — `CallingReferParams.device.params` **requires `to`**; the open `DeviceInput` let the SDK send `params: {}` (server-rejected).
- `collect()` `speech`/`digits`: sourced from `CallingCollectParams` (the RELAY collect schema) instead of the REST-derived `CallCollectRequest` — exposes `speech.model` (not the REST-only `speech.engine`, absent from the collect schema) and the **required** `digits.max`. `playAndCollect` (`CollectConfig`) was already correct; the two entrypoints now agree.
- `dial()`: no longer sends `max_duration` (absent from `CallingDialParams` — it only survived via the index signature) and now exposes the real optional knobs **`region`** + **`maxPricePerMinute`** (`max_price_per_minute`). `connect()` keeps `max_duration`, which `CallingConnectParams` does define.
- `sendMessage()`: now consumes the exported `SendMessageOptions` (previously dead — the method re-declared an inline options object), and `SendMessageOptions` gains the missing **`region`** field (present on the wire / `MessagingSendParams`).

Also updates the relay wire-dump oracle input (`scripts/wire-relay-dump.ts`) and the dial mock test to the corrected `dial` knobs.

Out of scope: lifecycle-state unions (`CallState`/`DialState`/`MessageState`) — `protocol.types.generated.ts` models only method `params`/`result` (no state enums), so they can't be diffed against it (noted in #19535).

## Type of Change
- [x] Bug fix (wire-shape mismatch) — includes breaking type changes to `PhoneDevice`/`SipDevice.headers`, `refer()`, `dial()` options, and `SendMessageOptions`

## Related Issues
Closes #19535
Relates to #19366

## Testing
- [x] `tsc` clean on all three projects (`src`, `tsconfig.test.json`, `tsconfig.examples.json`); `eslint src tests` clean; prettier clean
- [x] Non-mock relay unit tests pass (144: `normalize`, `Call`, `RelayClient`, `Action`)
- [x] Runtime proof: `normalizeDevice({ type:'sip', to, headers:{…} })` → `{ type:'sip', params:{ to, headers:{…} } }` (headers a map, `to` present)
- [x] Compile-time proof: `@ts-expect-error` smoke confirms array-headers and a `to`-less refer device are now rejected
- [ ] Mock-backed relay tests (`tests/relay/*_mock`) + parity gates (BEHAVIORAL-WIRE-RELAY, DRIFT, SEMVER-DIFF) need CI with porting-sdk — see notes

## Additional Notes
- The wire change for `dial` (drops `max_duration`) and the signature changes touch the RELAY wire dumped by `BEHAVIORAL-WIRE-RELAY`; if the Python reference sends the same shapes it may need the coupled fix (the issue flags `hagrid/relay` as also affected). To be validated when the parity gates run with porting-sdk + the python oracle.
- These changes alter public method signatures / exported types, so `port_signatures.json` and the version bump (`SEMVER-DIFF`) should be regenerated in CI (porting-sdk not available locally). Breaking type changes — a **major**-appropriate bump.