### PR TITLE
Fix REST types generator over-nesting free-form object params (#19537)

### DIFF
--- a/scripts/_gen-common.ts
+++ b/scripts/_gen-common.ts
@@ -142,6 +142,42 @@ export function refName(ref: string): string {
 
 // ---- schema → TS type expression ------------------------------------------
 
+/**
+ * True when `s` carries no keyword that pins a concrete TS type — the empty `{}`
+ * (or annotation-only) schema. In a Record/index-signature VALUE position this is
+ * the "allow any value" idiom, so the value type is `unknown`.
+ */
+function isUnconstrainedSchema(s: Schema): boolean {
+  return (
+    !s.$ref &&
+    s.type === undefined &&
+    s.properties === undefined &&
+    s.enum === undefined &&
+    s.const === undefined &&
+    s.allOf === undefined &&
+    s.oneOf === undefined &&
+    s.anyOf === undefined &&
+    s.items === undefined &&
+    s.additionalProperties === undefined &&
+    s.unevaluatedProperties === undefined &&
+    s['x-sdk-enum-literal'] === undefined &&
+    !s['x-sdk-widen']
+  );
+}
+
+/**
+ * The VALUE type of a `Record<string, …>` / index signature whose value schema is
+ * `ap`. An empty / unconstrained value schema — the SWML `unevaluatedProperties:
+ * {}` (or `additionalProperties: {}`) "allow any additional property" idiom —
+ * describes arbitrary values, so the value type is `unknown`, yielding
+ * `Record<string, unknown>` instead of double-wrapping to `Record<string,
+ * Record<string, unknown>>` (issue #19537). A constrained value schema (e.g.
+ * `{ type: 'object' }`, `{ type: 'string' }`, a `$ref`) keeps its real type.
+ */
+function recordValueType(ap: Schema, indent: number): string {
+  return isUnconstrainedSchema(ap) ? 'unknown' : tsType(ap, indent);
+}
+
 export function tsType(schema: Schema | undefined, indent = 0): string {
   if (!schema) return 'unknown';
 
@@ -224,9 +260,11 @@ export function tsType(schema: Schema | undefined, indent = 0): string {
       if (schema.properties) {
         return wrapNull(objectBody(schema, indent));
       }
-      // free-form object → Record. additionalProperties may give a value type.
+      // free-form object → Record. additionalProperties may give a value type;
+      // an empty/unconstrained value schema means `unknown` (issue #19537).
       const ap = schema.additionalProperties ?? schema.unevaluatedProperties;
-      if (ap && typeof ap === 'object') return wrapNull(`Record<string, ${tsType(ap, indent)}>`);
+      if (ap && typeof ap === 'object')
+        return wrapNull(`Record<string, ${recordValueType(ap, indent)}>`);
       // a bare `type: object` with no shape, or no type at all → open record
       return wrapNull('Record<string, unknown>');
     }
@@ -339,11 +377,20 @@ export function objectBody(
   if (ap === true) {
     if (topLevel) lines.push(`${pad}[key: string]: unknown;`);
   } else if (ap && typeof ap === 'object') {
-    const base = tsType(ap, indent + 1);
-    const propTypes = Object.values(props).map((p) => tsType(p, indent + 1));
-    const hasOptional = Object.keys(props).some((k) => !required.has(k));
-    const members = [base, ...propTypes, ...(hasOptional ? ['undefined'] : [])];
-    const value = [...new Set(members)].join(' | ');
+    const base = recordValueType(ap, indent + 1);
+    // An unconstrained value schema makes the index type `unknown` — it already
+    // absorbs every declared prop type, so emit it bare rather than a redundant
+    // `unknown | string | …` union (issue #19537). Otherwise the index type must
+    // union in the declared prop types so they stay assignable to it (TS2411).
+    let value: string;
+    if (base === 'unknown') {
+      value = 'unknown';
+    } else {
+      const propTypes = Object.values(props).map((p) => tsType(p, indent + 1));
+      const hasOptional = Object.keys(props).some((k) => !required.has(k));
+      const members = [base, ...propTypes, ...(hasOptional ? ['undefined'] : [])];
+      value = [...new Set(members)].join(' | ');
+    }
     lines.push(`${pad}[key: string]: ${value};`);
   }
   // No declared members AND no emitted index signature → this is an open object

--- a/src/rest/namespaces/calling.resources.generated.ts
+++ b/src/rest/namespaces/calling.resources.generated.ts
@@ -144,7 +144,7 @@ export class Calling extends BaseResource {
       role?: 'system' | 'user' | 'assistant';
       message_text?: string;
       reset?: CallAIMessageResetParams;
-      global_data?: Record<string, Record<string, unknown>>;
+      global_data?: Record<string, unknown>;
       extras?: Record<string, unknown>;
     },
   ): Promise<CallResponse> {
@@ -225,7 +225,7 @@ export class Calling extends BaseResource {
 
   async userEvent(
     callId: string,
-    event: Record<string, Record<string, unknown>>,
+    event: Record<string, unknown>,
     options?: { extras?: Record<string, unknown> },
   ): Promise<CallResponse> {
     const params: Record<string, unknown> = {};

--- a/src/rest/namespaces/calling.types.generated.ts
+++ b/src/rest/namespaces/calling.types.generated.ts
@@ -12,7 +12,7 @@ export interface AI {
 
 export interface AIObject {
   /** A key-value object for storing data that persists throughout the AI session. */
-  global_data?: Record<string, Record<string, unknown>>;
+  global_data?: Record<string, unknown>;
   /** Hints help the AI agent understand certain words or phrases better. Words that can commonly be misinterpreted can be added to the hints to help the AI speak more accurately. */
   hints?: (string | Hint)[];
   /** An array of JSON objects defining supported languages in the conversation. */
@@ -206,45 +206,7 @@ export interface AIParams {
   eleven_labs_stability?: number | SWMLVar;
   /** The similarity slider dictates how closely the AI should adhere to the original voice when attempting to replicate it. The higher the similarity, the closer the AI will sound to the original voice. */
   eleven_labs_similarity?: number | SWMLVar;
-  [key: string]:
-    | Record<string, unknown>
-    | boolean
-    | SWMLVar
-    | 'gpt-4o-mini'
-    | 'gpt-4.1-mini'
-    | 'gpt-4.1-nano'
-    | string
-    | string
-    | number
-    | SWMLVar
-    | AttentionTimeout
-    | 0
-    | SWMLVar
-    | number
-    | null
-    | SWMLVar
-    | string
-    | boolean
-    | SWMLVar
-    | ConversationMessage[]
-    | boolean
-    | number
-    | SWMLVar
-    | Direction
-    | SWMLVar
-    | string
-    | SWMLVar
-    | 'markdown'
-    | 'xml'
-    | 'string'
-    | 'original'
-    | SWMLVar
-    | boolean
-    | string[]
-    | SWMLVar
-    | 'international'
-    | 'national'
-    | undefined;
+  [key: string]: unknown;
 }
 
 export type AIPostPrompt = AIPostPromptText | AIPostPromptPom;
@@ -353,7 +315,7 @@ export interface AmazonBedrock {
 
 export interface AmazonBedrockObject {
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script */
-  global_data?: Record<string, Record<string, unknown>>;
+  global_data?: Record<string, unknown>;
   /** A JSON object containing parameters as key-value pairs. */
   params?: BedrockParams;
   /** The final set of instructions and configuration settings to send to the agent. */
@@ -519,7 +481,7 @@ export type BedrockSWAIGFunction =
       /** Whether the function is active. **Default:** `true`. */
       active?: boolean | SWMLVar;
       /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-      meta_data?: Record<string, Record<string, unknown>>;
+      meta_data?: Record<string, unknown>;
       /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
       meta_data_token?: string;
       /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -537,7 +499,7 @@ export type BedrockSWAIGFunction =
       /** Whether the function is active. **Default:** `true`. */
       active?: boolean | SWMLVar;
       /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-      meta_data?: Record<string, Record<string, unknown>>;
+      meta_data?: Record<string, unknown>;
       /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
       meta_data_token?: string;
       /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -555,7 +517,7 @@ export type BedrockSWAIGFunction =
       /** Whether the function is active. **Default:** `true`. */
       active?: boolean | SWMLVar;
       /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-      meta_data?: Record<string, Record<string, unknown>>;
+      meta_data?: Record<string, unknown>;
       /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
       meta_data_token?: string;
       /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -573,7 +535,7 @@ export type BedrockSWAIGFunction =
       /** Whether the function is active. **Default:** `true`. */
       active?: boolean | SWMLVar;
       /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-      meta_data?: Record<string, Record<string, unknown>>;
+      meta_data?: Record<string, unknown>;
       /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
       meta_data_token?: string;
       /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -610,7 +572,7 @@ export interface CallAIMessageRequest {
     /** Parameters for resetting the AI conversation state. When provided, `role` and `message_text` are optional. */
     reset?: CallAIMessageResetParams;
     /** Arbitrary JSON data to merge into the AI session's global data store. */
-    global_data?: Record<string, Record<string, unknown>>;
+    global_data?: Record<string, unknown>;
   };
 }
 
@@ -1357,7 +1319,7 @@ export interface CallUserEventRequest {
   /** An object of parameters that will be utilized by the active command. */
   params: {
     /** Arbitrary JSON event data to fire on the call. */
-    event: Record<string, Record<string, unknown>>;
+    event: Record<string, unknown>;
   };
 }
 
@@ -1778,9 +1740,9 @@ export interface Execute {
     /** Specifies what to execute. The value can be one of: */
     dest: string;
     /** Named parameters to send to section or URL */
-    params?: Record<string, Record<string, unknown>>;
+    params?: Record<string, unknown>;
     /** User-defined metadata, ignored by SignalWire */
-    meta?: Record<string, Record<string, unknown>>;
+    meta?: Record<string, unknown>;
     /** The list of SWML instructions to be executed when the executed section or URL returns */
     on_return?: SWMLMethod[];
     /** Action to take based on the result of the call. This will run once the peer leg of the call has ended. */
@@ -2090,7 +2052,7 @@ export interface HangUpHookSWAIGFunction {
   /** Whether the function is active. **Default:** `true`. */
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-  meta_data?: Record<string, Record<string, unknown>>;
+  meta_data?: Record<string, unknown>;
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
   /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -2439,7 +2401,7 @@ export interface ObjectProperty {
   /** The type of parameter(s) the AI is passing to the function. */
   type: 'object';
   /** The default object value */
-  default?: Record<string, Record<string, unknown>>;
+  default?: Record<string, unknown>;
   /** Nested properties */
   properties?: Record<string, SchemaType>;
   /** Required property names */
@@ -2736,9 +2698,9 @@ export interface Request {
     /** The HTTP method to be used for the request. Can be `GET`, `POST`, `PUT`, or `DELETE`. */
     method: 'GET' | 'POST' | 'PUT' | 'DELETE';
     /** Object containing HTTP headers to set. Valid header values are Accept, Authorization, Content-Type, Range, and custom X- headers. */
-    headers?: Record<string, Record<string, unknown>>;
+    headers?: Record<string, unknown>;
     /** Request body. Content-Type header should be explicitly set, but if not set, the most likely type */
-    body?: string | Record<string, Record<string, unknown>>;
+    body?: string | Record<string, unknown>;
     /** Maximum time in seconds to wait for a response. */
     timeout?: number | SWMLVar;
     /** Maximum time in seconds to wait for a connection. */
@@ -2825,7 +2787,7 @@ export interface SWAIGIncludes {
   /** URL to fetch remote functions and include in your AI application. Authentication can also be set in the url in the format of `username:password@url`. */
   url: string;
   /** User-defined metadata to pass with the remote function request. */
-  meta_data?: Record<string, Record<string, unknown>>;
+  meta_data?: Record<string, unknown>;
 }
 
 export interface SWAIGInternalFiller {
@@ -2957,17 +2919,17 @@ export interface SendSMS {
 
 export interface Set_ {
   /** Set script variables to the specified values. */
-  set: Record<string, Record<string, unknown>>;
+  set: Record<string, unknown>;
 }
 
 export interface SetGlobalDataAction {
   /** A JSON object containing any global data, as a key-value map. This action sets the data in the `global_data` to be globally referenced. */
-  set_global_data: Record<string, Record<string, unknown>>;
+  set_global_data: Record<string, unknown>;
 }
 
 export interface SetMetaDataAction {
   /** A JSON object containing any metadata, as a key-value map. This action sets the data in the `meta_data` to be referenced locally in the function. */
-  set_meta_data: Record<string, Record<string, unknown>>;
+  set_meta_data: Record<string, unknown>;
 }
 
 export interface Sleep {
@@ -3036,7 +2998,7 @@ export interface StartUpHookSWAIGFunction {
   /** Whether the function is active. **Default:** `true`. */
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-  meta_data?: Record<string, Record<string, unknown>>;
+  meta_data?: Record<string, unknown>;
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
   /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -3143,7 +3105,7 @@ export interface SummarizeConversationSWAIGFunction {
   /** Whether the function is active. **Default:** `true`. */
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-  meta_data?: Record<string, Record<string, unknown>>;
+  meta_data?: Record<string, unknown>;
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
   /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -3252,9 +3214,9 @@ export interface Transfer {
     /** Specifies where to transfer to. The value can be one of: */
     dest: string;
     /** Named parameters to send to transfer destination. */
-    params?: Record<string, Record<string, unknown>>;
+    params?: Record<string, unknown>;
     /** User data, ignored by SignalWire. */
-    meta?: Record<string, Record<string, unknown>>;
+    meta?: Record<string, unknown>;
   };
 }
 
@@ -3317,7 +3279,7 @@ export interface UnsetMetaDataAction {
 export interface UserEvent {
   /** Allows the user to set and send events to the connected client on the call. */
   user_event: {
-    event: Record<string, Record<string, unknown>>;
+    event: Record<string, unknown>;
   };
 }
 
@@ -3340,7 +3302,7 @@ export interface UserSWAIGFunction {
   /** Whether the function is active. **Default:** `true`. */
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-  meta_data?: Record<string, Record<string, unknown>>;
+  meta_data?: Record<string, unknown>;
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
   /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -3395,13 +3357,13 @@ export interface Webhook {
     append: string;
   };
   /** Any necessary headers for the API call. */
-  headers?: Record<string, Record<string, unknown>>;
+  headers?: Record<string, unknown>;
   /** The HTTP method (GET, POST, etc.) for the API call. */
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
   /** A boolean to determine if the input arguments should be passed as parameters. */
   input_args_as_params?: boolean | SWMLVar;
   /** An object of any necessary parameters for the API call. The key is the parameter name and the value is the parameter value. */
-  params?: Record<string, Record<string, unknown>>;
+  params?: Record<string, unknown>;
   /** A string or array of strings that represent the `arguments` that are required to make the webhook request. */
   require_args?: string | string[];
   /** An object that contains a response and a list of actions to be performed upon completion of the webhook request. */

--- a/src/rest/namespaces/chat.types.generated.ts
+++ b/src/rest/namespaces/chat.types.generated.ts
@@ -23,7 +23,7 @@ export interface ChatPermissionWithWrite {
 }
 
 /** An arbitrary JSON object available to store stateful application information in. Must be valid JSON and have a maximum size of 2,000 characters. */
-export type ChatState = Record<string, Record<string, unknown>>;
+export type ChatState = Record<string, unknown>;
 
 export interface ChatToken {
   /** The generated Chat Token. */

--- a/src/rest/namespaces/fabric.types.generated.ts
+++ b/src/rest/namespaces/fabric.types.generated.ts
@@ -24,7 +24,7 @@ export interface AIAddressPaginationResponse {
 /** An AI Agent configuration that extends the SWML AI object with additional API-specific properties. */
 export interface AIAgent {
   /** A key-value object for storing data that persists throughout the AI session. */
-  global_data?: Record<string, Record<string, unknown>>;
+  global_data?: Record<string, unknown>;
   /** Hints help the AI agent understand certain words or phrases better. Words that can commonly be misinterpreted can be added to the hints to help the AI speak more accurately. */
   hints?: (string | Hint)[];
   /** An array of JSON objects defining supported languages in the conversation. */
@@ -56,7 +56,7 @@ export interface AIAgentAddressListResponse {
 
 export interface AIAgentCreateRequest {
   /** A key-value object for storing data that persists throughout the AI session. */
-  global_data?: Record<string, Record<string, unknown>>;
+  global_data?: Record<string, unknown>;
   /** Hints help the AI agent understand certain words or phrases better. Words that can commonly be misinterpreted can be added to the hints to help the AI speak more accurately. */
   hints?: (string | Hint)[];
   /** An array of JSON objects defining supported languages in the conversation. */
@@ -122,7 +122,7 @@ export interface AIAgentResponse {
 
 export interface AIAgentUpdateRequest {
   /** A key-value object for storing data that persists throughout the AI session. */
-  global_data?: Record<string, Record<string, unknown>>;
+  global_data?: Record<string, unknown>;
   /** Hints help the AI agent understand certain words or phrases better. Words that can commonly be misinterpreted can be added to the hints to help the AI speak more accurately. */
   hints?: (string | Hint)[];
   /** An array of JSON objects defining supported languages in the conversation. */
@@ -153,7 +153,7 @@ export interface AIAgentUpdateStatusCode422 {
 
 export interface AIObject {
   /** A key-value object for storing data that persists throughout the AI session. */
-  global_data?: Record<string, Record<string, unknown>>;
+  global_data?: Record<string, unknown>;
   /** Hints help the AI agent understand certain words or phrases better. Words that can commonly be misinterpreted can be added to the hints to help the AI speak more accurately. */
   hints?: (string | Hint)[];
   /** An array of JSON objects defining supported languages in the conversation. */
@@ -347,45 +347,7 @@ export interface AIParams {
   eleven_labs_stability?: number | SWMLVar;
   /** The similarity slider dictates how closely the AI should adhere to the original voice when attempting to replicate it. The higher the similarity, the closer the AI will sound to the original voice. */
   eleven_labs_similarity?: number | SWMLVar;
-  [key: string]:
-    | Record<string, unknown>
-    | boolean
-    | SWMLVar
-    | 'gpt-4o-mini'
-    | 'gpt-4.1-mini'
-    | 'gpt-4.1-nano'
-    | string
-    | string
-    | number
-    | SWMLVar
-    | AttentionTimeout
-    | 0
-    | SWMLVar
-    | number
-    | null
-    | SWMLVar
-    | string
-    | boolean
-    | SWMLVar
-    | ConversationMessage[]
-    | boolean
-    | number
-    | SWMLVar
-    | Direction
-    | SWMLVar
-    | string
-    | SWMLVar
-    | 'markdown'
-    | 'xml'
-    | 'string'
-    | 'original'
-    | SWMLVar
-    | boolean
-    | string[]
-    | SWMLVar
-    | 'international'
-    | 'national'
-    | undefined;
+  [key: string]: unknown;
 }
 
 export type AIPostPrompt = AIPostPromptText | AIPostPromptPom;
@@ -572,7 +534,7 @@ export interface AmazonBedrock {
 
 export interface AmazonBedrockObject {
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script */
-  global_data?: Record<string, Record<string, unknown>>;
+  global_data?: Record<string, unknown>;
   /** A JSON object containing parameters as key-value pairs. */
   params?: BedrockParams;
   /** The final set of instructions and configuration settings to send to the agent. */
@@ -743,7 +705,7 @@ export type BedrockSWAIGFunction =
       /** Whether the function is active. **Default:** `true`. */
       active?: boolean | SWMLVar;
       /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-      meta_data?: Record<string, Record<string, unknown>>;
+      meta_data?: Record<string, unknown>;
       /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
       meta_data_token?: string;
       /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -761,7 +723,7 @@ export type BedrockSWAIGFunction =
       /** Whether the function is active. **Default:** `true`. */
       active?: boolean | SWMLVar;
       /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-      meta_data?: Record<string, Record<string, unknown>>;
+      meta_data?: Record<string, unknown>;
       /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
       meta_data_token?: string;
       /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -779,7 +741,7 @@ export type BedrockSWAIGFunction =
       /** Whether the function is active. **Default:** `true`. */
       active?: boolean | SWMLVar;
       /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-      meta_data?: Record<string, Record<string, unknown>>;
+      meta_data?: Record<string, unknown>;
       /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
       meta_data_token?: string;
       /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -797,7 +759,7 @@ export type BedrockSWAIGFunction =
       /** Whether the function is active. **Default:** `true`. */
       active?: boolean | SWMLVar;
       /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-      meta_data?: Record<string, Record<string, unknown>>;
+      meta_data?: Record<string, unknown>;
       /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
       meta_data_token?: string;
       /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -1260,7 +1222,7 @@ export interface ConferenceRoom {
   /** Syncs the participants audio and video. */
   sync_audio_video: boolean | null;
   /** Metadata of the conference. */
-  meta: Record<string, Record<string, unknown>>;
+  meta: Record<string, unknown>;
   /** Indicator if the Conference Room will prioritize showing participants utilizing the hand raised feature. */
   prioritize_handraise: boolean;
 }
@@ -1309,7 +1271,7 @@ export interface ConferenceRoomCreateRequest {
   /** Enables live video room previews for the conference. */
   enable_room_previews: boolean;
   /** Metadata of the conference. */
-  meta?: Record<string, Record<string, unknown>>;
+  meta?: Record<string, unknown>;
   /** Syncs the participants audio and video. */
   sync_audio_video?: boolean;
   /** Plays a tone when a participant joins or leaves the conference. */
@@ -1376,7 +1338,7 @@ export interface ConferenceRoomUpdateRequest {
   /** Enables live video room previews for the conference. */
   enable_room_previews: boolean;
   /** Metadata of the conference. */
-  meta?: Record<string, Record<string, unknown>>;
+  meta?: Record<string, unknown>;
   /** Syncs the participants audio and video. */
   sync_audio_video: boolean;
   /** Plays a tone when a participant joins or leaves the conference. */
@@ -2069,9 +2031,9 @@ export interface Execute {
     /** Specifies what to execute. The value can be one of: */
     dest: string;
     /** Named parameters to send to section or URL */
-    params?: Record<string, Record<string, unknown>>;
+    params?: Record<string, unknown>;
     /** User-defined metadata, ignored by SignalWire */
-    meta?: Record<string, Record<string, unknown>>;
+    meta?: Record<string, unknown>;
     /** The list of SWML instructions to be executed when the executed section or URL returns */
     on_return?: SWMLMethod[];
     /** Action to take based on the result of the call. This will run once the peer leg of the call has ended. */
@@ -2798,7 +2760,7 @@ export interface HangUpHookSWAIGFunction {
   /** Whether the function is active. **Default:** `true`. */
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-  meta_data?: Record<string, Record<string, unknown>>;
+  meta_data?: Record<string, unknown>;
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
   /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -3068,7 +3030,7 @@ export interface ObjectProperty {
   /** The type of parameter(s) the AI is passing to the function. */
   type: 'object';
   /** The default object value */
-  default?: Record<string, Record<string, unknown>>;
+  default?: Record<string, unknown>;
   /** Nested properties */
   properties?: Record<string, SchemaType>;
   /** Required property names */
@@ -3488,9 +3450,9 @@ export interface Request {
     /** The HTTP method to be used for the request. Can be `GET`, `POST`, `PUT`, or `DELETE`. */
     method: 'GET' | 'POST' | 'PUT' | 'DELETE';
     /** Object containing HTTP headers to set. Valid header values are Accept, Authorization, Content-Type, Range, and custom X- headers. */
-    headers?: Record<string, Record<string, unknown>>;
+    headers?: Record<string, unknown>;
     /** Request body. Content-Type header should be explicitly set, but if not set, the most likely type */
-    body?: string | Record<string, Record<string, unknown>>;
+    body?: string | Record<string, unknown>;
     /** Maximum time in seconds to wait for a response. */
     timeout?: number | SWMLVar;
     /** Maximum time in seconds to wait for a connection. */
@@ -3905,7 +3867,7 @@ export interface SWAIGIncludes {
   /** URL to fetch remote functions and include in your AI application. Authentication can also be set in the url in the format of `username:password@url`. */
   url: string;
   /** User-defined metadata to pass with the remote function request. */
-  meta_data?: Record<string, Record<string, unknown>>;
+  meta_data?: Record<string, unknown>;
 }
 
 export interface SWAIGInternalFiller {
@@ -4201,17 +4163,17 @@ export interface SendSMS {
 
 export interface Set_ {
   /** Set script variables to the specified values. */
-  set: Record<string, Record<string, unknown>>;
+  set: Record<string, unknown>;
 }
 
 export interface SetGlobalDataAction {
   /** A JSON object containing any global data, as a key-value map. This action sets the data in the `global_data` to be globally referenced. */
-  set_global_data: Record<string, Record<string, unknown>>;
+  set_global_data: Record<string, unknown>;
 }
 
 export interface SetMetaDataAction {
   /** A JSON object containing any metadata, as a key-value map. This action sets the data in the `meta_data` to be referenced locally in the function. */
-  set_meta_data: Record<string, Record<string, unknown>>;
+  set_meta_data: Record<string, unknown>;
 }
 
 export interface SipEndpoint {
@@ -4506,7 +4468,7 @@ export interface StartUpHookSWAIGFunction {
   /** Whether the function is active. **Default:** `true`. */
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-  meta_data?: Record<string, Record<string, unknown>>;
+  meta_data?: Record<string, unknown>;
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
   /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -4871,7 +4833,7 @@ export interface SummarizeConversationSWAIGFunction {
   /** Whether the function is active. **Default:** `true`. */
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-  meta_data?: Record<string, Record<string, unknown>>;
+  meta_data?: Record<string, unknown>;
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
   /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -5072,9 +5034,9 @@ export interface Transfer {
     /** Specifies where to transfer to. The value can be one of: */
     dest: string;
     /** Named parameters to send to transfer destination. */
-    params?: Record<string, Record<string, unknown>>;
+    params?: Record<string, unknown>;
     /** User data, ignored by SignalWire. */
-    meta?: Record<string, Record<string, unknown>>;
+    meta?: Record<string, unknown>;
   };
 }
 
@@ -5146,7 +5108,7 @@ export type UsedForType = 'calling' | 'messaging';
 export interface UserEvent {
   /** Allows the user to set and send events to the connected client on the call. */
   user_event: {
-    event: Record<string, Record<string, unknown>>;
+    event: Record<string, unknown>;
   };
 }
 
@@ -5169,7 +5131,7 @@ export interface UserSWAIGFunction {
   /** Whether the function is active. **Default:** `true`. */
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
-  meta_data?: Record<string, Record<string, unknown>>;
+  meta_data?: Record<string, unknown>;
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
   /** An object that processes function inputs and executes operations through expressions, webhooks, or direct output. */
@@ -5229,13 +5191,13 @@ export interface Webhook {
     append: string;
   };
   /** Any necessary headers for the API call. */
-  headers?: Record<string, Record<string, unknown>>;
+  headers?: Record<string, unknown>;
   /** The HTTP method (GET, POST, etc.) for the API call. */
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
   /** A boolean to determine if the input arguments should be passed as parameters. */
   input_args_as_params?: boolean | SWMLVar;
   /** An object of any necessary parameters for the API call. The key is the parameter name and the value is the parameter value. */
-  params?: Record<string, Record<string, unknown>>;
+  params?: Record<string, unknown>;
   /** A string or array of strings that represent the `arguments` that are required to make the webhook request. */
   require_args?: string | string[];
   /** An object that contains a response and a list of actions to be performed upon completion of the webhook request. */

--- a/src/rest/namespaces/pubsub.types.generated.ts
+++ b/src/rest/namespaces/pubsub.types.generated.ts
@@ -34,7 +34,7 @@ export interface PubSubPermissionWithWrite {
 }
 
 /** An arbitrary JSON object available to store stateful application information in. Must be valid JSON and have a maximum size of 2,000 characters. */
-export type PubSubState = Record<string, Record<string, unknown>>;
+export type PubSubState = Record<string, unknown>;
 
 export interface PubSubToken {
   /** A PubSub Token to be used to authenticate clients to the PubSub Service. */

--- a/src/rest/namespaces/video.resources.generated.ts
+++ b/src/rest/namespaces/video.resources.generated.ts
@@ -175,8 +175,8 @@ export class VideoRoomTokens extends BaseResource {
       end_room_session_on_leave?: boolean;
       join_as?: JoinAsType;
       media_allowed?: MediaAllowedType;
-      room_meta?: Record<string, Record<string, unknown>>;
-      meta?: Record<string, Record<string, unknown>>;
+      room_meta?: Record<string, unknown>;
+      meta?: Record<string, unknown>;
       sync_audio_video?: boolean;
       extras?: Record<string, unknown>;
     },

--- a/src/rest/namespaces/video.types.generated.ts
+++ b/src/rest/namespaces/video.types.generated.ts
@@ -110,7 +110,7 @@ export interface Conference {
   /** Error indication color (light theme). */
   light_negative: string | null;
   /** User-defined metadata for the conference. */
-  meta: Record<string, Record<string, unknown>> | null;
+  meta: Record<string, unknown> | null;
   /** Timestamp when the conference was created. */
   created_at: string;
   /** Timestamp when the conference was last updated. */
@@ -207,7 +207,7 @@ export interface CreateRoomRequest {
   /** Whether a video with a preview of the content of the room is to be generated. */
   enable_room_previews?: boolean;
   /** User-defined metadata for the room. Must be a valid JSON object. Maximum of 2000 characters when serialized. */
-  meta?: Record<string, Record<string, unknown>>;
+  meta?: Record<string, unknown>;
   /** Enable/disable jitter buffer audio-video sync. */
   sync_audio_video?: boolean;
 }
@@ -245,9 +245,9 @@ export interface CreateRoomTokenRequest {
   /** Indicates what media the user is allowed to receive. */
   media_allowed?: MediaAllowedType;
   /** Set the room meta. Maximum of 2000 characters when serialized to JSON. */
-  room_meta?: Record<string, Record<string, unknown>>;
+  room_meta?: Record<string, unknown>;
   /** Set the member meta. Maximum of 2000 characters when serialized to JSON. */
-  meta?: Record<string, Record<string, unknown>>;
+  meta?: Record<string, unknown>;
   /** Enable/disable jitter buffer audio-video sync. */
   sync_audio_video?: boolean;
 }
@@ -497,7 +497,7 @@ export interface RoomResponse {
   /** Enable/disable jitter buffer audio-video sync. */
   sync_audio_video: boolean | null;
   /** User-defined metadata for the room. */
-  meta: Record<string, Record<string, unknown>> | null;
+  meta: Record<string, unknown> | null;
   /** Whether hand raises are prioritized in the room layout. */
   prioritize_handraise: boolean;
   /** Active session information for the room. */
@@ -589,7 +589,7 @@ export interface RoomSessionEvent {
   /** The name of the event. */
   name: string;
   /** Event-specific payload data. */
-  payload: Record<string, Record<string, unknown>>;
+  payload: Record<string, unknown>;
   /** Timestamp when the event was created. */
   created_at: string;
 }
@@ -858,7 +858,7 @@ export interface UpdateRoomRequest {
   /** Whether a video with a preview of the content of the room is to be generated. */
   enable_room_previews?: boolean;
   /** User-defined metadata for the room. Must be a valid JSON object. Maximum of 2000 characters when serialized. */
-  meta?: Record<string, Record<string, unknown>>;
+  meta?: Record<string, unknown>;
   /** Enable/disable jitter buffer audio-video sync. */
   sync_audio_video?: boolean;
 }

--- a/src/swml_verbs_generated.ts
+++ b/src/swml_verbs_generated.ts
@@ -65,7 +65,7 @@ export interface Answer {
     username?: string;
     /** Password to use for SIP authentication. */
     password?: string;
-    [key: string]: Record<string, unknown> | number | SWMLVar | string | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -98,7 +98,7 @@ export interface Connect {
 export interface Denoise {
   /** Start noise reduction. You can stop it at any time using `stop_denoise`. */
   denoise?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -116,26 +116,17 @@ export interface Execute {
     dest: string;
     /** Named parameters to send to section or URL */
     params?: {
-      [key: string]: Record<string, unknown>;
+      [key: string]: unknown;
     };
     /** User-defined metadata, ignored by SignalWire */
     meta?: {
-      [key: string]: Record<string, unknown>;
+      [key: string]: unknown;
     };
     /** The list of SWML instructions to be executed when the executed section or URL returns */
     on_return?: SWMLMethod[];
     /** Action to take based on the result of the call. This will run once the peer leg of the call has ended. */
     result?: ExecuteSwitch | CondParams[];
-    [key: string]:
-      | Record<string, unknown>
-      | string
-      | {
-          [key: string]: Record<string, unknown>;
-        }
-      | SWMLMethod[]
-      | ExecuteSwitch
-      | CondParams[]
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -149,7 +140,7 @@ export interface Goto {
     when?: string;
     /** The maximum number of times to perform the jump. Must be a number between 1 and 100. Default `100`. */
     max?: number | SWMLVar;
-    [key: string]: Record<string, unknown> | string | number | SWMLVar | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -165,7 +156,7 @@ export interface LiveTranscribe {
   live_transcribe?: {
     /** The action to perform during live transcription. */
     action: TranscribeAction;
-    [key: string]: Record<string, unknown> | TranscribeAction;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -175,7 +166,7 @@ export interface LiveTranslate {
   live_translate?: {
     /** The action to perform during live translation. */
     action: TranslateAction;
-    [key: string]: Record<string, unknown> | TranslateAction;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -185,7 +176,7 @@ export interface Hangup {
   hangup?: {
     /** The reason for hanging up the call. */
     reason?: string;
-    [key: string]: Record<string, unknown> | string | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -195,7 +186,7 @@ export interface JoinRoom {
   join_room?: {
     /** Name of the room to join. Allowed characters: A-Z, a-z, 0-9, underscore, and hyphen. */
     name: string;
-    [key: string]: Record<string, unknown> | string;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -245,21 +236,7 @@ export interface Prompt {
     speech_engine?: string;
     /** http or https URL to deliver prompt status events */
     status_url?: string;
-    [key: string]:
-      | Record<string, unknown>
-      | play_url
-      | play_url[]
-      | SWMLVar
-      | SWMLVar[]
-      | number
-      | string
-      | 'male'
-      | 'female'
-      | number
-      | SWMLVar
-      | string[]
-      | SWMLVar[]
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -269,7 +246,7 @@ export interface ReceiveFax {
   receive_fax?: {
     /** http or https URL to deliver receive_fax status events */
     status_url?: string;
-    [key: string]: Record<string, unknown> | string | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -297,19 +274,7 @@ export interface Record_ {
     max_length?: number | SWMLVar;
     /** URL to send recording status events to. */
     status_url?: string;
-    [key: string]:
-      | Record<string, unknown>
-      | boolean
-      | SWMLVar
-      | 'wav'
-      | 'mp3'
-      | 'mp4'
-      | 'speak'
-      | 'listen'
-      | string
-      | number
-      | SWMLVar
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -339,20 +304,7 @@ export interface RecordCall {
     max_length?: number | SWMLVar;
     /** http or https URL to deliver record_call status events */
     status_url?: string;
-    [key: string]:
-      | Record<string, unknown>
-      | string
-      | boolean
-      | SWMLVar
-      | 'wav'
-      | 'mp3'
-      | 'mp4'
-      | 'speak'
-      | 'listen'
-      | 'both'
-      | number
-      | SWMLVar
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -366,13 +318,13 @@ export interface Request {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE';
     /** Object containing HTTP headers to set. Valid header values are Accept, Authorization, Content-Type, Range, and custom X- headers. */
     headers?: {
-      [key: string]: Record<string, unknown>;
+      [key: string]: unknown;
     };
     /** Request body. Content-Type header should be explicitly set, but if not set, the most likely type */
     body?:
       | string
       | {
-          [key: string]: Record<string, unknown>;
+          [key: string]: unknown;
         };
     /** Maximum time in seconds to wait for a response. */
     timeout?: number | SWMLVar;
@@ -380,25 +332,7 @@ export interface Request {
     connect_timeout?: number | SWMLVar;
     /** Store parsed JSON response as variables. */
     save_variables?: boolean | SWMLVar;
-    [key: string]:
-      | Record<string, unknown>
-      | string
-      | 'GET'
-      | 'POST'
-      | 'PUT'
-      | 'DELETE'
-      | {
-          [key: string]: Record<string, unknown>;
-        }
-      | string
-      | {
-          [key: string]: Record<string, unknown>;
-        }
-      | number
-      | SWMLVar
-      | boolean
-      | SWMLVar
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -414,7 +348,7 @@ export interface SendDigits {
   send_digits?: {
     /** The digits to send. Valid values are 0123456789*#ABCDWw. Character W is a 1 second delay, and w is a 500ms delay. */
     digits: string;
-    [key: string]: Record<string, unknown> | string;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -430,7 +364,7 @@ export interface SendFax {
     identity?: string;
     /** http or https URL to deliver send_fax status events */
     status_url?: string;
-    [key: string]: Record<string, unknown> | string | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -444,7 +378,7 @@ export interface SendSMS {
 export interface Set_ {
   /** Set script variables to the specified values. */
   set?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -455,7 +389,7 @@ export interface Sleep {
     | {
         /** The amount of time to sleep in milliseconds. */
         duration: number | SWMLVar;
-        [key: string]: Record<string, unknown> | number | SWMLVar;
+        [key: string]: unknown;
       }
     | number
     | SWMLVar;
@@ -473,7 +407,7 @@ export interface SIPRefer {
     username?: string;
     /** Password to use for SIP authentication. */
     password?: string;
-    [key: string]: Record<string, unknown> | string | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -481,7 +415,7 @@ export interface SIPRefer {
 export interface StopDenoise {
   /** Stop noise reduction that was started with denoise. */
   stop_denoise?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -491,7 +425,7 @@ export interface StopRecordCall {
   stop_record_call?: {
     /** Identifier for the recording to stop. */
     control_id?: string;
-    [key: string]: Record<string, unknown> | string | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -501,7 +435,7 @@ export interface StopTap {
   stop_tap?: {
     /** ID of the tap to stop. */
     control_id?: string;
-    [key: string]: Record<string, unknown> | string | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -517,14 +451,7 @@ export interface Switch {
     };
     /** Array of SWML methods to execute if no cases match. */
     default?: SWMLMethod[];
-    [key: string]:
-      | Record<string, unknown>
-      | string
-      | {
-          [key: string]: SWMLMethod[];
-        }
-      | SWMLMethod[]
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -544,17 +471,7 @@ export interface Tap {
     rtp_ptime?: number | SWMLVar;
     /** http or https URL to deliver tap status events */
     status_url?: string;
-    [key: string]:
-      | Record<string, unknown>
-      | string
-      | 'speak'
-      | 'listen'
-      | 'both'
-      | 'PCMU'
-      | 'PCMA'
-      | number
-      | SWMLVar
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -566,19 +483,13 @@ export interface Transfer {
     dest: string;
     /** Named parameters to send to transfer destination. */
     params?: {
-      [key: string]: Record<string, unknown>;
+      [key: string]: unknown;
     };
     /** User data, ignored by SignalWire. */
     meta?: {
-      [key: string]: Record<string, unknown>;
+      [key: string]: unknown;
     };
-    [key: string]:
-      | Record<string, unknown>
-      | string
-      | {
-          [key: string]: Record<string, unknown>;
-        }
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -628,22 +539,7 @@ export interface Pay {
     valid_card_types?: string;
     /** Text-to-speech voice to use. Please refer to https://developer.signalwire.com/voice/getting-started/voice-and-languages for more information. */
     voice?: string;
-    [key: string]:
-      | Record<string, unknown>
-      | string
-      | 'dtmf'
-      | number
-      | SWMLVar
-      | PayParameters[]
-      | 'credit-card'
-      | boolean
-      | string
-      | PayPrompts[]
-      | boolean
-      | SWMLVar
-      | 'one-time'
-      | 'reusable'
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -673,16 +569,7 @@ export interface DetectMachine {
     tone?: 'CED' | 'CNG';
     /** If false, the detector will run asynchronously and status_url must be set. */
     wait?: boolean | SWMLVar;
-    [key: string]:
-      | Record<string, unknown>
-      | boolean
-      | SWMLVar
-      | string
-      | number
-      | SWMLVar
-      | 'CED'
-      | 'CNG'
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -691,13 +578,9 @@ export interface UserEvent {
   /** Allows the user to set and send events to the connected client on the call. */
   user_event?: {
     event: {
-      [key: string]: Record<string, unknown>;
+      [key: string]: unknown;
     };
-    [key: string]:
-      | Record<string, unknown>
-      | {
-          [key: string]: Record<string, unknown>;
-        };
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -708,7 +591,7 @@ export type SWMLVar = string;
 export interface AIObject {
   /** A key-value object for storing data that persists throughout the AI session. */
   global_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Hints help the AI agent understand certain words or phrases better. Words that can commonly be misinterpreted can be added to the hints to help the AI speak more accurately. */
   hints?: (string | Hint)[];
@@ -732,7 +615,7 @@ export interface AIObject {
 export interface AmazonBedrockObject {
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script */
   global_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** A JSON object containing parameters as key-value pairs. */
   params?: BedrockParams;
@@ -993,14 +876,7 @@ export interface JoinConferenceObject {
         };
         /** Array of SWML methods to execute if no cases match. */
         default?: SWMLMethod[];
-        [key: string]:
-          | Record<string, unknown>
-          | string
-          | {
-              [key: string]: SWMLMethod[];
-            }
-          | SWMLMethod[]
-          | undefined;
+        [key: string]: unknown;
       }
     | CondParams[];
   [key: string]: unknown;
@@ -1435,16 +1311,7 @@ export interface TranscribeStartAction {
     speech_engine?: SpeechEngine;
     /** The AI prompt that instructs how to summarize the conversation when `ai_summary` is enabled. */
     ai_summary_prompt?: string;
-    [key: string]:
-      | Record<string, unknown>
-      | boolean
-      | SWMLVar
-      | string
-      | number
-      | SWMLVar
-      | TranscribeDirection[]
-      | SpeechEngine
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -1486,18 +1353,7 @@ export interface StartAction {
     speech_engine?: SpeechEngine;
     /** The AI prompt that instructs how to summarize the conversation when `ai_summary` is enabled. */
     ai_summary_prompt?: string;
-    [key: string]:
-      | Record<string, unknown>
-      | string
-      | TranslationFilterPreset
-      | CustomTranslationFilter
-      | boolean
-      | SWMLVar
-      | number
-      | SWMLVar
-      | TranslateDirection[]
-      | SpeechEngine
-      | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -1511,7 +1367,7 @@ export interface InjectAction {
     message: string;
     /** The direction of the message. */
     direction: TranslateDirection;
-    [key: string]: Record<string, unknown> | string | TranslateDirection;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -1671,7 +1527,7 @@ export interface SWAIGIncludes {
   url?: string;
   /** User-defined metadata to pass with the remote function request. */
   meta_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -1800,7 +1656,7 @@ export interface TranscribeSummarizeAction {
     webhook?: string;
     /** The prompt for summarization. */
     prompt?: string;
-    [key: string]: Record<string, unknown> | string | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -1820,7 +1676,7 @@ export interface SummarizeAction {
     webhook?: string;
     /** The AI prompt that instructs how to summarize the conversation. */
     prompt?: string;
-    [key: string]: Record<string, unknown> | string | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -1875,7 +1731,7 @@ export interface UserSWAIGFunction {
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
   meta_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
@@ -1911,7 +1767,7 @@ export interface StartUpHookSWAIGFunction {
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
   meta_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
@@ -1947,7 +1803,7 @@ export interface HangUpHookSWAIGFunction {
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
   meta_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
@@ -1984,7 +1840,7 @@ export interface SummarizeConversationSWAIGFunction {
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
   meta_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
@@ -2010,277 +1866,277 @@ export type FunctionFillers =
   | {
       /** Default language set by the user */
       default: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Bulgarian */
       bg: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Catalan */
       ca: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Chinese (Simplified) */
       zh: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Chinese (Simplified, China) */
       'zh-CN': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Chinese (Simplified Han) */
       'zh-Hans': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Chinese (Traditional, Taiwan) */
       'zh-TW': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Chinese (Traditional Han) */
       'zh-Hant': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Chinese (Traditional, Hong Kong) */
       'zh-HK': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Czech */
       cs: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Danish */
       da: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Danish (Denmark) */
       'da-DK': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Dutch */
       nl: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** English */
       en: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** English (United States) */
       'en-US': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** English (United Kingdom) */
       'en-GB': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** English (New Zealand) */
       'en-NZ': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** English (India) */
       'en-IN': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** English (Australia) */
       'en-AU': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Estonian */
       et: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Finnish */
       fi: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Flemish (Belgian Dutch) */
       'nl-BE': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** French */
       fr: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** French (Canada) */
       'fr-CA': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** German */
       de: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** German (Switzerland) */
       'de-CH': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Greek */
       el: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Hindi */
       hi: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Hungarian */
       hu: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Indonesian */
       id: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Italian */
       it: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Japanese */
       ja: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Korean */
       ko: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Korean (South Korea) */
       'ko-KR': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Latvian */
       lv: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Lithuanian */
       lt: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Malay */
       ms: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Multilingual (Spanish + English) */
       multi: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Norwegian */
       no: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Polish */
       pl: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Portuguese */
       pt: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Portuguese (Brazil) */
       'pt-BR': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Portuguese (Portugal) */
       'pt-PT': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Romanian */
       ro: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Russian */
       ru: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Slovak */
       sk: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Spanish */
       es: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Spanish (Latin America) */
       'es-419': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Swedish */
       sv: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Swedish (Sweden) */
       'sv-SE': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Thai */
       th: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Thai (Thailand) */
       'th-TH': string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Turkish */
       tr: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Ukrainian */
       uk: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     }
   | {
       /** Vietnamese */
       vi: string[];
-      [key: string]: Record<string, unknown> | string[];
+      [key: string]: unknown;
     };
 
 /** The template for picking properties. */
@@ -2293,7 +2149,7 @@ export interface PickPropertiesUserSWAIGFunctionPickedSWAIGFunctionProps {
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
   meta_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
@@ -2316,7 +2172,7 @@ export interface PickPropertiesStartUpHookSWAIGFunctionPickedSWAIGFunctionProps 
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
   meta_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
@@ -2339,7 +2195,7 @@ export interface PickPropertiesHangUpHookSWAIGFunctionPickedSWAIGFunctionProps {
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
   meta_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
@@ -2362,7 +2218,7 @@ export interface PickPropertiesSummarizeConversationSWAIGFunctionPickedSWAIGFunc
   active?: boolean | SWMLVar;
   /** A powerful and flexible environmental variable which can accept arbitrary data that is set initially in the SWML script or from the SWML set_meta_data action. */
   meta_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Scoping token for meta_data. If not supplied, metadata will be scoped to function's `web_hook_url`. Default is set by SignalWire. */
   meta_data_token?: string;
@@ -2509,11 +2365,11 @@ export interface Webhook {
     max?: number | SWMLVar;
     /** The values to append to the output_key. */
     append: string;
-    [key: string]: Record<string, unknown> | string | number | SWMLVar | undefined;
+    [key: string]: unknown;
   };
   /** Any necessary headers for the API call. */
   headers?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** The HTTP method (GET, POST, etc.) for the API call. */
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
@@ -2521,7 +2377,7 @@ export interface Webhook {
   input_args_as_params?: boolean | SWMLVar;
   /** An object of any necessary parameters for the API call. The key is the parameter name and the value is the parameter value. */
   params?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** A string or array of strings that represent the `arguments` that are required to make the webhook request. */
   require_args?: string | string[];
@@ -2619,7 +2475,7 @@ export interface ObjectProperty {
   type?: 'object';
   /** The default object value */
   default?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Nested properties */
   properties?: {
@@ -2759,7 +2615,7 @@ export interface ContextSwitchAction {
     consolidate?: boolean | SWMLVar;
     /** A string serving as simulated user input for the AI Agent. */
     user_prompt?: string;
-    [key: string]: Record<string, unknown> | string | boolean | SWMLVar | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -2778,7 +2634,7 @@ export interface HoldAction {
     | {
         /** The duration to hold the caller in seconds. Can be a number or an object with timeout property. */
         timeout?: number | SWMLVar;
-        [key: string]: Record<string, unknown> | number | SWMLVar | undefined;
+        [key: string]: unknown;
       };
   [key: string]: unknown;
 }
@@ -2790,7 +2646,7 @@ export interface PlaybackBGAction {
     file: string;
     /** Whether to wait for the audio file to finish playing before continuing. Default is `false`. */
     wait?: boolean | SWMLVar;
-    [key: string]: Record<string, unknown> | string | boolean | SWMLVar | undefined;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -2804,7 +2660,7 @@ export interface SayAction {
 export interface SetGlobalDataAction {
   /** A JSON object containing any global data, as a key-value map. This action sets the data in the `global_data` to be globally referenced. */
   set_global_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -2812,7 +2668,7 @@ export interface SetGlobalDataAction {
 export interface SetMetaDataAction {
   /** A JSON object containing any metadata, as a key-value map. This action sets the data in the `meta_data` to be referenced locally in the function. */
   set_meta_data?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -2836,7 +2692,7 @@ export interface ToggleFunctionsAction {
     active: boolean | SWMLVar;
     /** The function names to toggle. */
     function: string | string[];
-    [key: string]: Record<string, unknown> | boolean | SWMLVar | string | string[];
+    [key: string]: unknown;
   }[];
   [key: string]: unknown;
 }
@@ -2846,7 +2702,7 @@ export interface UnsetGlobalDataAction {
   unset_global_data?:
     | string
     | {
-        [key: string]: Record<string, unknown>;
+        [key: string]: unknown;
       };
   [key: string]: unknown;
 }
@@ -2856,7 +2712,7 @@ export interface UnsetMetaDataAction {
   unset_meta_data?:
     | string
     | {
-        [key: string]: Record<string, unknown>;
+        [key: string]: unknown;
       };
   [key: string]: unknown;
 }
@@ -2921,11 +2777,11 @@ export interface ExecuteConfig {
   dest?: string;
   /** Named parameters to send to section or URL */
   params?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** User-defined metadata, ignored by SignalWire */
   meta?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** The list of SWML instructions to be executed when the executed section or URL returns */
   on_return?: SWMLMethod[];
@@ -3068,13 +2924,13 @@ export interface RequestConfig {
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
   /** Object containing HTTP headers to set. Valid header values are Accept, Authorization, Content-Type, Range, and custom X- headers. */
   headers?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** Request body. Content-Type header should be explicitly set, but if not set, the most likely type */
   body?:
     | string
     | {
-        [key: string]: Record<string, unknown>;
+        [key: string]: unknown;
       };
   /** Maximum time in seconds to wait for a response. */
   timeout?: number | SWMLVar;
@@ -3168,11 +3024,11 @@ export interface TransferConfig {
   dest?: string;
   /** Named parameters to send to transfer destination. */
   params?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   /** User data, ignored by SignalWire. */
   meta?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -3248,7 +3104,7 @@ export interface DetectMachineConfig {
 /** Allows the user to set and send events to the connected client on the call. */
 export interface UserEventConfig {
   event?: {
-    [key: string]: Record<string, unknown>;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Description
The OpenAPI/JSON-Schema → TS generator over-nested free-form `object` params, emitting `Record<string, Record<string, unknown>>` where the wire shape is a flat key→value map — so the generated type **rejects a valid payload**. E.g. SWML `Transfer.params` / `Execute.params` are `{ type: object, unevaluatedProperties: {} }` with string-valued examples (`{ department: 'sales', priority: 'high' }`), but the generated `params?: Record<string, Record<string, unknown>>` rejects `{ department: 'sales' }` (a string is not a `Record`).

**Root cause** (`scripts/_gen-common.ts`): the SWML "allow any additional property" idiom is `unevaluatedProperties: {}` (an empty schema). The generator used that empty schema as the Record's **value** type, and `tsType({})` resolves an unconstrained `{}` to `Record<string, unknown>` (the correct top-level open-record form) — so the value **double-wrapped** into `Record<string, Record<string, unknown>>`. (The sister generator `generateVerbTypes.ts` already got this right.)

**Fix:** a new `recordValueType()` helper — in a Record / index-signature **value** position, an empty/unconstrained value schema is `unknown`, not `Record<string, unknown>`, yielding the correct `Record<string, unknown>`.
- A **constrained** value schema (`{ type: 'object' }`, a `$ref`, `{ type: 'string' }`, …) keeps its real type, so genuine map-of-maps are untouched.
- The index-signature path (props-bearing type + `additionalProperties: {}`) collapses to a bare `[key: string]: unknown` — which already absorbs the declared prop types — instead of a redundant `unknown | string | …` union.

Applied to `_gen-common.ts` (shared by all generators), so both the REST types and the SWML verb types are corrected consistently. ~65 `Record<string, Record<string, unknown>>` occurrences across `calling` / `fabric` / `video` / `chat` / `pubsub` and `swml_verbs_generated.ts` are now `Record<string, unknown>`; the two affected method signatures (`global_data`, `event`, `room_meta`, `meta`) in the generated resource classes are fixed too.

Per #19530, these REST types aren't exported to consumers yet, so the wrong types were latent — this corrects them at the source before they're surfaced.

## Type of Change
- [x] Bug fix (generated type rejects a valid wire payload) — code generator + regenerated output

## Related Issues
Closes #19537
Relates to #19366, #19530, #19533

## Testing
- [x] **GEN-FRESH `--check` passes for all four generators** (rest-types / relay-protocol / swaig-payloads / swml-verbs) against `porting-sdk@main` — the committed `*.generated.ts` reproduce exactly from the specs with the fix
- [x] `tsc` clean on all three projects (`src`, `tsconfig.test.json`, `tsconfig.examples.json`)
- [x] `scripts/run-lint.sh` (tsc + eslint + TS-idiom checks) clean on the regenerated files — no redundant-type-constituents / empty-object-type violations
- [x] prettier clean
- [x] 0 remaining `Record<string, Record<string, unknown>>` across `src/`; `Transfer.params` / `Execute.params` now `Record<string, unknown>`; genuine constrained-value Records unaffected

## Additional Notes
Regenerated relay-protocol / swaig / swml-webhook payloads too (shared helper) — they produced no changes (no empty-value-schema pattern there), so only the REST types + SWML verbs moved. Pure generated-type change; no runtime behavior change.