### PR TITLE
docs: document SIGNALWIRE_RELAY_HOST + SIGNALWIRE_RELAY_SCHEME env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ Guides are also available in the [`docs/`](docs/) directory:
 | `SIGNALWIRE_PROJECT_ID` | RELAY, REST | Project identifier |
 | `SIGNALWIRE_API_TOKEN` | RELAY, REST | API token |
 | `SIGNALWIRE_SPACE` | RELAY, REST | Space hostname (e.g. `example.signalwire.com`) |
+| `SIGNALWIRE_RELAY_HOST` | RELAY | Override the RELAY WebSocket host (advanced/testing). Precedence: `host` option > `SIGNALWIRE_RELAY_HOST` > `SIGNALWIRE_SPACE` > built-in default. |
+| `SIGNALWIRE_RELAY_SCHEME` | RELAY | Override the RELAY WebSocket scheme (`ws`/`wss`; default `wss`). Precedence: `scheme` option > `SIGNALWIRE_RELAY_SCHEME` > `wss`; any value other than `ws`/`wss` falls back to `wss`. |
 | `SWML_BASIC_AUTH_USER` | Agents | Basic auth username (default: auto-generated) |
 | `SWML_BASIC_AUTH_PASSWORD` | Agents | Basic auth password (default: auto-generated) |
 | `SWML_PROXY_URL_BASE` | Agents | Base URL when behind a reverse proxy |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,15 @@ The SDK reads the following environment variables at startup. All are optional.
 |---|---|---|---|
 | `PORT` | `number` | `3000` | HTTP server port. Overridden by the constructor `port` option. |
 
+### RELAY Connection
+
+Read by the `RelayClient` constructor. Credentials (`SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_API_TOKEN`, `SIGNALWIRE_JWT_TOKEN`, `SIGNALWIRE_SPACE`) fall back to these env vars when the corresponding constructor option is omitted; the two below override the RELAY WebSocket endpoint itself.
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `SIGNALWIRE_RELAY_HOST` | `string` | -- | Override the RELAY WebSocket host (advanced/testing). Precedence: `host` option > `SIGNALWIRE_RELAY_HOST` > `SIGNALWIRE_SPACE` > built-in default. |
+| `SIGNALWIRE_RELAY_SCHEME` | `"ws" \| "wss"` | `"wss"` | Override the RELAY WebSocket scheme (`ws`/`wss`; default `wss`). Precedence: `scheme` option > `SIGNALWIRE_RELAY_SCHEME` > `wss`; any value other than `ws`/`wss` falls back to `wss`. |
+
 ### Authentication
 
 | Variable | Type | Default | Description |


### PR DESCRIPTION
## What

Document the two RELAY WebSocket-endpoint override env vars that the
production `RelayClient` constructor reads but no tracked markdown described:

| Var | Source | Effect |
|---|---|---|
| `SIGNALWIRE_RELAY_HOST` | `src/relay/RelayClient.ts:215` | Override the RELAY WebSocket host (advanced/testing). Precedence: `host` option > `SIGNALWIRE_RELAY_HOST` > `SIGNALWIRE_SPACE` > built-in default. |
| `SIGNALWIRE_RELAY_SCHEME` | `src/relay/RelayClient.ts:220` | Override the RELAY WebSocket scheme (`ws`/`wss`; default `wss`). Precedence: `scheme` option > `SIGNALWIRE_RELAY_SCHEME` > `wss`; any other value falls back to `wss`. |

## Why

Both are real, shipping SDK knobs read in the production constructor. The
porting-sdk DOC-ENV gate — after its dotted-`process.env.X` regex bug was
fixed — correctly surfaces them as undocumented "hidden env knobs". DOC-ENV
is blocking in the ts run-ci. The right fix is to **document** them (make the
docs truthful), not to allowlist them.

## Where

- `README.md` — added to the Environment Variables table, alongside the
  existing `SIGNALWIRE_*` RELAY vars.
- `docs/configuration.md` — new **RELAY Connection** subsection under
  Environment Variables (previously this file documented no RELAY connection
  vars at all).

Precedence documented verbatim from the constructor source, not memory.

## Verification

- `doc_env.py --port typescript` against the widened + dotted-read-fixed
  perimeter: **2 findings → 0**.
- Full `scripts/run-ci.sh pr` tier: **all gates PASS** (DOC-ENV, FMT, LINT,
  TEST, REST-COVERAGE, PACKAGE-SMOKE, …).

Docs-only diff (README +2, configuration.md +9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
