### PR TITLE
feat(rest): RequestOptions envelope — timeout/retries/abort (plan 4.2)

### DIFF
--- a/PORT_SIGNATURE_OMISSIONS.md
+++ b/PORT_SIGNATURE_OMISSIONS.md
@@ -141,6 +141,7 @@ signalwire.skills.spider.skill.SpiderSkill.__init__: TS constructor signature fo
 signalwire.skills.weather_api.skill.WeatherApiSkill.__init__: TS constructor signature follows TS conventions; param shape may differ from Python kwargs
 signalwire.utils.schema_utils.SchemaUtils.__init__: TS constructor signature follows TS conventions; param shape may differ from Python kwargs
 signalwire.web.web_service.WebService.__init__: TS constructor signature follows TS conventions; param shape may differ from Python kwargs
+signalwire.rest._request_options.RequestOptions.__init__: TS constructor signature follows TS conventions; param shape may differ from Python kwargs (RequestOptions(init?: RequestOptionsInit) collapses the reference's timeout/retries/retry_on_status/retry_backoff/abort_signal positional-or-keyword params into one options-object init; same fields, same resolved values).
 
 ## Idiom: TS fluent API returns this
 
@@ -254,6 +255,14 @@ signalwire.relay.call.Call.amazon_bedrock: TS amazonBedrock(options) types the c
 signalwire.relay.call.Call.on: TS on(event, handler) types handler as the plain callback (event) => void; Python wraps it in an EventHandler class. Same subscription; EventHandler is a Python-internal wrapper.
 signalwire.relay.client.RelayClient.on_call: TS onCall(handler) types handler as (call) => void and returns void; Python's CallHandler is a Python-internal wrapper class returned for decorator use. Same registration.
 signalwire.relay.client.RelayClient.on_message: TS onMessage(handler) types handler as (message) => void and returns void; Python's MessageHandler is a Python-internal wrapper. Same registration.
+signalwire.rest._base.HttpClient.get: ts-options-object: the request_options param is typed as RequestOptionsInit (the plain-object init shape of the RequestOptions value class) so a call site passes an object literal; the reference types it as the RequestOptions class. Identical field set and resolved values; the retry/backoff behavior is wire-proven by the ERROR-ENVELOPE differ.
+signalwire.rest._base.HttpClient.post: ts-options-object: request_options typed as RequestOptionsInit (the object-literal init of the RequestOptions value class) vs the reference's RequestOptions class; identical fields and resolved values, same wire.
+signalwire.rest._base.HttpClient.put: ts-options-object: request_options typed as RequestOptionsInit (the object-literal init of the RequestOptions value class) vs the reference's RequestOptions class; identical fields and resolved values, same wire.
+signalwire.rest._base.HttpClient.patch: ts-options-object: request_options typed as RequestOptionsInit (the object-literal init of the RequestOptions value class) vs the reference's RequestOptions class; identical fields and resolved values, same wire.
+signalwire.rest._base.HttpClient.delete: ts-options-object: request_options typed as RequestOptionsInit (the object-literal init of the RequestOptions value class) vs the reference's RequestOptions class; identical fields and resolved values, same wire.
+signalwire.rest._request_options.RequestOptions.merge: ts-options-object: the override param is typed as RequestOptionsInit (the object-literal init of the RequestOptions value class) so a caller passes a plain object; the reference types it as RequestOptions. Same shallow-merge semantics over an identical field set.
+signalwire.rest._request_options.resolve: ts-options-object: the client_default/per_request params are typed as RequestOptionsInit (the object-literal init of the RequestOptions value class) vs the reference's RequestOptions; identical fields, identical resolve-over-default semantics.
+signalwire.rest._request_options.RequestOptions.abort_signal: field-vs-accessor idiom: the reference dataclass surfaces abort_signal as a read accessor; TS carries it as a public readonly field on the RequestOptions value object (RequestOptions.abortSignal). Same value, read the same way — a TS field is the idiomatic analog of a Python dataclass field.
 
 ## Reference-oracle gap: signalwire.livewire not in the signatures oracle
 

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -14529,6 +14529,12 @@
                   "name": "path",
                   "type": "string",
                   "required": true
+                },
+                {
+                  "name": "request_options",
+                  "type": "class:signalwire.rest._request_options.RequestOptionsInit",
+                  "required": false,
+                  "default": null
                 }
               ],
               "returns": "any"
@@ -14549,6 +14555,12 @@
                   "type": "dict<string,any>",
                   "required": false,
                   "default": null
+                },
+                {
+                  "name": "request_options",
+                  "type": "class:signalwire.rest._request_options.RequestOptionsInit",
+                  "required": false,
+                  "default": null
                 }
               ],
               "returns": "any"
@@ -14567,6 +14579,12 @@
                 {
                   "name": "body",
                   "type": "any",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "request_options",
+                  "type": "class:signalwire.rest._request_options.RequestOptionsInit",
                   "required": false,
                   "default": null
                 }
@@ -14595,6 +14613,12 @@
                   "type": "dict<string,any>",
                   "required": false,
                   "default": null
+                },
+                {
+                  "name": "request_options",
+                  "type": "class:signalwire.rest._request_options.RequestOptionsInit",
+                  "required": false,
+                  "default": null
                 }
               ],
               "returns": "any"
@@ -14613,6 +14637,12 @@
                 {
                   "name": "body",
                   "type": "any",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "request_options",
+                  "type": "class:signalwire.rest._request_options.RequestOptionsInit",
                   "required": false,
                   "default": null
                 }
@@ -14759,6 +14789,80 @@
               "returns": "void"
             }
           }
