### PR TITLE
fix(test): loosen brittle wall-clock bound in per_page_timeout test

### DIFF
--- a/tests/skills/web-search.test.ts
+++ b/tests/skills/web-search.test.ts
@@ -521,8 +521,15 @@ describe('WebSearchSkill — latency control (deadline / per_page_timeout / snip
         .handler({ query: 'widgets gizmos' }, {})) as FunctionResult;
       const elapsed = Date.now() - start;
 
-      // All page fetches aborted at ~0.3s; we never wait the 5s body delay.
-      expect(elapsed).toBeLessThan(2000);
+      // The snippet-fallback response below is the real proof the 5s body was
+      // never awaited (a completed scrape yields the full-content path, not
+      // "Snippet-only results"). The wall-clock check only guards against
+      // waiting the full 5000ms body, so bound it LOOSELY below that — a tight
+      // 2000ms bound asserts scheduler latency, not our logic: on a loaded
+      // 2-core CI runner timers fire seconds late (this line measured 2692ms
+      // with the deadline logic perfectly correct, matrix run 29854008467) —
+      // the same flaw already fixed in the two siblings above.
+      expect(elapsed).toBeLessThan(4500); // below the 5s body we prove we skip
       expect(result.response).toContain('Snippet-only results');
       expect(result.response).toContain('First CSE snippet about widgets.');
     } finally {


### PR DESCRIPTION
Fixes the one red on `main` HEAD (run 29854008467, commit f0567de = the nightly-YAML-quote fix #170).

## Root cause — brittle wall-clock assertion, not an SDK bug
`tests/skills/web-search.test.ts > per_page_timeout aborts a single slow page fetch` asserted `expect(elapsed).toBeLessThan(2000)`. On a loaded 2-core CI runner it measured **2692ms** — the abort logic is perfectly correct (the fetches DID abort at ~0.3s; the extra ~2.4s is fixed test/runner overhead: import took 29.86s that run). 2729/2730 tests passed; every gate (SURFACE, BEHAVIORAL incl SWAIG-HTTP-INVOKE/TLS-VERIFY/CA-VAR/SECRET-SCRUB, LINT) passed.

This is the **exact flaw already fixed in the two sibling tests directly above** in the same file, whose comments call it out ("under CI CPU starvation timers fire seconds late ... a tight bound asserts scheduler latency, not our logic; seen at 5019ms"). This twin was missed in that pass.

## Fix
The snippet-fallback assertions are the real proof the 5s body was never awaited (a completed scrape yields the full-content path, not "Snippet-only results"). The wall-clock line only needs to guard against waiting that full 5000ms body — loosened to `< 4500ms` with a comment matching the siblings. Test-only; no SDK behavior change. 28/28 local pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhUoqrbptHNS3cypq9s6t
