### PR TITLE
ci: unpin porting-sdk checkout to main (post-merge)

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -34,7 +34,7 @@ jobs:
           # CI-PIN (Wave 1): the doc-truth gate scripts (doc_env.py CA-var set,
           # tracked_docs) this branch depends on live on porting-sdk wave/1-aplus.
           # REVERT this ref back to main (default) when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/surface-audit.yml
+++ b/.github/workflows/surface-audit.yml
@@ -35,7 +35,7 @@ jobs:
           # wave/1-aplus, not yet on main. This branch's DRIFT/SURFACE gates diff
           # against that new oracle, so pin the checkout to wave/1-aplus.
           # REVERT this ref back to main (default) when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           # CI-PIN (Wave 1): the SEMVER/SURFACE oracle + PY-7 request_options gate
           # scripts live on porting-sdk wave/1-aplus, not yet on main.
           # REVERT this ref back to main (default) when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
@@ -49,7 +49,7 @@ jobs:
           # CI-PIN (Wave 1): the reference's Wave-1 changes (PY-1..9, incl PY-7
           # request_options) live on signalwire-python wave/1-aplus (PR #67), not
           # yet on main. REVERT to main when signalwire-python wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
 
       # run-ci.sh's TEST/SIGNATURES/SURFACE-FRESH/EMISSION gates drive vitest /
       # tsx; the script expects Node 24 (it prepends a local nvm path when


### PR DESCRIPTION
Wave 1 merged; wave/1-aplus deleted. Revert workflow pins to `ref: main`. 0 residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)