### PR TITLE
fix(test): make swaig-test CLI contract tests Windows-safe (spawn + embedded import path)

### DIFF
--- a/tests/cli/swaig-test.test.ts
+++ b/tests/cli/swaig-test.test.ts
@@ -9,12 +9,21 @@ import { FunctionResult } from '../../src/FunctionResult.js';
 
 const CLI = fileURLToPath(new URL('../../src/cli/swaig-test.ts', import.meta.url));
 
-/** Run the swaig-test CLI via tsx as a subprocess; resolves with code+output. */
+/**
+ * Run the swaig-test CLI via tsx as a subprocess; resolves with code+output.
+ *
+ * Invokes the current `node` binary with tsx's loader (`--import tsx`) rather
+ * than `npx tsx`. `execFile` runs WITHOUT a shell, so a bare `'npx'` cannot be
+ * spawned on Windows (the launcher there is `npx.cmd`, not `npx`) — the spawn
+ * fails, stdout comes back empty, and the error maps to a spurious exit code.
+ * Going through `process.execPath` sidesteps `.cmd` resolution entirely and is
+ * robust on Linux, macOS, and Windows alike.
+ */
 function runCli(args: string[]): Promise<{ code: number; out: string }> {
   return new Promise((resolve) => {
     execFile(
-      'npx',
-      ['tsx', CLI, ...args],
+      process.execPath,
+      ['--import', 'tsx', CLI, ...args],
       { timeout: 60_000, env: { ...process.env, SIGNALWIRE_LOG_MODE: 'off' } },
       (err, stdout, stderr) => {
         const code =

--- a/tests/cli/swaig-test.test.ts
+++ b/tests/cli/swaig-test.test.ts
@@ -42,12 +42,17 @@ function runCli(args: string[]): Promise<{ code: number; out: string }> {
 function writeAgentFile(): { path: string; cleanup: () => void } {
   const dir = mkdtempSync(join(tmpdir(), 'swaig-cli-'));
   const path = join(dir, 'agent.ts');
+  // Embed the AgentBase import as a `file://` URL, NOT a filesystem path. On
+  // Windows `fileURLToPath` yields backslashes (`C:\...\src\AgentBase.ts`);
+  // baked into a single-quoted TS string literal, `\a`/`\s`/`\A`... collapse as
+  // escape sequences and the specifier is corrupted, so the generated agent
+  // fails to import AgentBase. An ESM `file:///...` URL uses forward slashes and
+  // imports correctly on every platform.
+  const agentBaseUrl = new URL('../../src/AgentBase.ts', import.meta.url).href;
   writeFileSync(
     path,
     [
-      "import { AgentBase } from '" +
-        fileURLToPath(new URL('../../src/AgentBase.ts', import.meta.url)) +
-        "';",
+      "import { AgentBase } from '" + agentBaseUrl + "';",
       "const agent = new AgentBase({ name: 'probe', route: '/' });",
       "agent.setPromptText('hi');",
       'export default agent;',


### PR DESCRIPTION
Two distinct Windows-only bugs in `tests/cli/swaig-test.test.ts`, both in the subprocess-CLI contract tests. The second was uncovered once the first was fixed and the CLI began actually running on Windows.

## Bug 1 — `execFile('npx', ...)` spawn trap

`runCli` spawned the CLI with `execFile('npx', ['tsx', CLI, ...args])`. `execFile` runs **without a shell**; on Windows there is no bare `npx` executable (the launcher is `npx.cmd`), so the spawn fails, `stdout` comes back empty, and the error→code mapping resolves to a spurious `1`. macOS/Linux pass because `npx` is a bare executable there. This produced the windows-latest failures `expected '\n' to contain 'bogus-platform-xyz'` and `expected 1 to be +0`.

**Fix:** `execFile(process.execPath, ['--import', 'tsx', CLI, ...args])` — runs the current node binary with tsx's documented loader, sidestepping `.cmd` resolution entirely. Identical on Linux/macOS/Windows. Confirmed: after this landed, the ~130 `mock_relay did not become ready` failures were gone (separate porting-sdk #111 fix) and the CLI executed — leaving only Bug 2.

## Bug 2 — backslash-escaping in the embedded import path

`writeAgentFile()` bakes the AgentBase import specifier into a **generated .ts source string** via `fileURLToPath(new URL(...))`. On Windows that returns a backslash path (`C:\...\src\AgentBase.ts`); embedded in a single-quoted TS string literal, `\a`/`\s`/`\A`... collapse as escape sequences (`C:a...srcAgentBase.ts`), corrupting the specifier. The generated agent then can't import AgentBase, so the CLI prints `Failed to import agent file: ...` instead of the expected platform-validation output — failing `toContain('bogus-platform-xyz')` / `toContain('--dump-swml')` / the exit-code assertions.

**Fix:** embed the specifier as `new URL(...).href` — a `file:///...` URL. ESM import specifiers accept `file://` URLs with forward slashes on every platform, so nothing is backslash-escaped.

The `CLI` const stays a raw path — it is passed as an `execFile` **argv arg**, not a string literal in generated source, so it is unaffected. Swept `tests/` for other `fileURLToPath` results embedded into written source: this was the only one (every other use is a runtime `__dirname`/argv/cert-dir path).

## Verification (local, macOS)

- `scripts/run-tests.sh tests/cli/swaig-test.test.ts` → **19/19 pass**
- `scripts/run-tests.sh` (full suite) → **130 files, 2730 tests, 0 failures**
- `scripts/run-lint.sh` → pass; `scripts/run-format.sh` → no changes beyond this file

Windows correctness is by construction (no bare `.cmd`-less `npx` under `execFile`; no backslash path baked into a source literal); the windows-latest leg of the nightly multi-OS lane confirms it end-to-end — cannot be run on the macOS host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhUoqrbptHNS3cypq9s6t
