### PR TITLE
wave6: retire dead ledger entries (logger idiom fold)

### DIFF
--- a/PORT_SIGNATURE_OMISSIONS.md
+++ b/PORT_SIGNATURE_OMISSIONS.md
@@ -337,7 +337,18 @@ canonical path differs.
 
 ## TS-idiomatic return-type divergences
 
-signalwire.core.skill_base.SkillBase.logger: TS port returns a `Logger` instance from `signalwire.core.logging_config.Logger`; Python's `logger` typing uses the `get_logger` factory's return-type annotation, so the canonical path resolves to `get_logger` rather than `Logger` — same logger object, different name in the canonical path
+# EMPTY as of 2026-07-27. The sole entry here was
+# `signalwire.core.skill_base.SkillBase.logger`, deleted in the Wave-6 ledger
+# burn-down. Owner ruling 2026-07-24 (ALLOWLIST_DISCIPLINE §8): logging is a
+# MODULE-LEVEL capability, and the per-instance `logger` attribute was Python's
+# structlog idiom leaking into the enumerated surface — not contract. The
+# reference enumerator now suppresses it at the logging factory's RETURN TYPE
+# (`enumerate_python.py` `_LOGGER_FACTORY_RETURN`), so the oracle emits no
+# class-attribute `logger` for this exemption to excuse. The capability is
+# signalled by the 5 module-level free functions in
+# `signalwire.core.logging_config` (get_logger / configure_logging /
+# get_execution_mode / reset_logging_configuration / strip_control_chars),
+# which the TS port implements.
 
 ## TS-idiomatic params-object vs **kwargs
 
@@ -420,7 +431,10 @@ signalwire.agents.bedrock.BedrockAgent.set_prompt_llm_params: reference signatur
 
 ## Idiom: renamed composition accessor — reference class-name spelling differs
 
-signalwire.agent_server.AgentServer.logger: TS AgentServer.logger (renamed from the `log` field) returns a `Logger` instance from signalwire.core.logging_config.Logger; Python's `logger` typing uses the `get_logger` factory's return-type annotation, so the canonical path resolves to `get_logger` rather than `Logger` — same logger object, different name in the canonical path (identical disposition to SkillBase.logger).
+# `signalwire.agent_server.AgentServer.logger` was deleted here 2026-07-27 (Wave-6
+# ledger burn-down) for the same reason as SkillBase.logger above: the reference
+# enumerator suppresses the per-instance logger member by the logging factory's
+# return type, so the oracle no longer emits the symbol this line excused.
 signalwire.web.web_service.WebService.security: TS WebService.security (renamed from the `ssl_config` accessor) returns `SslConfig`; the Python reference types the same accessor as `SecurityConfig`. Same TLS/security configuration object, different class name across the port idiom (TS names the config `SslConfig`; the reference `SecurityConfig`). Accessor now compares by name after the rename — the residual is only the config class-name spelling.
 
 ## Port-only typed composition getters + framework-app accessor (signature-side additions)


### PR DESCRIPTION
## What

Wave 6 ledger burn-down for **typescript**: deletes the 2 dead `logger` entries from
`PORT_SIGNATURE_OMISSIONS.md`. No `src/` change, no new ledger entry of any kind.

## Counts (before → after)

Measured against the **committed** tree with the gate's own parser
(`diff_port_signatures.parse_omissions`), not by grep:

| file | before | after | delta |
|---|---|---|---|
| `PORT_SIGNATURE_OMISSIONS.md` (total entries) | 249 | 247 | −2 |
| `PORT_SIGNATURE_OMISSIONS.md` (member == `logger`) | 2 | 0 | −2 |
| `PORT_ADDITIONS.md` | 468 | 468 | 0 (untouched) |
| `PORT_OMISSIONS.md` | 36 | 36 | 0 (untouched) |

Command used to produce them (`parse_omissions` is the function the DRIFT gate itself
calls, so these are the counts the gate sees):

```python
import sys; sys.path.insert(0, '<porting-sdk>/scripts')
from diff_port_signatures import parse_omissions
e = parse_omissions(Path('PORT_SIGNATURE_OMISSIONS.md'))
print(len(e), len([k for k in e if k.rsplit('.', 1)[-1] == 'logger']))
```

## Entries removed, and why each is correct

```
signalwire.core.skill_base.SkillBase.logger
signalwire.agent_server.AgentServer.logger
```

Not merely "dead" — the underlying disposition changed. Owner ruling 2026-07-24, recorded
in `ALLOWLIST_DISCIPLINE.md` §8 and implemented at
`porting-sdk/scripts/enumerate_python.py:365` (`_LOGGER_FACTORY_RETURN`): **logging is a
MODULE-LEVEL capability a port may reach however its language does.** The per-instance
`logger` attribute was Python's structlog idiom leaking into the enumerated surface; it is
not contract. The exclusion keys on the logging factory's RETURN TYPE rather than a
hand-typed symbol list, so it cannot drift as classes get renamed.

Both entries were verified dead on **both** sides, not just the reference:

- **oracle** — `query_signatures.py python_signatures.json search logger` returns exactly
  one hit, `modules.signalwire.core.logging_config.functions.get_logger` (the module-level
  factory). No class-attribute `logger`.
- **port** — the same query over `port_signatures.json` returns the same single hit. The TS
  port emits no `.logger` member either.

The capability is unchanged and still satisfied by the 5 module-level free functions the
oracle records — `get_logger`, `configure_logging`, `get_execution_mode`,
`reset_logging_configuration`, `strip_control_chars` — all implemented by this port.

**The proof they excused nothing:** the DRIFT gate's excused-divergence count is
**unchanged at 684** across the deletion. Had either entry been load-bearing, that number
would have dropped and an unexcused drift would have appeared.

