### PR TITLE
fix(env): rename datasphere token env var to SIGNALWIRE_API_TOKEN (plan 4.4)

### DIFF
--- a/EXAMPLES_RUN_ALLOW.md
+++ b/EXAMPLES_RUN_ALLOW.md
@@ -11,7 +11,7 @@ Format: `- <path> — <reason>` (date).
 ## Skill examples requiring real provider credentials / config
 
 - examples/datasphere.ts — DataSphereSkill.setup() fails-loud on missing required params (space_name, project_id, token, document_id); needs a real SignalWire DataSphere knowledge base (2026-07-09).
-- examples/datasphere-serverless-env.ts — requires SIGNALWIRE_SPACE, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN, DATASPHERE_DOCUMENT_ID env vars for a real DataSphere document (2026-07-09).
+- examples/datasphere-serverless-env.ts — requires SIGNALWIRE_SPACE, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_API_TOKEN, DATASPHERE_DOCUMENT_ID env vars for a real DataSphere document (2026-07-09).
 - examples/datasphere-webhook-env.ts — same real-DataSphere env-var requirement as datasphere-serverless-env.ts (2026-07-09).
 - examples/web-search.ts — WebSearchSkill requires GOOGLE_SEARCH_API_KEY + GOOGLE_SEARCH_ENGINE_ID (real Google Programmable Search creds) (2026-07-09).
 - examples/web-search-multi-instance.ts — same `GOOGLE_SEARCH_*` real-creds requirement as web-search.ts (2026-07-09).

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -254,8 +254,8 @@ These skills involve complex integrations, multiple API calls, or advanced proce
 | `web_search` | `WebSearchSkill` | Google Custom Search | `web_search` | `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID` | `num_results`, `tool_name`, `no_results_message`, `safe_search`, `delay`, `max_content_length`, `oversample_factor`, `min_quality_score` |
 | `wikipedia_search` | `WikipediaSearchSkill` | Wikipedia article summaries | `search_wiki` | None | `num_results`, `no_results_message`, `language`, `max_content_length` |
 | `google_maps` | `GoogleMapsSkill` | Address geocoding + coordinate routing | `lookup_address`, `compute_route` | `GOOGLE_MAPS_API_KEY` | `lookup_tool_name`, `route_tool_name` |
-| `datasphere` | `DataSphereSkill` | SignalWire DataSphere semantic search | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `count`, `distance`, `document_id`, `tags`, `language`, `pos_to_expand`, `max_synonyms`, `no_results_message` |
-| `datasphere_serverless` | `DataSphereServerlessSkill` | DataSphere via server-side DataMap | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE` | `count`, `distance`, `document_id`, `tags`, `language`, `pos_to_expand`, `max_synonyms`, `no_results_message` |
+| `datasphere` | `DataSphereSkill` | SignalWire DataSphere semantic search | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_API_TOKEN`, `SIGNALWIRE_SPACE` | `count`, `distance`, `document_id`, `tags`, `language`, `pos_to_expand`, `max_synonyms`, `no_results_message` |
+| `datasphere_serverless` | `DataSphereServerlessSkill` | DataSphere via server-side DataMap | `search_datasphere` | `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_API_TOKEN`, `SIGNALWIRE_SPACE` | `count`, `distance`, `document_id`, `tags`, `language`, `pos_to_expand`, `max_synonyms`, `no_results_message` |
 | `native_vector_search` | `NativeVectorSearchSkill` | In-memory TF-IDF document search | `search_documents` | None | `documents` |
 | `spider` | `SpiderSkill` | Web page scraping via Spider API | `scrape_url` | `SPIDER_API_KEY` | `max_content_length` |
 | `claude_skills` | `ClaudeSkillsSkill` | Load Claude SKILL.md files as tools | (dynamic) | None | `skills_path`, `include`, `exclude`, `tool_prefix` |
@@ -879,7 +879,7 @@ This two-layer approach (warn at registration, error at call time) allows agents
 | `GOOGLE_SEARCH_ENGINE_ID` | `web_search` |
 | `GOOGLE_MAPS_API_KEY` | `google_maps` |
 | `SIGNALWIRE_PROJECT_ID` | `datasphere`, `datasphere_serverless` |
