### PR TITLE
fix(test): loosen brittle exact-count in sequential overall_deadline test

### DIFF
--- a/tests/skills/web-search.test.ts
+++ b/tests/skills/web-search.test.ts
@@ -490,14 +490,20 @@ describe('WebSearchSkill — latency control (deadline / per_page_timeout / snip
         .handler({ query: 'widgets gizmos' }, {})) as FunctionResult;
 
       // Sequential: page 1 starts before the 1.0s deadline and hangs until the
-      // deadline's shared AbortController (or its per_page_timeout) ends it;
-      // the loop's deadline check must then prevent page 2 from EVER starting.
-      // Assert that observable — the scrape-call count — rather than wall
-      // clock: under CI CPU starvation timers fire seconds late and an
-      // elapsed-ms bound flakes on scheduler latency while the deadline logic
-      // is perfectly correct (seen at 5019ms on a loaded runner, matrix run
-      // 28939151975).
-      expect(scrapeCalls).toBe(1);
+      // deadline's shared AbortController ends it; the loop's per-item deadline
+      // guard (`if (Date.now() >= deadlineAt) return null`) then stops further
+      // scrapes. The real contract is "the deadline halts the sequential walk"
+      // — proven by the snippet-only fallback below (a completed scrape would
+      // yield the full-content path instead).
+      //
+      // Do NOT assert `scrapeCalls === 1`: the guard is checked when the NEXT
+      // item's scrapeOne runs, so there is a one-tick race — if page 1's abort
+      // resolves a hair before `deadlineAt`, page 2's guard can read `Date.now()
+      // < deadlineAt` and start (then immediately abort itself). Under CI CPU
+      // starvation that timer skew is routine (seen scrapeCalls=2, matrix run
+      // 29862199166). page 2 starting-then-aborting is correct behavior; what
+      // must never happen is the walk running away — so bound it, don't pin it.
+      expect(scrapeCalls).toBeLessThanOrEqual(2);
       expect(result.response).toContain('Snippet-only results');
       expect(result.response).toContain('First CSE snippet about widgets.');
     } finally {


### PR DESCRIPTION
Fixes the ts cross-port red on porting-sdk main (matrix run 29862199166 — the only failing job after porting-sdk #111 merged). **Unrelated to #111** (a mock-cert change can't affect a web-search skill test) — it's a brittle exact-count assertion surfacing under cross-port matrix CPU load.

## Root cause
`tests/skills/web-search.test.ts > overall_deadline is enforced in sequential mode too` asserted `expect(scrapeCalls).toBe(1)`. The sequential scrape loop's per-item deadline guard is `if (Date.now() >= deadlineAt) return null`, checked when the **next** item's `scrapeOne` runs. So there's a one-tick race: if page 1's abort resolves a hair before `deadlineAt`, page 2's guard reads `Date.now() < deadlineAt` and starts (then immediately aborts itself via the shared `deadlineController`). Under CI CPU starvation that timer skew is routine → `scrapeCalls === 2` → red, though the deadline logic is correct.

## Fix
page 2 starting-then-aborting is correct behavior; what must never happen is the walk running away. So bound it (`<= 2`) instead of pinning it, and keep the real contract assertion — the snippet-only fallback (a completed scrape would yield the full-content path, not "Snippet-only results"). This is the sibling of #171's wall-clock brittleness fix in the same file. Test-only; no SDK change. 28/28 local pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhUoqrbptHNS3cypq9s6t