+        }
+      }
+    },
+    "signalwire.rest._request_options": {
+      "classes": {
+        "RequestOptions": {
+          "methods": {
+            "__init__": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "init",
+                  "type": "class:signalwire.rest._request_options.RequestOptionsInit",
+                  "required": false,
+                  "default": {}
+                }
+              ],
+              "returns": "void"
+            },
+            "merge": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "override",
+                  "type": "class:signalwire.rest._request_options.RequestOptionsInit",
+                  "required": true
+                }
+              ],
+              "returns": "class:signalwire.rest._request_options.RequestOptions"
+            }
+          }
+        }
+      },
+      "functions": {
+        "resolve": {
+          "params": [
+            {
+              "name": "client_default",
+              "type": "class:signalwire.rest._request_options.RequestOptionsInit",
+              "required": true
+            },
+            {
+              "name": "per_request",
+              "type": "class:signalwire.rest._request_options.RequestOptionsInit",
+              "required": true
+            }
+          ],
+          "returns": "class:signalwire.rest._request_options._EffectiveOptions"
+        },
+        "status_is_retryable": {
+          "params": [
+            {
+              "name": "method",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "status",
+              "type": "float",
+              "required": true
+            },
+            {
+              "name": "opts",
+              "type": "class:signalwire.rest._request_options._EffectiveOptions",
+              "required": true
+            }
+          ],
+          "returns": "bool"
         }
       }
     },

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated_from": "signalwire-typescript @ 84a1b2b508c503bd4fe1b22bdcd551a95a9d09c0",
+  "generated_from": "signalwire-typescript @ a76ed3e3cea57d2f5e40d80e9efa6c0d6ad190c1",
   "typescript_version": "6.0.3",
   "modules": {
     "signalwire": {
@@ -1669,6 +1669,17 @@
       "functions": [
         "paginate",
         "paginate_all"
+      ]
+    },
+    "signalwire.rest._request_options": {
+      "classes": {
+        "RequestOptions": [
+          "merge"
+        ]
+      },
+      "functions": [
+        "resolve",
+        "status_is_retryable"
       ]
     },
     "signalwire.rest.client": {

--- a/scripts/enumerate-signatures.ts
+++ b/scripts/enumerate-signatures.ts
@@ -83,6 +83,10 @@ const TS_MODULE_ALIASES: Record<string, string> = {
   'src/rest/index.ts': 'signalwire.rest.client',
   'src/rest/HttpClient.ts': 'signalwire.rest._base',
   'src/rest/RestError.ts': 'signalwire.rest._base',
+  // RequestOptions envelope (plan 4.2): the reference keeps it in its own module
+  // signalwire/rest/_request_options.py; map the TS file so RequestOptions +
+  // resolve/status_is_retryable compare 1:1 with the oracle.
+  'src/rest/RequestOptions.ts': 'signalwire.rest._request_options',
   // Base resource classes — Python keeps these under signalwire.rest._base.
   'src/rest/base/BaseResource.ts': 'signalwire.rest._base',
   'src/rest/base/CrudResource.ts': 'signalwire.rest._base',

--- a/scripts/enumerate-surface.ts
+++ b/scripts/enumerate-surface.ts
@@ -212,6 +212,10 @@ const TS_MODULE_ALIASES: Record<string, string> = {
   'src/rest/index.ts': 'signalwire.rest.client',
   'src/rest/HttpClient.ts': 'signalwire.rest._base',
   'src/rest/RestError.ts': 'signalwire.rest._base',
+  // RequestOptions envelope (plan 4.2): the reference keeps it in its own
+  // module `signalwire/rest/_request_options.py`; map the TS file to match so
+  // RequestOptions + resolve/status_is_retryable compare 1:1 with the oracle.
+  'src/rest/RequestOptions.ts': 'signalwire.rest._request_options',
   'src/rest/callHandler.ts': 'signalwire.rest.call_handler',
   'src/rest/pagination.ts': 'signalwire.rest._pagination',
   'src/rest/base/BaseResource.ts': 'signalwire.rest._base',

--- a/scripts/envelope-dump.ts
+++ b/scripts/envelope-dump.ts
@@ -22,6 +22,9 @@
  *
  * The corpus below is the TS-native mirror of porting-sdk/scripts/envelope_corpus.py
  * (the single source of truth). When that corpus grows, add the new case here.
+ * As of plan 4.2 it also covers the RequestOptions envelope: request_options
+ * (retries / retry_backoff / timeout), scenario_repeat (arm the SAME override N
+ * times FIFO), and POST cases (a call.method/body + a distinct endpoint/path).
  *
  * Run from the signalwire-typescript repo root (the mock is discovered via the
  * porting-sdk adjacency walk, or reused via MOCK_SIGNALWIRE_PORT):
@@ -45,6 +48,7 @@ import { existsSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { HttpClient as HttpClientType } from '../src/rest/HttpClient.js';
+import type { RequestOptionsInit } from '../src/rest/RequestOptions.js';
 
 const { HttpClient } = await import('../src/rest/HttpClient.js');
 const { RestError } = await import('../src/rest/RestError.js');
@@ -55,10 +59,13 @@ const PROJECT = 'envelope_proj';
 const TOKEN = 'envelope_tok';
 const AUTH_HEADER = 'Basic ' + Buffer.from(`${PROJECT}:${TOKEN}`).toString('base64');
 
-// The endpoint every case targets: fabric.list_fabric_addresses -> GET
-// /api/fabric/addresses (a list route present in every port's client).
+// The default endpoint every GET case targets: fabric.list_fabric_addresses ->
+// GET /api/fabric/addresses (a list route present in every port's client).
 const ENDPOINT = 'fabric.list_fabric_addresses';
 const PATH = '/api/fabric/addresses';
+// A POST route present in every port — for the idempotency-asymmetry cases.
+const CREATE_ENDPOINT = 'relay-rest.create_address';
+const CREATE_PATH = '/api/relay/rest/addresses';
 
 interface Scenario {
   status: number;
@@ -67,17 +74,40 @@ interface Scenario {
   delay_ms?: number;
 }
 
+interface CaseCall {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+interface CaseRequestOptions {
+  retries?: number;
+  retry_backoff?: number;
+  timeout?: number;
+}
+
 interface Case {
   id: string;
+  endpoint: string;
+  call: CaseCall;
   scenario: Scenario | null;
+  /** Arm the SAME scenario override N times (FIFO). Default 1. */
+  scenarioRepeat?: number;
+  /** RequestOptions to pass for this call (absent => port default, retries 0). */
+  requestOptions?: CaseRequestOptions;
   transport?: boolean;
 }
 
 // Mirror of porting-sdk/scripts/envelope_corpus.py CORPUS.
+const GET_CALL: CaseCall = { method: 'GET', path: PATH };
+const CREATE_CALL: CaseCall = { method: 'POST', path: CREATE_PATH, body: { label: 'x' } };
+
 const CORPUS: Case[] = [
-  { id: 'envelope_200_success', scenario: null },
+  { id: 'envelope_200_success', endpoint: ENDPOINT, call: GET_CALL, scenario: null },
   {
     id: 'envelope_404_typed',
+    endpoint: ENDPOINT,
+    call: GET_CALL,
     scenario: {
       status: 404,
       response: { errors: [{ code: 'NOT_FOUND', message: 'no such address' }] },
@@ -85,6 +115,8 @@ const CORPUS: Case[] = [
   },
   {
     id: 'envelope_429_retry_after',
+    endpoint: ENDPOINT,
+    call: GET_CALL,
     scenario: {
       status: 429,
       response: { errors: [{ code: 'RATE_LIMITED', message: 'slow down' }] },
@@ -93,6 +125,8 @@ const CORPUS: Case[] = [
   },
   {
     id: 'envelope_503_unavailable',
+    endpoint: ENDPOINT,
+    call: GET_CALL,
     scenario: {
       status: 503,
       response: { errors: [{ code: 'UNAVAILABLE', message: 'maintenance' }] },
@@ -100,10 +134,14 @@ const CORPUS: Case[] = [
   },
   {
     id: 'envelope_500_malformed_body',
+    endpoint: ENDPOINT,
+    call: GET_CALL,
     scenario: { status: 500, response: 'not-json-at-all <garbage' },
   },
   {
     id: 'envelope_200_with_error_body',
+    endpoint: ENDPOINT,
+    call: GET_CALL,
     scenario: {
       status: 200,
       response: { errors: [{ code: 'SOFT_FAIL', message: 'ignored on 2xx' }] },
@@ -111,13 +149,65 @@ const CORPUS: Case[] = [
   },
   {
     id: 'envelope_503_delayed',
+    endpoint: ENDPOINT,
+    call: GET_CALL,
     scenario: {
       status: 503,
       response: { errors: [{ code: 'UNAVAILABLE', message: 'slow-fail' }] },
       delay_ms: 200,
     },
   },
-  { id: 'envelope_transport_refused', scenario: null, transport: true },
+  {
+    id: 'envelope_transport_refused',
+    endpoint: ENDPOINT,
+    call: GET_CALL,
+    scenario: null,
+    transport: true,
+  },
+
+  // ---- RequestOptions envelope — opt-in retry (plan 4.2). retry_backoff=0 so
+  // the differ never waits on wall-clock; the observable is the attempt COUNT.
+  {
+    id: 'envelope_get_retry_once_succeeds',
+    endpoint: ENDPOINT,
+    call: GET_CALL,
+    scenario: {
+      status: 503,
+      response: { errors: [{ code: 'UNAVAILABLE', message: 'transient' }] },
+    },
+    requestOptions: { retries: 1, retry_backoff: 0 },
+  },
+  {
+    id: 'envelope_get_retry_exhausted',
+    endpoint: ENDPOINT,
+    call: GET_CALL,
+    scenario: {
+      status: 503,
+      response: { errors: [{ code: 'UNAVAILABLE', message: 'down' }] },
+    },
+    requestOptions: { retries: 1, retry_backoff: 0 },
+    scenarioRepeat: 2,
+  },
+  {
+    id: 'envelope_post_500_not_retried',
+    endpoint: CREATE_ENDPOINT,
+    call: CREATE_CALL,
+    scenario: {
+      status: 500,
+      response: { errors: [{ code: 'SERVER_ERROR', message: 'boom' }] },
+    },
+    requestOptions: { retries: 2, retry_backoff: 0 },
+  },
+  {
+    id: 'envelope_post_503_retried',
+    endpoint: CREATE_ENDPOINT,
+    call: CREATE_CALL,
+    scenario: {
+      status: 503,
+      response: { errors: [{ code: 'UNAVAILABLE', message: 'throttled' }] },
+    },
+    requestOptions: { retries: 1, retry_backoff: 0 },
+  },
 ];
 
 interface Artifact {
@@ -279,13 +369,23 @@ interface JournalEntry {
   path: string;
 }
 
-async function journalCount(baseUrl: string): Promise<number> {
+async function journalCount(baseUrl: string, path: string): Promise<number> {
   const resp = await fetch(
     `${baseUrl}/__mock__/journal?session_id=${encodeURIComponent(AUTH_HEADER)}`,
   );
   const data = (await resp.json()) as JournalEntry[] | { entries?: JournalEntry[] };
   const entries = Array.isArray(data) ? data : (data.entries ?? []);
-  return entries.filter((e) => e.path === PATH).length;
+  return entries.filter((e) => e.path === path).length;
+}
+
+/** Translate a corpus request_options spec into the SDK's RequestOptions. */
+function toRequestOptions(spec: CaseRequestOptions | undefined): RequestOptionsInit | undefined {
+  if (!spec) return undefined;
+  const opts: RequestOptionsInit = {};
+  if (spec.retries !== undefined) opts.retries = spec.retries;
+  if (spec.retry_backoff !== undefined) opts.retryBackoff = spec.retry_backoff;
+  if (spec.timeout !== undefined) opts.timeout = spec.timeout;
+  return opts;
 }
 
 async function runCase(server: MockServer, c: Case): Promise<Artifact> {
@@ -294,10 +394,15 @@ async function runCase(server: MockServer, c: Case): Promise<Artifact> {
   await post(`${server.url}/__mock__/scenarios/reset`);
 
   if (c.scenario !== null) {
-    await post(
-      `${server.url}/__mock__/scenarios/${ENDPOINT}?session_id=${encodeURIComponent(AUTH_HEADER)}`,
-      c.scenario,
-    );
+    // scenarioRepeat arms the SAME override N times (FIFO) so a retry-armed
+    // case sees the failure on every attempt.
+    const repeat = c.scenarioRepeat ?? 1;
+    for (let i = 0; i < repeat; i++) {
+      await post(
+        `${server.url}/__mock__/scenarios/${c.endpoint}?session_id=${encodeURIComponent(AUTH_HEADER)}`,
+        c.scenario,
+      );
+    }
   }
 
   // A transport case points the client at a DEAD port (bind a free port then
@@ -309,6 +414,7 @@ async function runCase(server: MockServer, c: Case): Promise<Artifact> {
   }
 
   const client: HttpClientType = new HttpClient({ baseUrl, project: PROJECT, token: TOKEN });
+  const reqOpts = toRequestOptions(c.requestOptions);
 
   const artifact: Artifact = {
     raised: false,
@@ -319,7 +425,11 @@ async function runCase(server: MockServer, c: Case): Promise<Artifact> {
   };
 
   try {
-    await client.get(PATH);
+    if (c.call.method === 'POST') {
+      await client.post(c.call.path, c.call.body, undefined, reqOpts);
+    } else {
+      await client.get(c.call.path, undefined, reqOpts);
+    }
   } catch (e) {
     artifact.raised = true;
     if (e instanceof RestError) {
@@ -337,7 +447,7 @@ async function runCase(server: MockServer, c: Case): Promise<Artifact> {
     }
   }
 
-  artifact.request_count = c.transport ? 0 : await journalCount(server.url);
+  artifact.request_count = c.transport ? 0 : await journalCount(server.url, c.call.path);
   return artifact;
 }
 

--- a/src/rest/HttpClient.ts
+++ b/src/rest/HttpClient.ts
@@ -3,6 +3,11 @@
  *
  * All methods return parsed JSON. Throws RestError on non-2xx responses.
  * Returns {} on 204 No Content.
+ *
+ * Transport behavior (timeout, opt-in retry with an idempotency-aware policy +
+ * exponential backoff, cooperative cancellation) is governed by the
+ * {@link RequestOptions} envelope (plan 4.2): a client default stored here, plus
+ * an optional per-request override each verb accepts. See RequestOptions.ts.
  */
 
 import { createRequire } from 'node:module';
@@ -10,6 +15,12 @@ import { getLogger } from '../Logger.js';
 import { RestError, RestTransportError } from './RestError.js';
 import type { SignalWireErrorBody } from '../PlatformContracts.js';
 import type { HttpClientOptions, QueryParams } from './types.js';
+import {
+  resolve,
+  statusIsRetryable,
+  type _EffectiveOptions,
+  type RequestOptionsInit,
+} from './RequestOptions.js';
 
 const logger = getLogger('rest_client');
 
@@ -37,11 +48,18 @@ function buildUserAgent(): string {
 
 const USER_AGENT = buildUserAgent();
 
+/** Backoff sleep between retries (a Promise-based delay). */
+function sleep(seconds: number): Promise<void> {
+  if (seconds <= 0) return Promise.resolve();
+  return new Promise((r) => setTimeout(r, seconds * 1000));
+}
+
 /**
  * Low-level HTTP client used by every REST namespace resource.
  *
- * Handles Basic Auth, JSON encoding/decoding, and error normalisation
- * ({@link RestError} on non-2xx). Normally you do not instantiate this
+ * Handles Basic Auth, JSON encoding/decoding, error normalisation
+ * ({@link RestError} on non-2xx), and the {@link RequestOptions} transport
+ * envelope (timeout / retry / abort). Normally you do not instantiate this
  * directly — construct a {@link RestClient} instead.
  */
 export class HttpClient {
@@ -49,13 +67,16 @@ export class HttpClient {
   readonly baseUrl: string;
   private readonly _authHeader: string;
   private readonly _fetch: typeof globalThis.fetch;
+  /** Client-default request options, shallow-overridden per request. */
+  private readonly _requestOptions?: RequestOptionsInit;
 
   /**
    * Build a new HTTP client.
    *
    * @param options - Connection options. Either `host` (bare hostname;
    *   `https://` is prepended automatically) or `baseUrl` (fully-qualified)
-   *   must be provided along with `project` + `token`.
+   *   must be provided along with `project` + `token`. An optional
+   *   `requestOptions` sets the client-default transport envelope.
    * @throws {Error} When neither `host` nor `baseUrl` is supplied.
    */
   constructor(options: HttpClientOptions) {
@@ -71,6 +92,15 @@ export class HttpClient {
     this._authHeader =
       'Basic ' + Buffer.from(`${options.project}:${options.token}`).toString('base64');
     this._fetch = options.fetchImpl ?? globalThis.fetch;
+    this._requestOptions = options.requestOptions;
+  }
+
+  /** Parse a `Retry-After` header (delta-seconds form) if present, else null. */
+  private _retryAfterSeconds(resp: Response): number | null {
+    const value = resp.headers.get('Retry-After');
+    if (value === null) return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null; // HTTP-date form: fall back to backoff
   }
 
   private async _request<T = unknown>(
@@ -78,6 +108,7 @@ export class HttpClient {
     path: string,
     body?: unknown,
     params?: QueryParams,
+    requestOptions?: RequestOptionsInit,
   ): Promise<T> {
     let url = path.startsWith('http') ? path : `${this.baseUrl}${path}`;
 
@@ -90,6 +121,7 @@ export class HttpClient {
       if (qsStr) url += (url.includes('?') ? '&' : '?') + qsStr;
     }
 
+    const opts = resolve(this._requestOptions, requestOptions);
     logger.debug(`${method} ${url}`);
 
     const headers: Record<string, string> = {
@@ -100,41 +132,90 @@ export class HttpClient {
     if (body !== undefined) {
       headers['Content-Type'] = 'application/json';
     }
+    const encodedBody = body !== undefined ? JSON.stringify(body) : undefined;
 
-    let resp: Response;
-    try {
-      resp = await this._fetch(url, {
-        method,
-        headers,
-        body: body !== undefined ? JSON.stringify(body) : undefined,
-      });
-    } catch (err) {
-      // Transport failure (connection refused / DNS / reset / TLS): fetch rejects
-      // (typically a TypeError) and the request never produced a response. Wrap it
-      // in the typed error family so a caller catching RestError handles it too,
-      // instead of a bare fetch TypeError leaking out.
-      const message = err instanceof Error ? err.message : String(err);
-      throw new RestTransportError(message, url, method);
-    }
-
-    if (!resp.ok) {
-      const text = await resp.text();
-      let errBody: string | SignalWireErrorBody = text;
-      try {
-        errBody = JSON.parse(text) as SignalWireErrorBody;
-      } catch {
-        // Response was not valid JSON — keep as plain string.
+    // total attempts = retries + 1; retry on a retryable status (idempotency-
+    // aware) or a transport error, honoring Retry-After then exponential
+    // backoff. abortSignal is checked cooperatively before every attempt AND
+    // passed to fetch for TRUE in-flight abort.
+    let attempt = 0;
+    for (;;) {
+      attempt += 1;
+      if (opts.abortSignal?.aborted) {
+        // Cancelled before this attempt — surface as the transport-error family
+        // (no response was produced), not a bare exception.
+        throw new RestTransportError('request cancelled by abortSignal', url, method);
       }
-      throw new RestError(resp.status, errBody, url, method);
-    }
 
-    if (resp.status === 204) {
-      return {} as T;
-    }
+      let resp: Response;
+      try {
+        resp = await this._fetch(url, {
+          method,
+          headers,
+          body: encodedBody,
+          signal: this._attemptSignal(opts),
+        });
+      } catch (err) {
+        // Transport failure (connection refused / DNS / reset / TLS / timeout /
+        // abort): fetch rejects and the request never produced a response.
+        // Retry if attempts remain, else wrap in the typed error family so a
+        // caller catching RestError handles it too.
+        if (this._isAbort(err) && opts.abortSignal?.aborted) {
+          // A user-driven abort (not a timeout) is terminal — do not retry.
+          throw new RestTransportError('request cancelled by abortSignal', url, method);
+        }
+        if (attempt <= opts.retries) {
+          await sleep(opts.retryBackoff * 2 ** (attempt - 1));
+          continue;
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        throw new RestTransportError(message, url, method);
+      }
 
-    const text = await resp.text();
-    if (!text) return {} as T;
-    return JSON.parse(text) as T;
+      if (!resp.ok) {
+        if (attempt <= opts.retries && statusIsRetryable(method, resp.status, opts)) {
+          let delay = this._retryAfterSeconds(resp);
+          if (delay === null) delay = opts.retryBackoff * 2 ** (attempt - 1);
+          await sleep(delay);
+          continue;
+        }
+        const text = await resp.text();
+        let errBody: string | SignalWireErrorBody = text;
+        try {
+          errBody = JSON.parse(text) as SignalWireErrorBody;
+        } catch {
+          // Response was not valid JSON — keep as plain string.
+        }
+        throw new RestError(resp.status, errBody, url, method);
+      }
+
+      if (resp.status === 204) {
+        return {} as T;
+      }
+
+      const text = await resp.text();
+      if (!text) return {} as T;
+      return JSON.parse(text) as T;
+    }
+  }
+
+  /**
+   * Build the per-attempt `AbortSignal` fed to fetch: the caller's abortSignal
+   * (TRUE in-flight cancellation) combined with a per-attempt timeout. A fresh
+   * timeout is created for each attempt so the wall-clock budget is per attempt,
+   * matching the contract. When neither applies, returns undefined.
+   */
+  private _attemptSignal(opts: _EffectiveOptions): AbortSignal | undefined {
+    const timeoutSignal = opts.timeout > 0 ? AbortSignal.timeout(opts.timeout * 1000) : undefined;
+    if (opts.abortSignal && timeoutSignal) {
+      return AbortSignal.any([opts.abortSignal, timeoutSignal]);
+    }
+    return opts.abortSignal ?? timeoutSignal;
+  }
+
+  /** Whether an error is an AbortError (fetch abort or timeout). */
+  private _isAbort(err: unknown): boolean {
+    return err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
   }
 
   /**
@@ -143,11 +224,16 @@ export class HttpClient {
    * @typeParam T - Expected response body type.
    * @param path - Absolute URL or path relative to {@link HttpClient.baseUrl}.
    * @param params - Optional query parameters; `undefined` values are skipped.
+   * @param requestOptions - Optional per-request transport envelope override.
    * @returns The parsed JSON body, or `{}` on `204 No Content`.
    * @throws {RestError} On any non-2xx HTTP response.
    */
-  async get<T = unknown>(path: string, params?: QueryParams): Promise<T> {
-    return this._request<T>('GET', path, undefined, params);
+  async get<T = unknown>(
+    path: string,
+    params?: QueryParams,
+    requestOptions?: RequestOptionsInit,
+  ): Promise<T> {
+    return this._request<T>('GET', path, undefined, params, requestOptions);
   }
 
   /**
@@ -157,11 +243,17 @@ export class HttpClient {
    * @param path - Absolute URL or path relative to {@link HttpClient.baseUrl}.
    * @param body - JSON-serialisable request body. Omit to send no body.
    * @param params - Optional query parameters appended to the URL.
+   * @param requestOptions - Optional per-request transport envelope override.
    * @returns The parsed JSON body, or `{}` on `204 No Content`.
    * @throws {RestError} On any non-2xx HTTP response.
    */
-  async post<T = unknown>(path: string, body?: unknown, params?: QueryParams): Promise<T> {
-    return this._request<T>('POST', path, body, params);
+  async post<T = unknown>(
+    path: string,
+    body?: unknown,
+    params?: QueryParams,
+    requestOptions?: RequestOptionsInit,
+  ): Promise<T> {
+    return this._request<T>('POST', path, body, params, requestOptions);
   }
 
   /**
@@ -170,11 +262,16 @@ export class HttpClient {
    * @typeParam T - Expected response body type.
    * @param path - Absolute URL or path relative to {@link HttpClient.baseUrl}.
    * @param body - JSON-serialisable request body.
+   * @param requestOptions - Optional per-request transport envelope override.
    * @returns The parsed JSON body, or `{}` on `204 No Content`.
    * @throws {RestError} On any non-2xx HTTP response.
    */
-  async put<T = unknown>(path: string, body?: unknown): Promise<T> {
-    return this._request<T>('PUT', path, body);
+  async put<T = unknown>(
+    path: string,
+    body?: unknown,
+    requestOptions?: RequestOptionsInit,
+  ): Promise<T> {
+    return this._request<T>('PUT', path, body, undefined, requestOptions);
   }
 
   /**
@@ -183,11 +280,16 @@ export class HttpClient {
    * @typeParam T - Expected response body type.
    * @param path - Absolute URL or path relative to {@link HttpClient.baseUrl}.
    * @param body - JSON-serialisable partial request body.
+   * @param requestOptions - Optional per-request transport envelope override.
    * @returns The parsed JSON body, or `{}` on `204 No Content`.
    * @throws {RestError} On any non-2xx HTTP response.
    */
-  async patch<T = unknown>(path: string, body?: unknown): Promise<T> {
-    return this._request<T>('PATCH', path, body);
+  async patch<T = unknown>(
+    path: string,
+    body?: unknown,
+    requestOptions?: RequestOptionsInit,
+  ): Promise<T> {
+    return this._request<T>('PATCH', path, body, undefined, requestOptions);
   }
 
   /**
@@ -195,10 +297,11 @@ export class HttpClient {
    *
    * @typeParam T - Expected response body type.
    * @param path - Absolute URL or path relative to {@link HttpClient.baseUrl}.
+   * @param requestOptions - Optional per-request transport envelope override.
    * @returns The parsed JSON body, or `{}` on `204 No Content`.
    * @throws {RestError} On any non-2xx HTTP response.
    */
-  async delete<T = unknown>(path: string): Promise<T> {
-    return this._request<T>('DELETE', path);
+  async delete<T = unknown>(path: string, requestOptions?: RequestOptionsInit): Promise<T> {
+    return this._request<T>('DELETE', path, undefined, undefined, requestOptions);
   }
 }

--- a/src/rest/RequestOptions.ts
+++ b/src/rest/RequestOptions.ts
@@ -1,0 +1,169 @@
+/**
+ * RequestOptions — the REST request-options envelope (plan 4.2).
+ *
+ * A single value object controlling per-request transport behavior: timeout,
+ * retries (with an idempotency-aware retry policy + exponential backoff), and
+ * cooperative cancellation. Supplied at two levels:
+ *
+ * - **Client default**: `new RestClient({ ..., requestOptions })` stored on the
+ *   {@link HttpClient} and applied to every request.
+ * - **Per-request override**: each verb accepts an optional `requestOptions`
+ *   that *shallow-overrides* the client default for that one call — an unset
+ *   (`undefined`) field falls back to the client default, then the built-in
+ *   default.
+ *
+ * The timeout + retry semantics are a wire-observable contract (the server sees
+ * N attempts and honors the backoff ordering). `abortSignal`
+ * fidelity is per-port idiom: the field exists in every port. In TypeScript the
+ * primitive is the native {@link AbortSignal}, which is passed straight to
+ * `fetch`, so cancellation is TRUE in-flight abort (an in-progress request is
+ * interrupted), not merely a between-attempt check — the strongest fidelity of
+ * any port. It is *also* checked before each attempt so an already-aborted
+ * signal raises before the send.
+ *
+ * Mirrors `signalwire-python`'s `signalwire/rest/_request_options.py`
+ * ``RequestOptions`` dataclass (a value object with a ``merge`` method).
+ */
+
+/**
+ * Plain-object initializer for {@link RequestOptions}. All fields optional;
+ * `undefined` = inherit (fall back to the client default, then the built-in).
+ * Every REST verb accepts this directly, so a call site passes an object
+ * literal — `client.get(path, params, { retries: 1 })` — without constructing a
+ * class instance.
+ */
+export interface RequestOptionsInit {
+  /**
+   * Max wall-clock seconds per attempt; on exceed the request raises the
+   * transport-error type ({@link RestTransportError}). Built-in default `30.0`.
+   */
+  timeout?: number;
+  /**
+   * Number of RETRY attempts (total attempts = `retries + 1`) on a retryable
+   * failure. Built-in default `0` (opt-in resilience — the no-retry behavior
+   * stays the default; a caller opts into retries).
+   */
+  retries?: number;
+  /**
+   * HTTP statuses that trigger a retry for an idempotent method. Built-in
+   * `{429, 500, 502, 503, 504}`.
+   */
+  retryOnStatus?: ReadonlySet<number>;
+  /**
+   * Base seconds for exponential backoff between retries
+   * (`backoff * 2 ** (attempt - 1)`), honoring `Retry-After` when present.
+   * Built-in `0.5`.
+   */
+  retryBackoff?: number;
+  /**
+   * Native cancellation primitive; passed straight to `fetch` for TRUE
+   * in-flight abort, and also checked before each attempt. Built-in none.
+   */
+  abortSignal?: AbortSignal;
+}
+
+// The built-in defaults (the contract floor). `undefined` on a RequestOptions
+// field means "inherit"; these are what an unset field resolves to at apply-time.
+export const DEFAULT_TIMEOUT = 30.0;
+export const DEFAULT_RETRIES = 0;
+export const DEFAULT_RETRY_ON_STATUS: ReadonlySet<number> = new Set([429, 500, 502, 503, 504]);
+export const DEFAULT_RETRY_BACKOFF = 0.5;
+
+/**
+ * Per-request transport options value object. Mirrors the Python reference's
+ * ``RequestOptions`` dataclass: all fields optional (`undefined` = inherit),
+ * plus a {@link merge} method for the per-request-over-client-default shallow
+ * merge. A call site may pass either an instance or a plain
+ * {@link RequestOptionsInit} object literal — every verb normalizes both.
+ */
+export class RequestOptions {
+  readonly timeout?: number;
+  readonly retries?: number;
+  readonly retryOnStatus?: ReadonlySet<number>;
+  readonly retryBackoff?: number;
+  readonly abortSignal?: AbortSignal;
+
+  constructor(init: RequestOptionsInit = {}) {
+    this.timeout = init.timeout;
+    this.retries = init.retries;
+    this.retryOnStatus = init.retryOnStatus;
+    this.retryBackoff = init.retryBackoff;
+    this.abortSignal = init.abortSignal;
+  }
+
+  /**
+   * Return a new RequestOptions with any set (non-`undefined`) field of
+   * `override` applied over this one. The per-request-over-client-default
+   * shallow merge: an unset field on `override` leaves this value intact.
+   */
+  merge(override: RequestOptionsInit | undefined): RequestOptions {
+    if (!override) return this;
+    return new RequestOptions({
+      timeout: override.timeout ?? this.timeout,
+      retries: override.retries ?? this.retries,
+      retryOnStatus: override.retryOnStatus ?? this.retryOnStatus,
+      retryBackoff: override.retryBackoff ?? this.retryBackoff,
+      abortSignal: override.abortSignal ?? this.abortSignal,
+    });
+  }
+}
+
+/** A RequestOptions with every field resolved to a concrete value. */
+export interface _EffectiveOptions {
+  timeout: number;
+  retries: number;
+  retryOnStatus: ReadonlySet<number>;
+  retryBackoff: number;
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Resolve the effective options: per-request over client-default over built-in.
+ *
+ * `undefined` on any field inherits the next level down; the built-in defaults
+ * are the floor. The result has every field concrete.
+ */
+export function resolve(
+  clientDefault: RequestOptionsInit | undefined,
+  perRequest: RequestOptionsInit | undefined,
+): _EffectiveOptions {
+  const base = new RequestOptions(clientDefault ?? {});
+  const m = base.merge(perRequest);
+  return {
+    timeout: m.timeout ?? DEFAULT_TIMEOUT,
+    retries: m.retries ?? DEFAULT_RETRIES,
+    retryOnStatus: m.retryOnStatus ?? DEFAULT_RETRY_ON_STATUS,
+    retryBackoff: m.retryBackoff ?? DEFAULT_RETRY_BACKOFF,
+    abortSignal: m.abortSignal,
+  };
+}
+
+// Methods with no server-side side effect — safe to retry on any retryable
+// status. POST/PATCH are excluded: they may create/mutate, so they retry ONLY
+// on a transport error or 429/503 (throttles that carry Retry-After and mean
+// "the request was NOT processed"), never blindly on 500/502/504, to avoid
+// duplicate side effects. This asymmetry is part of the pinned contract.
+const IDEMPOTENT_METHODS: ReadonlySet<string> = new Set([
+  'GET',
+  'PUT',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+]);
+
+/**
+ * Whether an HTTP `status` for `method` should trigger a retry.
+ *
+ * Idempotent methods (GET/PUT/DELETE) retry on the full `retryOnStatus` set.
+ * Non-idempotent methods (POST/PATCH) retry only on 429/503, never on
+ * 500/502/504, to avoid replaying a side effect that may have partially applied.
+ */
+export function statusIsRetryable(
+  method: string,
+  status: number,
+  opts: _EffectiveOptions,
+): boolean {
+  if (!opts.retryOnStatus.has(status)) return false;
+  if (IDEMPOTENT_METHODS.has(method.toUpperCase())) return true;
+  return status === 429 || status === 503;
+}

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -73,6 +73,7 @@ export class RestClient extends _GeneratedResourceTree {
       project,
       token,
       fetchImpl: options.fetchImpl,
+      requestOptions: options.requestOptions,
     });
 
     logger.info('RestClient initialized', { host });
@@ -93,6 +94,10 @@ export {
   SignalWireRestTransportError,
 } from './RestError.js';
 export { paginate, paginateAll } from './pagination.js';
+
+// Request-options transport envelope (plan 4.2): timeout / retry / abort.
+export { RequestOptions } from './RequestOptions.js';
+export type { RequestOptionsInit } from './RequestOptions.js';
 
 // Types
 export type {

--- a/src/rest/types.ts
+++ b/src/rest/types.ts
@@ -2,6 +2,8 @@
  * Types for the REST client module.
  */
 
+import type { RequestOptionsInit } from './RequestOptions.js';
+
 /** Options for constructing a RestClient. */
 export interface ClientOptions {
   /** SignalWire project ID. Falls back to SIGNALWIRE_PROJECT_ID env var. */
@@ -12,6 +14,12 @@ export interface ClientOptions {
   host?: string;
   /** Custom fetch implementation for testing. */
   fetchImpl?: typeof globalThis.fetch;
+  /**
+   * Client-default transport envelope (timeout / retries / abort) applied to
+   * every request; a per-request `requestOptions` shallow-overrides it. See
+   * {@link RequestOptions}.
+   */
+  requestOptions?: RequestOptionsInit;
 }
 
 /** Options for constructing an HttpClient. */
@@ -33,6 +41,12 @@ export interface HttpClientOptions {
   token: string;
   /** Custom fetch implementation for testing. */
   fetchImpl?: typeof globalThis.fetch;
+  /**
+   * Client-default transport envelope (timeout / retries / abort) applied to
+   * every request; a per-request `requestOptions` shallow-overrides it. See
+   * {@link RequestOptions}.
+   */
+  requestOptions?: RequestOptionsInit;
 }
 
 /** Standard paginated response with links-based navigation (relay REST). */

--- a/tests/rest/request_options_mock.test.ts
+++ b/tests/rest/request_options_mock.test.ts
@@ -1,0 +1,211 @@
+/**
+ * RequestOptions envelope — behavioral contract over the real mock (plan 4.2).
+ *
+ * Translated from signalwire-python/tests/unit/rest/test_request_options.py.
+ * These drive a real {@link HttpClient} through the real `fetch` transport into
+ * the shared `mock_signalwire` and assert on the recorded journal — the same
+ * journal the REST-COVERAGE gate reads. Retry / timeout are wire-observable: the
+ * mock sees N attempts and honors the backoff ordering, so the contract is
+ * proven over the real mock, NOT a transport stub.
+ *
+ * Contract pinned here (the oracle):
+ * - `retries`: a retryable failure is retried up to `retries` extra times; the
+ *   mock sees `retries + 1` attempts; the final success is returned.
+ * - idempotency asymmetry: GET/PUT/DELETE retry on the full `retryOnStatus`
+ *   set; POST/PATCH retry only on 429/503 (throttles), never 500/502/504.
+ * - `timeout`: a server-side delay exceeding the timeout raises the transport
+ *   error family.
+ * - `abortSignal`: an already-aborted signal raises the transport error family
+ *   before the send (and TS passes it to fetch for true in-flight abort).
+ * - per-request options shallow-override the client default.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { HttpClient } from '../../src/rest/HttpClient.js';
+import { RestError, RestTransportError } from '../../src/rest/RestError.js';
+import type { RequestOptionsInit } from '../../src/rest/RequestOptions.js';
+import { newMockClient } from './mocktest.js';
+
+const ADDRESSES_ENDPOINT_ID = 'fabric.list_fabric_addresses';
+const ADDRESSES_PATH = '/api/fabric/addresses';
+const CREATE_ADDRESS_ENDPOINT_ID = 'relay-rest.create_address';
+const CREATE_ADDRESS_PATH = '/api/relay/rest/addresses';
+const TOKEN = 'test_tok';
+
+let mockUrl: string;
+let project: string;
+let authHeader: string;
+
+/** Boot (or reuse) the shared mock and mint a per-suite isolated auth header. */
+beforeEach(async () => {
+  // newMockClient boots the shared mock server and hands back its URL. We take
+  // the URL and build our OWN HttpClient (mirroring python's client._http) with
+  // a fresh random project so this suite's journal + scenarios are isolated.
+  const { mock } = await newMockClient();
+  mockUrl = mock.url;
+  project = `test_ro_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
+  authHeader = 'Basic ' + Buffer.from(`${project}:${TOKEN}`).toString('base64');
+});
+
+/** A fresh HttpClient pointed at the mock with this suite's isolated auth. */
+function makeClient(requestOptions?: RequestOptionsInit): HttpClient {
+  return new HttpClient({ baseUrl: mockUrl, project, token: TOKEN, requestOptions });
+}
+
+interface ScenarioSpec {
+  status: number;
+  response: unknown;
+  headers?: Record<string, string>;
+  delay_ms?: number;
+}
+
+/** Arm a scenario override scoped to THIS suite's auth header (FIFO). */
+async function arm(endpointId: string, scenario: ScenarioSpec): Promise<void> {
+  const resp = await fetch(
+    `${mockUrl}/__mock__/scenarios/${endpointId}?session_id=${encodeURIComponent(authHeader)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(scenario),
+    },
+  );
+  if (!resp.ok) throw new Error(`arm ${endpointId} failed: ${resp.status}`);
+}
+
+interface JournalEntry {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+}
+
+/** This suite's journal entries for a given method + path (auth-scoped). */
+async function attempts(method: string, path: string): Promise<number> {
+  const resp = await fetch(`${mockUrl}/__mock__/journal`);
+  const entries = (await resp.json()) as JournalEntry[];
+  return entries.filter(
+    (e) => e.path === path && e.method === method && e.headers.authorization === authHeader,
+  ).length;
+}
+
+describe('RequestOptions retry contract', () => {
+  it('GET retries a 503 then succeeds (2 attempts)', async () => {
+    await arm(ADDRESSES_ENDPOINT_ID, { status: 503, response: { errors: [{ code: 'X' }] } });
+    const client = makeClient();
+    const result = await client.get(ADDRESSES_PATH, undefined, {
+      retries: 1,
+      retryBackoff: 0,
+    });
+    expect(result).not.toBeNull();
+    expect(await attempts('GET', ADDRESSES_PATH)).toBe(2);
+  });
+
+  it('does not retry by default — raises on the first failure', async () => {
+    await arm(ADDRESSES_ENDPOINT_ID, { status: 503, response: { errors: [{ code: 'X' }] } });
+    const client = makeClient();
+    await expect(client.get(ADDRESSES_PATH)).rejects.toMatchObject({ statusCode: 503 });
+    expect(await attempts('GET', ADDRESSES_PATH)).toBe(1);
+  });
+
+  it('retries exhausted — raises the last error (2 attempts)', async () => {
+    await arm(ADDRESSES_ENDPOINT_ID, { status: 503, response: { errors: [{ code: 'X' }] } });
+    await arm(ADDRESSES_ENDPOINT_ID, { status: 503, response: { errors: [{ code: 'X' }] } });
+    const client = makeClient();
+    await expect(
+      client.get(ADDRESSES_PATH, undefined, { retries: 1, retryBackoff: 0 }),
+    ).rejects.toMatchObject({ statusCode: 503 });
+    expect(await attempts('GET', ADDRESSES_PATH)).toBe(2);
+  });
+});
+
+describe('RequestOptions idempotency asymmetry', () => {
+  it('POST does not retry a 500 (side-effect safety) — 1 attempt', async () => {
+    await arm(CREATE_ADDRESS_ENDPOINT_ID, { status: 500, response: { error: 'x' } });
+    const client = makeClient();
+    await expect(
+      client.post(CREATE_ADDRESS_PATH, { label: 'x' }, undefined, {
+        retries: 2,
+        retryBackoff: 0,
+      }),
+    ).rejects.toMatchObject({ statusCode: 500 });
+    expect(await attempts('POST', CREATE_ADDRESS_PATH)).toBe(1);
+  });
+
+  it('POST retries a 503 throttle (safe) — 2 attempts', async () => {
+    await arm(CREATE_ADDRESS_ENDPOINT_ID, { status: 503, response: { error: 'x' } });
+    const client = makeClient();
+    await client.post(CREATE_ADDRESS_PATH, { label: 'x' }, undefined, {
+      retries: 1,
+      retryBackoff: 0,
+    });
+    expect(await attempts('POST', CREATE_ADDRESS_PATH)).toBe(2);
+  });
+});
+
+describe('RequestOptions timeout', () => {
+  it('a slow response exceeding the timeout raises the transport error', async () => {
+    await arm(ADDRESSES_ENDPOINT_ID, {
+      status: 200,
+      response: { data: [], links: {} },
+      delay_ms: 400,
+    });
+    const client = makeClient();
+    await expect(client.get(ADDRESSES_PATH, undefined, { timeout: 0.1 })).rejects.toBeInstanceOf(
+      RestTransportError,
+    );
+  });
+});
+
+describe('RequestOptions abortSignal', () => {
+  it('an already-aborted signal raises before the request goes out', async () => {
+    const client = makeClient();
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      client.get(ADDRESSES_PATH, undefined, { abortSignal: controller.signal }),
+    ).rejects.toBeInstanceOf(RestTransportError);
+    // Nothing reached the mock — cancelled before the send.
+    expect(await attempts('GET', ADDRESSES_PATH)).toBe(0);
+  });
+
+  it('aborting mid-flight interrupts an in-progress request (true in-flight abort)', async () => {
+    // A 400ms-delayed 200; abort after 50ms => the in-flight fetch is cut,
+    // surfacing the transport error. Proves TS passes abortSignal to fetch.
+    await arm(ADDRESSES_ENDPOINT_ID, {
+      status: 200,
+      response: { data: [], links: {} },
+      delay_ms: 400,
+    });
+    const client = makeClient();
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 50);
+    await expect(
+      client.get(ADDRESSES_PATH, undefined, { abortSignal: controller.signal }),
+    ).rejects.toBeInstanceOf(RestTransportError);
+  });
+});
+
+describe('RequestOptions per-request override', () => {
+  it('per-request retries override the client default', async () => {
+    await arm(ADDRESSES_ENDPOINT_ID, { status: 503, response: { errors: [{ code: 'X' }] } });
+    // Client default = no retries; per-request opts in to 1 retry.
+    const client = makeClient({ retries: 0 });
+    const result = await client.get(ADDRESSES_PATH, undefined, {
+      retries: 1,
+      retryBackoff: 0,
+    });
+    expect(result).not.toBeNull();
+    expect(await attempts('GET', ADDRESSES_PATH)).toBe(2);
+  });
+
+  it('a typed RestError is raised (not a bare error) on an un-retried failure', async () => {
+    await arm(ADDRESSES_ENDPOINT_ID, { status: 404, response: { errors: [{ code: 'X' }] } });
+    const client = makeClient();
+    await expect(client.get(ADDRESSES_PATH)).rejects.toBeInstanceOf(RestError);
+  });
+});
+
+afterAll(() => {
+  // The shared mock server is owned by mocktest's process-level lifecycle
+  // (registerChildCleanup); nothing suite-local to tear down.
+});


### PR DESCRIPTION
Plan item 4.2 — the RequestOptions transport envelope in this port's idiom, implementing the python reference contract.

Adds RequestOptions (timeout + retries + abort) with client-default + per-request override, the idempotency-aware retry policy (GET/PUT/DELETE full set; POST/PATCH only 429/503), exponential backoff honoring Retry-After, and cooperative cancellation in the port's native primitive. Refreshes the envelope-dump program for the new retry corpus and schedules the ENVELOPE behavioral gate (diff_port_envelope vs the python oracle — verified ✓ PASS). Request-options unit tests over the shared mock (no transport stub).

Depends on porting-sdk landing first (port CI clones porting-sdk main for the oracle + ENVELOPE gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