-| `SIGNALWIRE_TOKEN` | `datasphere`, `datasphere_serverless` |
+| `SIGNALWIRE_API_TOKEN` | `datasphere`, `datasphere_serverless` |
 | `SIGNALWIRE_SPACE` | `datasphere`, `datasphere_serverless` |
 | `SPIDER_API_KEY` | `spider` |
 | `ANTHROPIC_API_KEY` | `ask_claude` |

--- a/examples/datasphere-serverless-env.ts
+++ b/examples/datasphere-serverless-env.ts
@@ -5,7 +5,7 @@
  * variables, showing best practices for production deployment.
  *
  * Required env vars:
- *   SIGNALWIRE_SPACE, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN,
+ *   SIGNALWIRE_SPACE, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_API_TOKEN,
  *   DATASPHERE_DOCUMENT_ID
  *
  * Optional env vars:
@@ -21,7 +21,7 @@ function requireEnv(name: string): string {
   if (!value) {
     console.error(`Error: Required environment variable ${name} is not set.`);
     console.error(
-      'Required: SIGNALWIRE_SPACE, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN, DATASPHERE_DOCUMENT_ID',
+      'Required: SIGNALWIRE_SPACE, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_API_TOKEN, DATASPHERE_DOCUMENT_ID',
     );
     process.exit(1);
   }

--- a/examples/datasphere-webhook-env.ts
+++ b/examples/datasphere-webhook-env.ts
@@ -5,7 +5,7 @@
  * configuration. Compare with datasphere-serverless-env.ts for the serverless approach.
  *
  * Required env vars:
- *   SIGNALWIRE_SPACE, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN,
+ *   SIGNALWIRE_SPACE, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_API_TOKEN,
  *   DATASPHERE_DOCUMENT_ID
  *
  * Run: npx tsx examples/datasphere-webhook-env.ts

--- a/examples/datasphere.ts
+++ b/examples/datasphere.ts
@@ -2,7 +2,7 @@
  * DataSphere Skill Example
  *
  * Uses the DataSphere skill to search a SignalWire knowledge base.
- * Requires SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN, and SIGNALWIRE_SPACE env vars.
+ * Requires SIGNALWIRE_PROJECT_ID, SIGNALWIRE_API_TOKEN, and SIGNALWIRE_SPACE env vars.
  * Run: npx tsx examples/datasphere.ts
  */
 

--- a/relay/README.md
+++ b/relay/README.md
@@ -49,7 +49,7 @@ client.run();
 | Variable | Description |
 |----------|-------------|
 | `SIGNALWIRE_PROJECT_ID` | Project ID for authentication |
-| `SIGNALWIRE_TOKEN` | API token for authentication |
+| `SIGNALWIRE_API_TOKEN` | API token for authentication |
 | `SIGNALWIRE_JWT_TOKEN` | JWT token (alternative to project/token) |
 | `SIGNALWIRE_SPACE` | Space hostname (default: `relay.signalwire.com`) |
 | `SIGNALWIRE_LOG_LEVEL` | Log level (`debug` for WebSocket traffic) |

--- a/relay/docs/guide.md
+++ b/relay/docs/guide.md
@@ -18,7 +18,7 @@ import { RelayClient } from '@signalwire/sdk';
 function makeClient() {
   return new RelayClient({
     project: 'your-project-id',    // or env: SIGNALWIRE_PROJECT_ID
-    token: 'your-api-token',       // or env: SIGNALWIRE_TOKEN
+    token: 'your-api-token',       // or env: SIGNALWIRE_API_TOKEN
     host: 'your-space.signalwire.com', // or env: SIGNALWIRE_SPACE
     contexts: ['office', 'support'],
   });
@@ -27,7 +27,7 @@ function makeClient() {
 
 All parameters can be provided via environment variables:
 - `SIGNALWIRE_PROJECT_ID` - Your SignalWire project ID
-- `SIGNALWIRE_TOKEN` - Your SignalWire API token (or `SIGNALWIRE_JWT_TOKEN` for JWT auth)
+- `SIGNALWIRE_API_TOKEN` - Your SignalWire API token (or `SIGNALWIRE_JWT_TOKEN` for JWT auth)
 - `SIGNALWIRE_SPACE` - Your SignalWire space hostname
 
 ## Handling Inbound Calls
@@ -304,7 +304,7 @@ call.on('calling.call.state', (event) => {
 | Variable | Purpose |
 |----------|---------|
 | `SIGNALWIRE_PROJECT_ID` | Project ID for authentication |
-| `SIGNALWIRE_TOKEN` | API token for authentication |
+| `SIGNALWIRE_API_TOKEN` | API token for authentication |
 | `SIGNALWIRE_JWT_TOKEN` | JWT token (alternative to project/token) |
 | `SIGNALWIRE_SPACE` | Space hostname (default: relay.signalwire.com) |
 | `SIGNALWIRE_LOG_LEVEL` | Log level: debug, info, warn, error |

--- a/src/skills/builtin/datasphere.ts
+++ b/src/skills/builtin/datasphere.ts
@@ -3,7 +3,7 @@
  *
  * Tier 3 built-in skill matching the Python SDK. All credentials (`space_name`,
  * `project_id`, `token`) and `document_id` are supplied via skill params. Env
- * var fallbacks (`SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, `SIGNALWIRE_SPACE`)
+ * var fallbacks (`SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_API_TOKEN`, `SIGNALWIRE_SPACE`)
  * are honored when the corresponding param is not set.
  */
 
@@ -55,7 +55,7 @@ interface DataSphereResponse {
  * Searches SignalWire DataSphere for knowledge base content using semantic search.
  *
  * Tier 3 built-in skill. Credentials can be supplied via params or fall back to
- * `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_TOKEN`, and `SIGNALWIRE_SPACE` environment
+ * `SIGNALWIRE_PROJECT_ID`, `SIGNALWIRE_API_TOKEN`, and `SIGNALWIRE_SPACE` environment
  * variables. Supports `count`, `distance`, `tags`, `language`, `pos_to_expand`,
  * `max_synonyms`, and `no_results_message` config options.
  *
@@ -103,7 +103,7 @@ export class DataSphereSkill extends SkillBase {
         description: 'SignalWire API token',
         required: true,
         hidden: true,
-        env_var: 'SIGNALWIRE_TOKEN',
+        env_var: 'SIGNALWIRE_API_TOKEN',
       },
       document_id: {
         type: 'string',
@@ -198,7 +198,7 @@ export class DataSphereSkill extends SkillBase {
       this.getConfig<string | undefined>('project_id', undefined) ??
       process.env['SIGNALWIRE_PROJECT_ID'];
     const token =
-      this.getConfig<string | undefined>('token', undefined) ?? process.env['SIGNALWIRE_TOKEN'];
+      this.getConfig<string | undefined>('token', undefined) ?? process.env['SIGNALWIRE_API_TOKEN'];
     const documentId = this.getConfig<string | undefined>('document_id', undefined);
     const missing: string[] = [];
     if (!spaceName) missing.push('space_name');
@@ -262,14 +262,14 @@ export class DataSphereSkill extends SkillBase {
             process.env['SIGNALWIRE_PROJECT_ID'];
           const token =
             this.getConfig<string | undefined>('token', undefined) ??
-            process.env['SIGNALWIRE_TOKEN'];
+            process.env['SIGNALWIRE_API_TOKEN'];
           const space =
             this.getConfig<string | undefined>('space_name', undefined) ??
             process.env['SIGNALWIRE_SPACE'];
 
           if (!projectId || !token || !space) {
             return new FunctionResult(
-              'DataSphere is not configured. The SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN, and SIGNALWIRE_SPACE environment variables (or equivalent config params) are required.',
+              'DataSphere is not configured. The SIGNALWIRE_PROJECT_ID, SIGNALWIRE_API_TOKEN, and SIGNALWIRE_SPACE environment variables (or equivalent config params) are required.',
             );
           }
 

--- a/src/skills/builtin/datasphere_serverless.ts
+++ b/src/skills/builtin/datasphere_serverless.ts
@@ -76,7 +76,7 @@ export class DataSphereServerlessSkill extends SkillBase {
         description: 'SignalWire API token',
         required: true,
         hidden: true,
-        env_var: 'SIGNALWIRE_TOKEN',
+        env_var: 'SIGNALWIRE_API_TOKEN',
       },
       document_id: {
         type: 'string',

--- a/tests/skills/builtin.test.ts
+++ b/tests/skills/builtin.test.ts
@@ -744,10 +744,10 @@ describe('DataSphereSkill', () => {
 
   it('should return error when env vars are not set', async () => {
     const origPid = process.env['SIGNALWIRE_PROJECT_ID'];
-    const origToken = process.env['SIGNALWIRE_TOKEN'];
+    const origToken = process.env['SIGNALWIRE_API_TOKEN'];
     const origSpace = process.env['SIGNALWIRE_SPACE'];
     delete process.env['SIGNALWIRE_PROJECT_ID'];
-    delete process.env['SIGNALWIRE_TOKEN'];
+    delete process.env['SIGNALWIRE_API_TOKEN'];
     delete process.env['SIGNALWIRE_SPACE'];
     const skill = createDataSphereSkill();
     const handler = skill.getTools()[0]!.handler;
@@ -756,7 +756,7 @@ describe('DataSphereSkill', () => {
     expect(result.response).toContain('not configured');
     expect(result.response).toContain('SIGNALWIRE_PROJECT_ID');
     if (origPid !== undefined) process.env['SIGNALWIRE_PROJECT_ID'] = origPid;
-    if (origToken !== undefined) process.env['SIGNALWIRE_TOKEN'] = origToken;
+    if (origToken !== undefined) process.env['SIGNALWIRE_API_TOKEN'] = origToken;
     if (origSpace !== undefined) process.env['SIGNALWIRE_SPACE'] = origSpace;
   });
 });

--- a/tests/skills/datasphere.test.ts
+++ b/tests/skills/datasphere.test.ts
@@ -80,7 +80,7 @@ describe('DataSphereSkill', () => {
 
   it('should return error when credentials are missing', async () => {
     delete process.env['SIGNALWIRE_PROJECT_ID'];
-    delete process.env['SIGNALWIRE_TOKEN'];
+    delete process.env['SIGNALWIRE_API_TOKEN'];
     delete process.env['SIGNALWIRE_SPACE'];
     const handler = new DataSphereSkill().getTools()[0]!.handler;
     const result = (await handler({ query: 'test' }, {})) as FunctionResult;


### PR DESCRIPTION
## What

Plan 4.4 ripple. The python reference standardized its token env var on canonical `SIGNALWIRE_API_TOKEN` and removed `SIGNALWIRE_TOKEN` outright (no back-compat alias). The ts datasphere skill still read `SIGNALWIRE_TOKEN`. This renames it to `SIGNALWIRE_API_TOKEN` everywhere in the SDK — outright, no fallback alias — so the datasphere skills match the relay/rest clients (already on `SIGNALWIRE_API_TOKEN`) and the reference.

## Sites changed (11 files, 23 occurrences)

- `src/skills/builtin/datasphere.ts` — `env_var` metadata, runtime `process.env` read, doc-comment fallback references, and the "not configured" error message.
- `src/skills/builtin/datasphere_serverless.ts` — `env_var` metadata.
- `docs/skills-guide.md` — the datasphere/datasphere_serverless env-var columns and the env-var index row.
- `relay/docs/guide.md`, `relay/README.md` — documented API-token env var (`SIGNALWIRE_JWT_TOKEN` left as-is).
- `examples/datasphere.ts`, `examples/datasphere-serverless-env.ts`, `examples/datasphere-webhook-env.ts` — required-env doc comments / the missing-env message.
- `tests/skills/builtin.test.ts`, `tests/skills/datasphere.test.ts` — the env-var save/delete/restore and missing-credentials assertions.
- `EXAMPLES_RUN_ALLOW.md` — the required-env note.

`SIGNALWIRE_JWT_TOKEN` is a distinct variable and is untouched.

## Verification

- `grep -rn SIGNALWIRE_TOKEN` (excl node_modules/.git/dist) → zero hits.
- `bash scripts/run-ci.sh` (pr tier) → **CI PASS** (all gates green, incl. DOC-ENV, DOC-AUDIT, TEST, LINT, SURFACE-FRESH, SIGNATURES).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
