### PR TITLE
ci(nightly): quote workflow name to fix YAML parse — nightly multi-OS never ran

### DIFF
--- a/.github/workflows/nightly-multi-os.yml
+++ b/.github/workflows/nightly-multi-os.yml
@@ -1,5 +1,4 @@
-name: Nightly (multi-OS: macOS + Windows)
-
+name: "Nightly (multi-OS: macOS + Windows)"
 # Plan 6.4 — the multi-OS lane. ubuntu-only CI cannot certify a cross-platform
 # SDK, so this nightly runs the two OS-SENSITIVE suites — TEST (vitest) and
 # PACKAGE-SMOKE (npm pack → install the tarball → import + construct) — on


### PR DESCRIPTION
The `nightly-multi-os.yml` workflow name has an unquoted colon (`name: Nightly (multi-OS: macOS + Windows)`), so GitHub rejected it as invalid YAML on every run since creation — 0 jobs, macOS/Windows coverage never actually executed. Quoting the name fixes it (actionlint exit 0).

Found via actionlint; verified the lane now parses + runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)