## `Logger`-wrapper ADDITIONS: none remain in this repo

The wave brief expected ts to carry 8–13 `Logger`-wrapper additions. It carries **0** —
they were already resolved. `PORT_ADDITIONS.md:230` records **12 entries DELETED
2026-07-25** under the same owner ruling, folded at the enumerator
(`LOGGING_CLASS_FOLDS` / `LOGGING_FUNCTION_FOLDS`, lock-step in `enumerate-surface.ts` +
`enumerate-signatures.ts`), plus a second resolved note at `PORT_ADDITIONS.md:454` for the
`log` accessor (`PER_INSTANCE_LOGGER_MEMBERS`). `PORT_ADDITIONS.md` is untouched by this PR.

## Task #67 (`WebService.start` `optional<int>` vs `optional<float>`) — already covered, no change needed

Investigated; **no code change, and no owner ruling required.** The `--numeric-monotype`
mechanism the wave brief pointed at is *already* wired for typescript, and the drift does
not reproduce on the committed tree.

- `porting-sdk/scripts/suites/_surface_commands.py:307` already builds the ts DRIFT
  invocation with `monotype=True`, so `run-ci.sh` passes `--numeric-monotype`.
- `.drift-numeric-monotype` is present **and committed** in this repo (since `f41d446`,
  2026-06-30) for the standalone `drift.sh` fast loop.
- Both paths are green on the committed artifact:
  - `drift.sh` → `signatures match (1528 reference symbols, 1857 port symbols, 684 excused
    divergences)`, `DRIFT exit=0`
  - `diff_port_surface.py` → `port matches Python reference (2674 symbols; 36 excused
    omissions, 468 excused additions)`
  - full `surface.py` suite → `[SURFACE] all 7 rules PASS`

Two corrections to the task-#67 write-up, for the tracker:

1. It is filed as a **SURFACE-DIFF** drift, but `WebService.start` is a *parameter type* on
   a signature — it can only surface via **DRIFT** (`diff_port_signatures.py`).
   `diff_port_surface.py` does not compare param types and is green.
2. It reproduces **only** when `diff_port_signatures.py` is invoked *without*
   `--numeric-monotype`, which yields 110 drifts — every one of them an int-vs-float
   mismatch, `WebService.start` among them. That is the signature of a missing flag, not of
   a real type divergence. No gate in `run-ci.sh` invokes it that way.

The reasoning in the brief holds and the mechanism is the right one: a port number **is** an
integer, widening the reference to `float` would be wrong, and TypeScript has exactly one
`number` type so its enumerator records every integer as `float`. That is wire-neutral —
JSON has no int/float distinction. Nothing to fix; task #67 can be closed as already
resolved by the 2026-07-18 monotype wiring (`porting-sdk` 9fd5314).

## Working tree found (task #67 note said this checkout may have WIP)

The note is stale. The checkout was on **`main`, clean, up to date with `origin/main`** at
`d30dcd4`. Two stashes exist (`stash@{0}` on `lint/ts-fmt-lint-gates`, `stash@{1}` on
`chore/types-node-22`) — **both left untouched**; neither was applied, dropped, or
committed. This branch was cut from `origin/main` after a `git fetch`, not from local state.

## Verification — full gate set, actual output

`bash scripts/run-ci.sh` → **exit 0**, `==> CI PASS`. All 22 gate lines PASS:

```
[TYPE-EROSION] ... PASS       [COORDINATED-PASS] ... PASS   [COORDINATED-REFS] ... PASS
[ENV-VAR-CONSISTENCY] ... PASS [ACTIONLINT] ... PASS         [DOC-CLI] ... PASS
[NO-CHEAT] ... PASS           [LEDGER] ... PASS              [DEAD-PUBLIC-ERROR] ... PASS
[AI-CHAT] ... PASS            [PACKAGE] ... PASS             [ROOT-HYGIENE] ... PASS
[DOC-TRUTH] ... PASS          [PUBLIC-JARGON] ... PASS       [WIRED-MODES] ... PASS
[DOC-SURFACE] ... PASS        [SURFACE] ... PASS             [GEN] ... PASS
[FMT] ... PASS                [TEST] ... PASS                [LINT] ... PASS
[BEHAVIORAL] ... PASS
==> CI PASS
```

`LEDGER` (the ledger-governance suite) and `SURFACE` both pass with the entries gone, which
is the gate-level confirmation the deletion is safe.

## Residual found, NOT touched — needs an owner ruling

`PORT_SIGNATURE_OMISSIONS.md` still carries two entries for the *`log`* accessor:

```
signalwire.core.agent_base.AgentBase.log
signalwire.core.swml_service.SWMLService.log
```

These are **live, not dead** — the TS port really does emit both (each a zero-arity getter
returning `class:signalwire.core.logging_config.Logger`), and the reference signature oracle
records neither, because Python sets `self.log` dynamically. So they are the signature-side
mirror of the very idiom this ruling addresses, but deleting them would red the gate rather
than clean it up.

The mechanism to fold them already exists: `PER_INSTANCE_LOGGER_MEMBERS` in both ts
enumerators. It is documented as "complete and self-activating," but it covers
`AgentServer`, `SkillBase`, `SkillManager`, and `SkillRegistry` — **`AgentBase` and
`SWMLService` are absent from the table.** Adding two keys there would fold both entries
away symmetrically, exactly as the 2026-07-25 pass did for the other four classes.

Left alone deliberately: extending that table is a surface-affecting judgement about what
the ruling covers, which is an owner call, not an agent one. Flagged here for a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFKJhLvfV8yGrASwqxdgaf
